### PR TITLE
feat(payroll): add Workday export option with connector-based architecture

### DIFF
--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -16,6 +16,7 @@ The Payroll Export feature allows you to export employee time tracking data dire
 **API Integrations:**
 - **Personio**: Direct API integration with Personio HR
 - **SAP SuccessFactors**: Direct API integration with SAP SuccessFactors Employee Central
+- **Workday**: Direct API integration with Workday via OAuth2
 
 Access payroll export at **Settings** → **Payroll Export**.
 
@@ -241,6 +242,56 @@ Non-retryable errors are logged with detailed error messages from the SAP Succes
 
 ---
 
+## Workday Integration
+
+Connect Z8 directly to Workday to validate credentials and prepare payroll export workflows through Workday APIs.
+
+### Setting Up Workday
+
+1. Go to **Settings** -> **Payroll Export** -> **Workday** tab
+2. Enter your Workday instance details:
+   - **Instance URL**: Your Workday API base URL (e.g., `https://wd5-impl-services1.workday.com`)
+   - **Tenant ID**: Your Workday tenant identifier
+3. Configure API credentials in the vault:
+   - **Client ID**: OAuth2 client ID for your Workday integration app
+   - **Client Secret**: OAuth2 client secret
+   - **Scope** (optional): OAuth scope required by your Workday tenant
+4. Click **Save Configuration** and **Save Credentials**
+
+Workday OAuth credentials are stored securely in the encrypted organization vault and are never persisted in plain text in payroll export settings.
+
+### Employee Matching
+
+Configure how Z8 matches employees to Workday workers:
+
+| Strategy | Description | Recommendation |
+|----------|-------------|----------------|
+| **Employee Number** | Match by employee number between Z8 and Workday | Recommended when IDs are aligned |
+| **Email** | Match by employee email address | Fallback if employee numbers are not synchronized |
+
+Use **Employee Number** whenever possible for stable and deterministic matching.
+
+### Testing the Connection
+
+After saving configuration and credentials:
+
+1. Click **Test Connection**
+2. Z8 requests an OAuth token with your configured credentials
+3. Z8 validates API access against your Workday tenant
+4. A success message confirms connectivity
+
+If the test fails, verify instance URL, tenant ID, OAuth client credentials, and scope.
+
+### v1 Behavior (Safe Placeholder Export)
+
+In v1, Workday export uses a safe placeholder path after connection validation:
+
+- Export records are not posted to Workday yet
+- Each attendance/absence record is marked as not synced with a clear placeholder error message
+- This prevents silent data loss while preserving full export traceability and retry visibility
+
+---
+
 ## Wage Type Mappings
 
 Map Z8 work categories and absence types to payroll wage codes.
@@ -370,6 +421,14 @@ View all previous exports:
 4. **Test connection first**: Always verify API access before running exports
 5. **Monitor sync results**: Review failed and skipped records after each export
 
+### For Workday Integration
+
+1. **Prefer Employee Number matching**: Use email only when employee numbers are not aligned
+2. **Store only OAuth secrets in vault**: Keep Client ID/Secret (and optional scope) in encrypted vault entries
+3. **Always test connection before export**: Validate OAuth and tenant access before each run
+4. **Account for v1 placeholder behavior**: Current Workday export run validates connectivity but does not post records yet
+5. **Review failed records after each run**: Placeholder export marks records unsynced by design in v1
+
 ### Data Quality
 
 - Ensure work periods are approved before export
@@ -425,6 +484,17 @@ View all previous exports:
 | Rate limit exceeded (429) | The system automatically retries with exponential backoff; reduce batch size if persistent |
 | API timeout | Increase the API Timeout setting or reduce batch size |
 | Absence skipped | Configure wage type mappings for all absence categories |
+
+### Workday Connection Issues
+
+| Issue | Solution |
+|-------|----------|
+| Authentication failed | Verify Workday Client ID, Client Secret, and optional scope in vault |
+| Invalid Instance URL | Confirm your Workday URL is correct and reachable (for example, `https://wd5-impl-services1.workday.com`) |
+| Tenant ID invalid | Ensure Tenant ID matches your Workday tenant exactly |
+| Connection test fails | Re-save configuration and credentials, then retry **Test Connection** |
+| Employee not matched | Align employee numbers or switch to email matching strategy |
+| Records not synced in v1 | Expected behavior: Workday export is a safe placeholder in v1 and does not push records yet |
 
 ### Common Errors
 

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -155,6 +155,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "2.4.4",
 		"@tailwindcss/postcss": "^4.2.0",
+		"@testing-library/react": "^16.3.2",
 		"@types/canvas-confetti": "^1.9.0",
 		"@types/luxon": "^3.7.1",
 		"@types/node": "^25.3.0",
@@ -169,6 +170,7 @@
 		"babel-plugin-react-compiler": "^1.0.0",
 		"dotenv-cli": "^11.0.0",
 		"drizzle-kit": "^0.31.9",
+		"jsdom": "^28.1.0",
 		"postcss": "^8.5.6",
 		"tsx": "^4.21.0",
 		"typescript": "^5.9.3",

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+	const session = {
+		user: {
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+		},
+		session: {
+			id: "session-1",
+			userId: "user-1",
+			expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+			token: "token",
+		},
+	};
+
+	return {
+		session,
+		isOrgAdminCasl: vi.fn(async () => true),
+		findEmployee: vi.fn(async () => ({ id: "emp-1" })),
+		createExportJob: vi.fn(async () => ({ jobId: "job-1", isAsync: true })),
+		processExportJob: vi.fn(),
+		getExportJobHistory: vi.fn(),
+		getExportDownloadUrl: vi.fn(),
+		getPayrollExportConfig: vi.fn(),
+		getWageTypeMappings: vi.fn(),
+		getWorkCategories: vi.fn(),
+		getAbsenceCategories: vi.fn(),
+		getEmployeesForFilter: vi.fn(),
+		getTeamsForFilter: vi.fn(),
+		getProjectsForFilter: vi.fn(),
+		revalidatePath: vi.fn(),
+	};
+});
+
+vi.mock("drizzle-orm", () => ({
+	and: vi.fn((...args: unknown[]) => ({ and: args })),
+	eq: vi.fn((left: unknown, right: unknown) => ({ eq: [left, right] })),
+}));
+
+vi.mock("@/db", () => ({
+	absenceCategory: {},
+	db: {
+		query: {
+			payrollExportFormat: { findFirst: vi.fn() },
+			payrollExportConfig: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	},
+	payrollExportConfig: {},
+	payrollExportFormat: {},
+	payrollWageTypeMapping: {},
+	workCategory: {},
+}));
+
+vi.mock("@/db/schema", () => ({
+	employee: {
+		userId: "userId",
+		organizationId: "organizationId",
+	},
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+	isOrgAdminCasl: mockState.isOrgAdminCasl,
+}));
+
+vi.mock("@/lib/vault/secrets", () => ({
+	getOrgSecret: vi.fn(),
+	storeOrgSecret: vi.fn(),
+	deleteOrgSecret: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: mockState.revalidatePath,
+}));
+
+vi.mock("@/lib/payroll-export", () => ({
+	createExportJob: mockState.createExportJob,
+	processExportJob: mockState.processExportJob,
+	getExportJobHistory: mockState.getExportJobHistory,
+	getExportDownloadUrl: mockState.getExportDownloadUrl,
+	getPayrollExportConfig: mockState.getPayrollExportConfig,
+	getWageTypeMappings: mockState.getWageTypeMappings,
+	getWorkCategories: mockState.getWorkCategories,
+	getAbsenceCategories: mockState.getAbsenceCategories,
+	getEmployeesForFilter: mockState.getEmployeesForFilter,
+	getTeamsForFilter: mockState.getTeamsForFilter,
+	getProjectsForFilter: mockState.getProjectsForFilter,
+}));
+
+vi.mock("@/lib/effect/services/auth.service", async () => {
+	const { Context } = await import("effect");
+	const AuthService = Context.GenericTag<{
+		readonly getSession: () => unknown;
+	}>("AuthService");
+
+	return {
+		AuthService,
+	};
+});
+
+vi.mock("@/lib/effect/services/database.service", async () => {
+	const { Context } = await import("effect");
+	const DatabaseService = Context.GenericTag<{
+		readonly db: {
+			query: {
+				employee: {
+					findFirst: (input: unknown) => Promise<{ id: string } | null>;
+				};
+			};
+		};
+		readonly query: <T>(key: string, fn: () => Promise<T>) => unknown;
+	}>("DatabaseService");
+
+	return {
+		DatabaseService,
+	};
+});
+
+vi.mock("@/lib/effect/runtime", async () => {
+	const { Effect, Layer } = await import("effect");
+	const { AuthService } = await import("@/lib/effect/services/auth.service");
+	const { DatabaseService } = await import("@/lib/effect/services/database.service");
+
+	const authLayer = Layer.succeed(AuthService, {
+		getSession: () => Effect.succeed(mockState.session),
+	});
+
+	const databaseLayer = Layer.succeed(DatabaseService, {
+		db: {
+			query: {
+				employee: {
+					findFirst: mockState.findEmployee,
+				},
+			},
+		},
+		query: <T>(_key: string, fn: () => Promise<T>) => Effect.promise(fn),
+	});
+
+	return {
+		AppLayer: Layer.merge(authLayer, databaseLayer),
+	};
+});
+
+vi.mock("@/lib/effect/result", async () => {
+	const { Cause, Effect, Exit, Option } = await import("effect");
+
+	const toServerActionResult = <T>(exit: unknown) =>
+		Exit.match(exit as never, {
+			onFailure: (cause) => {
+				const defects = Cause.defects(cause);
+				const defect = [...defects][0] ?? null;
+				const failure = Option.getOrNull(Cause.failureOption(cause));
+				const error = defect ?? failure ?? cause;
+
+				if (error && typeof error === "object" && "_tag" in error) {
+					return {
+						success: false as const,
+						error: (error as { message: string }).message,
+						code: (error as { _tag: string })._tag,
+					};
+				}
+
+				if (error instanceof Error) {
+					return {
+						success: false as const,
+						error: error.message || "An unexpected error occurred",
+						code: "UNKNOWN_ERROR",
+					};
+				}
+
+				return {
+					success: false as const,
+					error: "An unexpected error occurred",
+					code: "UNKNOWN_ERROR",
+				};
+			},
+			onSuccess: (data) => ({ success: true as const, data }),
+		});
+
+	return {
+		runServerActionSafe: async <T>(effect: Parameters<typeof Effect.runPromiseExit<T>>[0]) => {
+			const exit = await Effect.runPromiseExit(effect);
+			return toServerActionResult(exit);
+		},
+		toServerActionResult,
+	};
+});
+
+const { startExportAction } = await import("./actions");
+
+describe("startExportAction", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.isOrgAdminCasl.mockResolvedValue(true);
+		mockState.findEmployee.mockResolvedValue({ id: "emp-1" });
+		mockState.createExportJob.mockResolvedValue({ jobId: "job-1", isAsync: true });
+	});
+
+	it("passes input formatId through to createExportJob", async () => {
+		const result = await startExportAction({
+			organizationId: "org-1",
+			formatId: "workday_api",
+			startDate: "2026-01-01",
+			endDate: "2026-01-31",
+		});
+
+		expect(result).toEqual({
+			success: true,
+			data: { jobId: "job-1", isAsync: true },
+		});
+
+		expect(mockState.createExportJob).toHaveBeenCalledWith(
+			expect.objectContaining({
+				organizationId: "org-1",
+				formatId: "workday_api",
+				requestedById: "emp-1",
+			}),
+		);
+
+		expect(mockState.createExportJob).not.toHaveBeenCalledWith(
+			expect.objectContaining({ formatId: "datev_lohn" }),
+		);
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
@@ -14,7 +14,7 @@ import {
 } from "@/db";
 import { employee } from "@/db/schema";
 import { isOrgAdminCasl } from "@/lib/auth-helpers";
-import { AuthorizationError, NotFoundError } from "@/lib/effect/errors";
+import { AuthorizationError, NotFoundError, ValidationError } from "@/lib/effect/errors";
 import { runServerActionSafe, type ServerActionResult } from "@/lib/effect/result";
 import { AppLayer } from "@/lib/effect/runtime";
 import { AuthService } from "@/lib/effect/services/auth.service";
@@ -35,6 +35,7 @@ import {
 	type DatevLohnConfig,
 	type LexwareLohnConfig,
 	type SageLohnConfig,
+	type WorkdayConfig,
 	type WageTypeMapping,
 	type PayrollExportJobSummary,
 } from "@/lib/payroll-export";
@@ -962,6 +963,366 @@ export async function deleteSuccessFactorsCredentialsAction(
 		revalidatePath("/settings/payroll-export");
 
 		return { success: true };
+	});
+
+	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));
+}
+
+// ============================================
+// WORKDAY CONFIGURATION TYPES
+// ============================================
+
+export const WORKDAY_FORMAT_ID = "workday_api";
+
+const WORKDAY_VAULT_KEY_CLIENT_ID = "payroll/workday/client_id";
+const WORKDAY_VAULT_KEY_CLIENT_SECRET = "payroll/workday/client_secret";
+
+export interface WorkdayConfigResult {
+	id: string;
+	formatId: string;
+	config: WorkdayConfig;
+	isActive: boolean;
+	hasCredentials: boolean;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export interface SaveWorkdayConfigInput {
+	organizationId: string;
+	config: WorkdayConfig;
+}
+
+export interface SaveWorkdayCredentialsInput {
+	organizationId: string;
+	clientId: string;
+	clientSecret: string;
+}
+
+// ============================================
+// WORKDAY CONFIGURATION ACTIONS
+// ============================================
+
+export async function getWorkdayConfigAction(
+	organizationId: string,
+): Promise<ServerActionResult<WorkdayConfigResult | null>> {
+	const effect = Effect.gen(function* (_) {
+		const authService = yield* _(AuthService);
+		const session = yield* _(authService.getSession());
+
+		const hasPermission = yield* _(
+			Effect.promise(() => isOrgAdminCasl(organizationId)),
+		);
+
+		if (!hasPermission) {
+			yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Insufficient permissions - admin role required",
+						userId: session.user.id,
+						resource: "payroll_export_config",
+						action: "read",
+					}),
+				),
+			);
+		}
+
+		const configResult = yield* _(
+			Effect.promise(() => getPayrollExportConfig(organizationId, WORKDAY_FORMAT_ID)),
+		);
+
+		if (!configResult) {
+			return null;
+		}
+
+		const hasCredentials = yield* _(
+			Effect.promise(async () => {
+				const clientId = await getOrgSecret(organizationId, WORKDAY_VAULT_KEY_CLIENT_ID);
+				const clientSecret = await getOrgSecret(
+					organizationId,
+					WORKDAY_VAULT_KEY_CLIENT_SECRET,
+				);
+				return (
+					clientId !== null &&
+					clientSecret !== null &&
+					clientId.trim().length > 0 &&
+					clientSecret.trim().length > 0
+				);
+			}),
+		);
+
+		return {
+			id: configResult.config.id,
+			formatId: configResult.config.formatId,
+			config: configResult.config.config as unknown as WorkdayConfig,
+			isActive: configResult.config.isActive,
+			hasCredentials,
+			createdAt: configResult.config.createdAt,
+			updatedAt: configResult.config.updatedAt,
+		};
+	});
+
+	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));
+}
+
+export async function saveWorkdayConfigAction(
+	input: SaveWorkdayConfigInput,
+): Promise<ServerActionResult<WorkdayConfigResult>> {
+	const effect = Effect.gen(function* (_) {
+		const authService = yield* _(AuthService);
+		const session = yield* _(authService.getSession());
+
+		const hasPermission = yield* _(
+			Effect.promise(() => isOrgAdminCasl(input.organizationId)),
+		);
+
+		if (!hasPermission) {
+			yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Insufficient permissions - admin role required",
+						userId: session.user.id,
+						resource: "payroll_export_config",
+						action: "create",
+					}),
+				),
+			);
+		}
+
+		yield* _(
+			Effect.promise(async () => {
+				const format = await db.query.payrollExportFormat.findFirst({
+					where: eq(payrollExportFormat.id, WORKDAY_FORMAT_ID),
+				});
+
+				if (!format) {
+					await db.insert(payrollExportFormat).values({
+						id: WORKDAY_FORMAT_ID,
+						name: "Workday (API)",
+						version: "1.0.0",
+						description: "Export to Workday via REST API",
+						isEnabled: true,
+						requiresConfiguration: true,
+						supportsAsync: true,
+						syncThreshold: 500,
+						updatedAt: new Date(),
+					});
+				}
+			}),
+		);
+
+		const config = yield* _(
+			Effect.promise(async () => {
+				const existing = await db.query.payrollExportConfig.findFirst({
+					where: and(
+						eq(payrollExportConfig.organizationId, input.organizationId),
+						eq(payrollExportConfig.formatId, WORKDAY_FORMAT_ID),
+					),
+				});
+
+				if (existing) {
+					const [updated] = await db
+						.update(payrollExportConfig)
+						.set({
+							config: input.config as unknown as Record<string, unknown>,
+							updatedBy: session.user.id,
+						})
+						.where(eq(payrollExportConfig.id, existing.id))
+						.returning();
+
+					return updated;
+				}
+
+				const [inserted] = await db
+					.insert(payrollExportConfig)
+					.values({
+						organizationId: input.organizationId,
+						formatId: WORKDAY_FORMAT_ID,
+						config: input.config as unknown as Record<string, unknown>,
+						isActive: true,
+						createdBy: session.user.id,
+						updatedAt: new Date(),
+					})
+					.returning();
+
+				return inserted;
+			}),
+		);
+
+		const hasCredentials = yield* _(
+			Effect.promise(async () => {
+				const clientId = await getOrgSecret(input.organizationId, WORKDAY_VAULT_KEY_CLIENT_ID);
+				const clientSecret = await getOrgSecret(
+					input.organizationId,
+					WORKDAY_VAULT_KEY_CLIENT_SECRET,
+				);
+				return (
+					clientId !== null &&
+					clientSecret !== null &&
+					clientId.trim().length > 0 &&
+					clientSecret.trim().length > 0
+				);
+			}),
+		);
+
+		revalidatePath("/settings/payroll-export");
+
+		return {
+			id: config.id,
+			formatId: config.formatId,
+			config: config.config as unknown as WorkdayConfig,
+			isActive: config.isActive,
+			hasCredentials,
+			createdAt: config.createdAt,
+			updatedAt: config.updatedAt,
+		};
+	});
+
+	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));
+}
+
+export async function saveWorkdayCredentialsAction(
+	input: SaveWorkdayCredentialsInput,
+): Promise<ServerActionResult<{ success: boolean }>> {
+	const effect = Effect.gen(function* (_) {
+		const authService = yield* _(AuthService);
+		const session = yield* _(authService.getSession());
+
+		const hasPermission = yield* _(
+			Effect.promise(() => isOrgAdminCasl(input.organizationId)),
+		);
+
+		if (!hasPermission) {
+			yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Insufficient permissions - admin role required",
+						userId: session.user.id,
+						resource: "payroll_export_config",
+						action: "create",
+					}),
+				),
+			);
+		}
+
+		const clientId = input.clientId.trim();
+		if (clientId.length === 0) {
+			yield* _(
+				Effect.fail(
+					new ValidationError({
+						message: "Workday client ID cannot be empty",
+						field: "clientId",
+					}),
+				),
+			);
+		}
+
+		const clientSecret = input.clientSecret.trim();
+		if (clientSecret.length === 0) {
+			yield* _(
+				Effect.fail(
+					new ValidationError({
+						message: "Workday client secret cannot be empty",
+						field: "clientSecret",
+					}),
+				),
+			);
+		}
+
+		yield* _(
+			Effect.promise(async () => {
+				await storeOrgSecret(input.organizationId, WORKDAY_VAULT_KEY_CLIENT_ID, clientId);
+				await storeOrgSecret(
+					input.organizationId,
+					WORKDAY_VAULT_KEY_CLIENT_SECRET,
+					clientSecret,
+				);
+			}),
+		);
+
+		revalidatePath("/settings/payroll-export");
+
+		return { success: true };
+	});
+
+	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));
+}
+
+export async function deleteWorkdayCredentialsAction(
+	organizationId: string,
+): Promise<ServerActionResult<{ success: boolean }>> {
+	const effect = Effect.gen(function* (_) {
+		const authService = yield* _(AuthService);
+		const session = yield* _(authService.getSession());
+
+		const hasPermission = yield* _(
+			Effect.promise(() => isOrgAdminCasl(organizationId)),
+		);
+
+		if (!hasPermission) {
+			yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Insufficient permissions - admin role required",
+						userId: session.user.id,
+						resource: "payroll_export_config",
+						action: "delete",
+					}),
+				),
+			);
+		}
+
+		yield* _(
+			Effect.promise(async () => {
+				await deleteOrgSecret(organizationId, WORKDAY_VAULT_KEY_CLIENT_ID);
+				await deleteOrgSecret(organizationId, WORKDAY_VAULT_KEY_CLIENT_SECRET);
+			}),
+		);
+
+		revalidatePath("/settings/payroll-export");
+
+		return { success: true };
+	});
+
+	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));
+}
+
+export async function testWorkdayConnectionAction(input: {
+	organizationId: string;
+	config: WorkdayConfig;
+}): Promise<ServerActionResult<{ success: boolean; error?: string }>> {
+	const effect = Effect.gen(function* (_) {
+		const authService = yield* _(AuthService);
+		const session = yield* _(authService.getSession());
+
+		const hasPermission = yield* _(
+			Effect.promise(() => isOrgAdminCasl(input.organizationId)),
+		);
+
+		if (!hasPermission) {
+			yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Insufficient permissions - admin role required",
+						userId: session.user.id,
+						resource: "payroll_export_config",
+						action: "read",
+					}),
+				),
+			);
+		}
+
+		const { workdayConnector } = yield* _(
+			Effect.promise(() => import("@/lib/payroll-export/exporters/workday/workday-connector")),
+		);
+
+		return yield* _(
+			Effect.promise(() =>
+				workdayConnector.testConnection(
+					input.organizationId,
+					input.config as unknown as Record<string, unknown>,
+				),
+			),
+		);
 	});
 
 	return runServerActionSafe(effect.pipe(Effect.provide(AppLayer)));

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
@@ -132,6 +132,7 @@ export interface DeleteMappingInput {
 
 export interface StartExportInput {
 	organizationId: string;
+	formatId: string;
 	startDate: string; // ISO date
 	endDate: string; // ISO date
 	employeeIds?: string[];
@@ -1822,7 +1823,7 @@ export async function startExportAction(
 			Effect.promise(() =>
 				createExportJob({
 					organizationId: input.organizationId,
-					formatId: "datev_lohn",
+					formatId: input.formatId,
 					requestedById: currentEmployee.id,
 					filters,
 				}),

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+	const session = {
+		user: {
+			id: "user-1",
+			email: "test@example.com",
+			name: "Test User",
+		},
+		session: {
+			id: "session-1",
+			userId: "user-1",
+			expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+			token: "token",
+		},
+	};
+
+	return {
+		session,
+		isOrgAdminCasl: vi.fn(async () => true),
+		getPayrollExportConfig: vi.fn(async () => null),
+		getOrgSecret: vi.fn(async () => null),
+		storeOrgSecret: vi.fn(async () => undefined),
+		deleteOrgSecret: vi.fn(async () => undefined),
+		createExportJob: vi.fn(),
+		processExportJob: vi.fn(),
+		getExportJobHistory: vi.fn(),
+		getExportDownloadUrl: vi.fn(),
+		getWageTypeMappings: vi.fn(),
+		getWorkCategories: vi.fn(),
+		getAbsenceCategories: vi.fn(),
+		getEmployeesForFilter: vi.fn(),
+		getTeamsForFilter: vi.fn(),
+		getProjectsForFilter: vi.fn(),
+		revalidatePath: vi.fn(),
+	};
+});
+
+vi.mock("@/db", () => ({
+	absenceCategory: {},
+	db: {
+		query: {
+			payrollExportFormat: { findFirst: vi.fn() },
+			payrollExportConfig: { findFirst: vi.fn() },
+		},
+		insert: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn(),
+	},
+	payrollExportConfig: {},
+	payrollExportFormat: {},
+	payrollWageTypeMapping: {},
+	workCategory: {},
+}));
+
+vi.mock("@/db/schema", () => ({
+	employee: {},
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+	isOrgAdminCasl: mockState.isOrgAdminCasl,
+}));
+
+vi.mock("@/lib/vault/secrets", () => ({
+	getOrgSecret: mockState.getOrgSecret,
+	storeOrgSecret: mockState.storeOrgSecret,
+	deleteOrgSecret: mockState.deleteOrgSecret,
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: mockState.revalidatePath,
+}));
+
+vi.mock("@/lib/payroll-export", () => ({
+	createExportJob: mockState.createExportJob,
+	processExportJob: mockState.processExportJob,
+	getExportJobHistory: mockState.getExportJobHistory,
+	getExportDownloadUrl: mockState.getExportDownloadUrl,
+	getPayrollExportConfig: mockState.getPayrollExportConfig,
+	getWageTypeMappings: mockState.getWageTypeMappings,
+	getWorkCategories: mockState.getWorkCategories,
+	getAbsenceCategories: mockState.getAbsenceCategories,
+	getEmployeesForFilter: mockState.getEmployeesForFilter,
+	getTeamsForFilter: mockState.getTeamsForFilter,
+	getProjectsForFilter: mockState.getProjectsForFilter,
+}));
+
+vi.mock("@/lib/effect/services/auth.service", async () => {
+	const { Context } = await import("effect");
+	const AuthService = Context.GenericTag<{
+		readonly getSession: () => unknown;
+	}>("AuthService");
+
+	return {
+		AuthService,
+	};
+});
+
+vi.mock("@/lib/effect/runtime", async () => {
+	const { Effect, Layer } = await import("effect");
+	const { AuthService } = await import("@/lib/effect/services/auth.service");
+
+	return {
+		AppLayer: Layer.succeed(AuthService, {
+			getSession: () => Effect.succeed(mockState.session),
+		}),
+	};
+});
+
+vi.mock("@/lib/effect/result", async () => {
+	const { Cause, Effect, Exit, Option } = await import("effect");
+
+	const toServerActionResult = <T>(exit: unknown) =>
+		Exit.match(exit as never, {
+			onFailure: (cause) => {
+				const defects = Cause.defects(cause);
+				const defect = [...defects][0] ?? null;
+				const failure = Option.getOrNull(Cause.failureOption(cause));
+				const error = defect ?? failure ?? cause;
+
+				if (error && typeof error === "object" && "_tag" in error) {
+					return {
+						success: false as const,
+						error: (error as { message: string }).message,
+						code: (error as { _tag: string })._tag,
+					};
+				}
+
+				if (error instanceof Error) {
+					return {
+						success: false as const,
+						error: error.message || "An unexpected error occurred",
+						code: "UNKNOWN_ERROR",
+					};
+				}
+
+				return {
+					success: false as const,
+					error: "An unexpected error occurred",
+					code: "UNKNOWN_ERROR",
+				};
+			},
+			onSuccess: (data) => ({ success: true as const, data }),
+		});
+
+	return {
+		runServerActionSafe: async <T>(effect: Parameters<typeof Effect.runPromiseExit<T>>[0]) => {
+			const exit = await Effect.runPromiseExit(effect);
+			return toServerActionResult(exit);
+		},
+		toServerActionResult,
+	};
+});
+
+const {
+	WORKDAY_FORMAT_ID,
+	deleteWorkdayCredentialsAction,
+	getWorkdayConfigAction,
+	saveWorkdayConfigAction,
+	saveWorkdayCredentialsAction,
+	testWorkdayConnectionAction,
+} = await import("./actions");
+
+describe("payroll export workday actions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.isOrgAdminCasl.mockResolvedValue(true);
+		mockState.getPayrollExportConfig.mockResolvedValue(null);
+		mockState.getOrgSecret.mockResolvedValue(null);
+	});
+
+	it("exports workday action handlers", () => {
+		expect(WORKDAY_FORMAT_ID).toBe("workday_api");
+		expect(typeof getWorkdayConfigAction).toBe("function");
+		expect(typeof saveWorkdayConfigAction).toBe("function");
+		expect(typeof saveWorkdayCredentialsAction).toBe("function");
+		expect(typeof deleteWorkdayCredentialsAction).toBe("function");
+		expect(typeof testWorkdayConnectionAction).toBe("function");
+	});
+
+	it("returns authorization error when user lacks access", async () => {
+		mockState.isOrgAdminCasl.mockResolvedValue(false);
+
+		const result = await getWorkdayConfigAction("org-1");
+
+		expect(result).toEqual({
+			success: false,
+			error: "Insufficient permissions - admin role required",
+			code: "AuthorizationError",
+		});
+	});
+
+	it("stores workday credentials and returns success", async () => {
+		const result = await saveWorkdayCredentialsAction({
+			organizationId: "org-1",
+			clientId: "  client-id  ",
+			clientSecret: "  client-secret  ",
+		});
+
+		expect(result).toEqual({ success: true, data: { success: true } });
+		expect(mockState.storeOrgSecret).toHaveBeenCalledTimes(2);
+		expect(mockState.storeOrgSecret).toHaveBeenNthCalledWith(
+			1,
+			"org-1",
+			"payroll/workday/client_id",
+			"client-id",
+		);
+		expect(mockState.storeOrgSecret).toHaveBeenNthCalledWith(
+			2,
+			"org-1",
+			"payroll/workday/client_secret",
+			"client-secret",
+		);
+		expect(mockState.revalidatePath).toHaveBeenCalledWith("/settings/payroll-export");
+	});
+
+	it("returns hasCredentials false when only one workday secret exists", async () => {
+		mockState.getPayrollExportConfig.mockResolvedValue({
+			config: {
+				id: "cfg-1",
+				formatId: WORKDAY_FORMAT_ID,
+				config: {
+					tenantId: "tenant-1",
+					hostname: "example.workday.com",
+					timeEntryType: "time_tracking_event",
+				} as unknown,
+				isActive: true,
+				createdAt: new Date("2026-01-01T00:00:00.000Z"),
+				updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+			},
+		});
+
+		mockState.getOrgSecret.mockImplementation(async (_orgId: string, key: string) => {
+			if (key === "payroll/workday/client_id") {
+				return "client-id";
+			}
+			return null;
+		});
+
+		const result = await getWorkdayConfigAction("org-1");
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data?.hasCredentials).toBe(false);
+		}
+	});
+
+	it("rejects whitespace-only credentials before storing", async () => {
+		const result = await saveWorkdayCredentialsAction({
+			organizationId: "org-1",
+			clientId: "   ",
+			clientSecret: "client-secret",
+		});
+
+		expect(result).toEqual({
+			success: false,
+			error: "Workday client ID cannot be empty",
+			code: "ValidationError",
+		});
+		expect(mockState.storeOrgSecret).not.toHaveBeenCalled();
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx
@@ -8,6 +8,7 @@ import { LexwareConfigForm } from "@/components/settings/payroll-export/lexware-
 import { SageConfigForm } from "@/components/settings/payroll-export/sage-config-form";
 import { PersonioConfigForm } from "@/components/settings/payroll-export/personio-config-form";
 import { SuccessFactorsConfigForm } from "@/components/settings/payroll-export/successfactors-config-form";
+import { WorkdayConfigForm } from "@/components/settings/payroll-export/workday-config-form";
 import { ExportForm } from "@/components/settings/payroll-export/export-form";
 import { ExportHistory } from "@/components/settings/payroll-export/export-history";
 import { WageTypeMappings } from "@/components/settings/payroll-export/wage-type-mappings";
@@ -22,6 +23,7 @@ import {
 	getSageConfigAction,
 	getPersonioConfigAction,
 	getSuccessFactorsConfigAction,
+	getWorkdayConfigAction,
 	getExportHistoryAction,
 } from "./actions";
 
@@ -49,12 +51,13 @@ async function PayrollExportContent() {
 	const organizationId = authContext.employee.organizationId;
 
 	// Fetch configs and history in parallel
-	const [datevConfigResult, lexwareConfigResult, sageConfigResult, personioConfigResult, successFactorsConfigResult, historyResult] = await Promise.all([
+	const [datevConfigResult, lexwareConfigResult, sageConfigResult, personioConfigResult, successFactorsConfigResult, workdayConfigResult, historyResult] = await Promise.all([
 		getDatevConfigAction(organizationId),
 		getLexwareConfigAction(organizationId),
 		getSageConfigAction(organizationId),
 		getPersonioConfigAction(organizationId),
 		getSuccessFactorsConfigAction(organizationId),
+		getWorkdayConfigAction(organizationId),
 		getExportHistoryAction(organizationId),
 	]);
 
@@ -63,6 +66,7 @@ async function PayrollExportContent() {
 	const sageConfig = sageConfigResult.success ? sageConfigResult.data : null;
 	const personioConfig = personioConfigResult.success ? personioConfigResult.data : null;
 	const successFactorsConfig = successFactorsConfigResult.success ? successFactorsConfigResult.data : null;
+	const workdayConfig = workdayConfigResult.success ? workdayConfigResult.data : null;
 	const exports = historyResult.success ? historyResult.data : [];
 
 	// For backward compatibility, use datevConfig as main config
@@ -102,6 +106,9 @@ async function PayrollExportContent() {
 					<TabsTrigger value="successfactors">
 						{t("settings.payrollExport.tabs.successfactors", "SAP SuccessFactors")}
 					</TabsTrigger>
+					<TabsTrigger value="workday">
+						{t("settings.payrollExport.tabs.workday", "Workday")}
+					</TabsTrigger>
 					<TabsTrigger value="mappings">
 						{t("settings.payrollExport.tabs.mappings", "Wage Types")}
 					</TabsTrigger>
@@ -132,6 +139,10 @@ async function PayrollExportContent() {
 
 				<TabsContent value="successfactors" className="mt-4">
 					<SuccessFactorsConfigForm organizationId={organizationId} initialConfig={successFactorsConfig} />
+				</TabsContent>
+
+				<TabsContent value="workday" className="mt-4">
+					<WorkdayConfigForm organizationId={organizationId} initialConfig={workdayConfig} />
 				</TabsContent>
 
 				<TabsContent value="mappings" className="mt-4">

--- a/apps/webapp/src/components/settings/payroll-export/export-form.test.tsx
+++ b/apps/webapp/src/components/settings/payroll-export/export-form.test.tsx
@@ -1,0 +1,209 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getFilterOptionsActionMock, startExportActionMock } = vi.hoisted(() => ({
+	getFilterOptionsActionMock: vi.fn(),
+	startExportActionMock: vi.fn(),
+}));
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, defaultValue?: string) => defaultValue ?? _key,
+	}),
+}));
+
+vi.mock("@/app/[locale]/(app)/settings/payroll-export/actions", () => ({
+	getFilterOptionsAction: getFilterOptionsActionMock,
+	startExportAction: startExportActionMock,
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@/components/ui/card", () => ({
+	Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+	CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+	CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button {...props}>{children}</button>
+	),
+}));
+
+vi.mock("@/components/ui/input", () => ({
+	Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+	Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+		<label {...props}>{children}</label>
+	),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+	Select: ({ value, onValueChange, children }: { value: string; onValueChange: (value: string) => void; children: React.ReactNode }) => (
+		<select value={value} onChange={(event) => onValueChange(event.target.value)}>
+			{children}
+		</select>
+	),
+	SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	SelectValue: () => null,
+	SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+		<option value={value}>{children}</option>
+	),
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+	Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	TabsTrigger: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+	TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/checkbox", () => ({
+	Checkbox: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input type="checkbox" {...props} />,
+}));
+
+vi.mock("@/components/ui/scroll-area", () => ({
+	ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+	Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/alert", () => ({
+	Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	AlertTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { ExportForm } from "./export-form";
+
+beforeAll(() => {
+	if (!globalThis.ResizeObserver) {
+		globalThis.ResizeObserver = class ResizeObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		};
+	}
+});
+
+describe("ExportForm", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getFilterOptionsActionMock.mockResolvedValue({
+			success: true,
+			data: {
+				employees: [],
+				teams: [],
+				projects: [],
+			},
+		});
+		startExportActionMock.mockResolvedValue({
+			success: true,
+			data: {
+				jobId: "job-1",
+				isAsync: true,
+			},
+		});
+	});
+
+	it("sends selected formatId and updates export button label", async () => {
+		render(
+			<ExportForm
+				organizationId="org_123"
+				config={{
+					id: "cfg_123",
+					formatId: "datev_lohn",
+					isActive: true,
+					createdAt: new Date("2026-01-01T00:00:00.000Z"),
+					updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+					config: {
+						consultantNumber: "1234",
+						clientNumber: "5678",
+						accountingMonth: 1,
+						accountingYear: 2026,
+						defaultWageType: "1000",
+						includeAbsences: true,
+						includeCostCenters: false,
+						exportFormat: "csv",
+					} as never,
+				}}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Export to DATEV" })).toBeTruthy();
+		});
+
+		const formatSelect = screen
+			.getAllByRole("combobox")
+			.find((combobox) => within(combobox).queryByRole("option", { name: "Workday" }));
+
+		expect(formatSelect).toBeTruthy();
+		fireEvent.change(formatSelect as HTMLSelectElement, { target: { value: "workday_api" } });
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Export to Workday" })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Export to Workday" }));
+
+		await waitFor(() => {
+			expect(startExportActionMock).toHaveBeenCalledTimes(1);
+		});
+
+		expect(startExportActionMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				organizationId: "org_123",
+				formatId: "workday_api",
+			}),
+		);
+	});
+
+	it("renders export flow without DATEV config and allows Workday selection", async () => {
+		render(<ExportForm organizationId="org_123" config={null} />);
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Export to DATEV" })).toBeTruthy();
+		});
+
+		const formatSelect = screen
+			.getAllByRole("combobox")
+			.find((combobox) => within(combobox).queryByRole("option", { name: "Workday" }));
+
+		expect(formatSelect).toBeTruthy();
+		fireEvent.change(formatSelect as HTMLSelectElement, { target: { value: "workday_api" } });
+
+		await waitFor(() => {
+			expect(screen.getByRole("button", { name: "Export to Workday" })).toBeTruthy();
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Export to Workday" }));
+
+		await waitFor(() => {
+			expect(startExportActionMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					organizationId: "org_123",
+					formatId: "workday_api",
+				}),
+			);
+		});
+	});
+});

--- a/apps/webapp/src/components/settings/payroll-export/index.ts
+++ b/apps/webapp/src/components/settings/payroll-export/index.ts
@@ -2,3 +2,4 @@ export { DatevConfigForm } from "./datev-config-form";
 export { ExportForm } from "./export-form";
 export { ExportHistory } from "./export-history";
 export { WageTypeMappings } from "./wage-type-mappings";
+export { WorkdayConfigForm } from "./workday-config-form";

--- a/apps/webapp/src/components/settings/payroll-export/workday-config-form.test.tsx
+++ b/apps/webapp/src/components/settings/payroll-export/workday-config-form.test.tsx
@@ -1,0 +1,106 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const {
+	saveWorkdayConfigActionMock,
+	saveWorkdayCredentialsActionMock,
+	deleteWorkdayCredentialsActionMock,
+	testWorkdayConnectionActionMock,
+} = vi.hoisted(() => ({
+	saveWorkdayConfigActionMock: vi.fn(),
+	saveWorkdayCredentialsActionMock: vi.fn(),
+	deleteWorkdayCredentialsActionMock: vi.fn(),
+	testWorkdayConnectionActionMock: vi.fn(),
+}));
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, defaultValue?: string) => defaultValue ?? _key,
+	}),
+}));
+
+vi.mock("@/app/[locale]/(app)/settings/payroll-export/actions", () => ({
+	saveWorkdayConfigAction: saveWorkdayConfigActionMock,
+	saveWorkdayCredentialsAction: saveWorkdayCredentialsActionMock,
+	deleteWorkdayCredentialsAction: deleteWorkdayCredentialsActionMock,
+	testWorkdayConnectionAction: testWorkdayConnectionActionMock,
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		success: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+import { WorkdayConfigForm } from "./workday-config-form";
+
+beforeAll(() => {
+	if (!globalThis.ResizeObserver) {
+		globalThis.ResizeObserver = class ResizeObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		};
+	}
+});
+
+describe("WorkdayConfigForm", () => {
+	it("renders key controls and triggers Test Connection action", async () => {
+		testWorkdayConnectionActionMock.mockResolvedValue({
+			success: true,
+			data: {
+				success: true,
+			},
+		});
+
+		render(
+			<WorkdayConfigForm
+				organizationId="org_123"
+				initialConfig={{
+					id: "cfg_123",
+					formatId: "workday_api",
+					isActive: true,
+					createdAt: new Date("2026-01-01T00:00:00.000Z"),
+					updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+					hasCredentials: true,
+					config: {
+						instanceUrl: "https://wd5-impl-services1.workday.com",
+						tenantId: "tenant_name",
+						employeeMatchStrategy: "employeeNumber",
+						includeZeroHours: false,
+						batchSize: 100,
+						apiTimeoutMs: 30000,
+					},
+				}}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Instance URL")).toBeTruthy();
+		expect(screen.getByLabelText("Tenant ID")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Save Settings" })).toBeTruthy();
+
+		const testConnectionButton = screen.getByRole("button", { name: "Test Connection" });
+		expect(testConnectionButton.hasAttribute("disabled")).toBe(false);
+
+		fireEvent.click(testConnectionButton);
+
+		await waitFor(() => {
+			expect(testWorkdayConnectionActionMock).toHaveBeenCalledTimes(1);
+		});
+
+		expect(testWorkdayConnectionActionMock).toHaveBeenCalledWith({
+			organizationId: "org_123",
+			config: {
+				instanceUrl: "https://wd5-impl-services1.workday.com",
+				tenantId: "tenant_name",
+				employeeMatchStrategy: "employeeNumber",
+				includeZeroHours: false,
+				batchSize: 100,
+				apiTimeoutMs: 30000,
+			},
+		});
+	});
+});

--- a/apps/webapp/src/components/settings/payroll-export/workday-config-form.tsx
+++ b/apps/webapp/src/components/settings/payroll-export/workday-config-form.tsx
@@ -1,0 +1,565 @@
+"use client";
+
+import {
+	IconCheck,
+	IconLoader2,
+	IconPlugConnected,
+	IconTrash,
+} from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
+import { useTranslate } from "@tolgee/react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import {
+	deleteWorkdayCredentialsAction,
+	saveWorkdayConfigAction,
+	saveWorkdayCredentialsAction,
+	testWorkdayConnectionAction,
+	type WorkdayConfigResult,
+} from "@/app/[locale]/(app)/settings/payroll-export/actions";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type { WorkdayConfig } from "@/lib/payroll-export";
+
+interface WorkdayConfigFormProps {
+	organizationId: string;
+	initialConfig?: WorkdayConfigResult | null;
+	onConfigSaved?: () => void;
+}
+
+const DEFAULT_CONFIG: WorkdayConfig = {
+	instanceUrl: "",
+	tenantId: "",
+	employeeMatchStrategy: "employeeNumber",
+	includeZeroHours: false,
+	batchSize: 100,
+	apiTimeoutMs: 30000,
+};
+
+export function WorkdayConfigForm({
+	organizationId,
+	initialConfig,
+	onConfigSaved,
+}: WorkdayConfigFormProps) {
+	const { t } = useTranslate();
+	const [isPending, startTransition] = useTransition();
+	const [isTesting, setIsTesting] = useState(false);
+	const [showCredentialsForm, setShowCredentialsForm] = useState(!initialConfig?.hasCredentials);
+	const [clientId, setClientId] = useState("");
+	const [clientSecret, setClientSecret] = useState("");
+
+	const form = useForm({
+		defaultValues: (initialConfig?.config ?? DEFAULT_CONFIG) satisfies WorkdayConfig,
+		onSubmit: async ({ value }) => {
+			startTransition(async () => {
+				const result = await saveWorkdayConfigAction({
+					organizationId,
+					config: value,
+				});
+
+				if (result.success) {
+					toast.success(t("settings.payrollExport.workday.saveSuccess", "Configuration saved"));
+					onConfigSaved?.();
+				} else {
+					toast.error(
+						t(
+							"settings.payrollExport.workday.saveError",
+							"Failed to save configuration",
+						),
+						{
+							description: result.error,
+						},
+					);
+				}
+			});
+		},
+	});
+
+	const handleSaveCredentials = async () => {
+		if (!clientId || !clientSecret) {
+			toast.error(
+				t(
+					"settings.payrollExport.workday.credentialsRequired",
+					"Please enter both Client ID and Client Secret",
+				),
+			);
+			return;
+		}
+
+		startTransition(async () => {
+			const result = await saveWorkdayCredentialsAction({
+				organizationId,
+				clientId,
+				clientSecret,
+			});
+
+			if (result.success) {
+				toast.success(
+					t(
+						"settings.payrollExport.workday.credentialsSaved",
+						"Credentials saved securely",
+					),
+				);
+				setShowCredentialsForm(false);
+				setClientId("");
+				setClientSecret("");
+				onConfigSaved?.();
+			} else {
+				toast.error(
+					t(
+						"settings.payrollExport.workday.credentialsSaveError",
+						"Failed to save credentials",
+					),
+					{
+						description: result.error,
+					},
+				);
+			}
+		});
+	};
+
+	const handleDeleteCredentials = async () => {
+		startTransition(async () => {
+			const result = await deleteWorkdayCredentialsAction(organizationId);
+
+			if (result.success) {
+				toast.success(
+					t(
+						"settings.payrollExport.workday.credentialsDeleted",
+						"Credentials deleted",
+					),
+				);
+				setShowCredentialsForm(true);
+				onConfigSaved?.();
+			} else {
+				toast.error(
+					t(
+						"settings.payrollExport.workday.credentialsDeleteError",
+						"Failed to delete credentials",
+					),
+					{
+						description: result.error,
+					},
+				);
+			}
+		});
+	};
+
+	const handleTestConnection = async () => {
+		setIsTesting(true);
+		const result = await testWorkdayConnectionAction({
+			organizationId,
+			config: form.state.values,
+		}).catch(() => null);
+
+		if (!result) {
+			toast.error(t("settings.payrollExport.workday.connectionFailed", "Connection test failed"));
+			setIsTesting(false);
+			return;
+		}
+
+		if (result.success && result.data.success) {
+			toast.success(
+				t(
+					"settings.payrollExport.workday.connectionSuccess",
+					"Successfully connected to Workday",
+				),
+			);
+		} else {
+			toast.error(t("settings.payrollExport.workday.connectionFailed", "Connection test failed"), {
+				description: result.success ? result.data.error : result.error,
+			});
+		}
+
+		setIsTesting(false);
+	};
+
+	const hasConfiguredCredentials = !showCredentialsForm;
+
+	return (
+		<div className="space-y-6">
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						{t(
+							"settings.payrollExport.workday.credentialsTitle",
+							"Workday API Credentials",
+						)}
+						{initialConfig?.hasCredentials && !showCredentialsForm && (
+							<Badge variant="secondary" className="gap-1">
+								<IconCheck className="h-3 w-3" aria-hidden="true" />
+								{t("settings.payrollExport.workday.connected", "Connected")}
+							</Badge>
+						)}
+					</CardTitle>
+					<CardDescription>
+						{t(
+							"settings.payrollExport.workday.credentialsDescription",
+							"Store OAuth credentials used for Workday API access",
+						)}
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					{showCredentialsForm ? (
+						<>
+							<div className="space-y-2">
+								<Label htmlFor="clientId">
+									{t("settings.payrollExport.workday.clientId", "Client ID")}
+								</Label>
+								<Input
+									id="clientId"
+									type="text"
+									autoComplete="off"
+									value={clientId}
+									onChange={(e) => setClientId(e.target.value)}
+									placeholder="workday-client-id"
+								/>
+							</div>
+							<div className="space-y-2">
+								<Label htmlFor="clientSecret">
+									{t("settings.payrollExport.workday.clientSecret", "Client Secret")}
+								</Label>
+								<Input
+									id="clientSecret"
+									type="password"
+									autoComplete="new-password"
+									value={clientSecret}
+									onChange={(e) => setClientSecret(e.target.value)}
+									placeholder="********"
+								/>
+							</div>
+						</>
+					) : (
+						<div className="flex items-center justify-between rounded-lg border p-4">
+							<div className="flex items-center gap-3">
+								<IconPlugConnected className="h-5 w-5 text-green-600" aria-hidden="true" />
+								<div>
+									<p className="font-medium">
+										{t(
+											"settings.payrollExport.workday.credentialsConfigured",
+											"Credentials configured",
+										)}
+									</p>
+									<p className="text-sm text-muted-foreground">
+										{t(
+											"settings.payrollExport.workday.credentialsSecure",
+											"Stored securely in vault",
+										)}
+									</p>
+								</div>
+							</div>
+							<div className="flex gap-2">
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => setShowCredentialsForm(true)}
+								>
+									{t("settings.payrollExport.workday.updateCredentials", "Update")}
+								</Button>
+								<AlertDialog>
+									<AlertDialogTrigger asChild>
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											aria-label={t(
+												"settings.payrollExport.workday.deleteCredentials",
+												"Delete credentials",
+											)}
+										>
+											<IconTrash className="h-4 w-4 text-destructive" aria-hidden="true" />
+										</Button>
+									</AlertDialogTrigger>
+									<AlertDialogContent>
+										<AlertDialogHeader>
+											<AlertDialogTitle>
+												{t(
+													"settings.payrollExport.workday.deleteCredentialsTitle",
+													"Delete Workday credentials?",
+												)}
+											</AlertDialogTitle>
+											<AlertDialogDescription>
+												{t(
+													"settings.payrollExport.workday.deleteCredentialsDescription",
+													"This removes stored Workday OAuth credentials for this organization.",
+												)}
+											</AlertDialogDescription>
+										</AlertDialogHeader>
+										<AlertDialogFooter>
+											<AlertDialogCancel>{t("common.cancel", "Cancel")}</AlertDialogCancel>
+											<AlertDialogAction
+												onClick={handleDeleteCredentials}
+												className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+											>
+												{t("common.delete", "Delete")}
+											</AlertDialogAction>
+										</AlertDialogFooter>
+									</AlertDialogContent>
+								</AlertDialog>
+							</div>
+						</div>
+					)}
+				</CardContent>
+				{showCredentialsForm && (
+					<CardFooter className="flex gap-2">
+						<Button
+							type="button"
+							onClick={handleSaveCredentials}
+							disabled={isPending || !clientId || !clientSecret}
+						>
+							{isPending ? (
+								<>
+									<IconLoader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+									{t("common.saving", "Saving...")}
+								</>
+							) : (
+								t("settings.payrollExport.workday.saveCredentials", "Save Credentials")
+							)}
+						</Button>
+						{initialConfig?.hasCredentials && (
+							<Button
+								type="button"
+								variant="ghost"
+								onClick={() => {
+									setShowCredentialsForm(false);
+									setClientId("");
+									setClientSecret("");
+								}}
+							>
+								{t("common.cancel", "Cancel")}
+							</Button>
+						)}
+					</CardFooter>
+				)}
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>{t("settings.payrollExport.workday.configTitle", "Workday Export Settings")}</CardTitle>
+					<CardDescription>
+						{t(
+							"settings.payrollExport.workday.configDescription",
+							"Configure how records are prepared and sent to Workday",
+						)}
+					</CardDescription>
+				</CardHeader>
+				<form
+					className="flex flex-col gap-6"
+					onSubmit={(e) => {
+						e.preventDefault();
+						form.handleSubmit();
+					}}
+				>
+					<CardContent className="space-y-4">
+						<form.Field name="instanceUrl">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="instanceUrl">
+										{t("settings.payrollExport.workday.instanceUrl", "Instance URL")}
+									</Label>
+									<Input
+										id="instanceUrl"
+										type="url"
+										autoComplete="url"
+										placeholder="https://wd5-impl-services1.workday.com"
+										value={field.state.value}
+										onChange={(e) => field.handleChange(e.target.value)}
+									/>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="tenantId">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="tenantId">
+										{t("settings.payrollExport.workday.tenantId", "Tenant ID")}
+									</Label>
+									<Input
+										id="tenantId"
+										type="text"
+										autoComplete="organization"
+										placeholder="tenant_name"
+										value={field.state.value}
+										onChange={(e) => field.handleChange(e.target.value)}
+									/>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="employeeMatchStrategy">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="employeeMatchStrategy">
+										{t(
+											"settings.payrollExport.workday.employeeMatchStrategy",
+											"Employee Matching",
+										)}
+									</Label>
+									<Select
+										value={field.state.value}
+										onValueChange={(value) =>
+											field.handleChange(value as "employeeNumber" | "email")
+										}
+									>
+										<SelectTrigger id="employeeMatchStrategy">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="employeeNumber">
+												{t(
+													"settings.payrollExport.workday.matchByEmployeeNumber",
+													"Employee Number (Recommended)",
+												)}
+											</SelectItem>
+											<SelectItem value="email">
+												{t(
+													"settings.payrollExport.workday.matchByEmail",
+													"Email Address",
+												)}
+											</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="batchSize">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="batchSize">
+										{t("settings.payrollExport.workday.batchSize", "Batch Size")}
+									</Label>
+									<Input
+										id="batchSize"
+										type="number"
+										autoComplete="off"
+										min={1}
+										max={500}
+										value={field.state.value}
+										onChange={(e) => field.handleChange(parseInt(e.target.value, 10) || 100)}
+									/>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="apiTimeoutMs">
+							{(field) => (
+								<div className="space-y-2">
+									<Label htmlFor="apiTimeoutMs">
+										{t("settings.payrollExport.workday.apiTimeoutMs", "API Timeout (ms)")}
+									</Label>
+									<Input
+										id="apiTimeoutMs"
+										type="number"
+										autoComplete="off"
+										min={1000}
+										step={1000}
+										value={field.state.value}
+										onChange={(e) =>
+											field.handleChange(parseInt(e.target.value, 10) || 30000)
+										}
+									/>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="includeZeroHours">
+							{(field) => (
+								<div className="flex items-center justify-between rounded-lg border p-4">
+									<div className="space-y-0.5">
+										<Label htmlFor="includeZeroHours" className="text-base">
+											{t(
+												"settings.payrollExport.workday.includeZeroHours",
+												"Include Zero Hours",
+											)}
+										</Label>
+										<p className="text-sm text-muted-foreground">
+											{t(
+												"settings.payrollExport.workday.includeZeroHoursDescription",
+												"Include records with zero hours in exports",
+											)}
+										</p>
+									</div>
+									<Switch
+										id="includeZeroHours"
+										checked={field.state.value}
+										onCheckedChange={field.handleChange}
+									/>
+								</div>
+							)}
+						</form.Field>
+					</CardContent>
+					<CardFooter className="flex gap-2">
+						<Button type="submit" disabled={isPending}>
+							{isPending ? (
+								<>
+									<IconLoader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+									{t("common.saving", "Saving...")}
+								</>
+							) : (
+								t("settings.payrollExport.workday.save", "Save Settings")
+							)}
+						</Button>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={handleTestConnection}
+							disabled={
+								isTesting ||
+								!hasConfiguredCredentials ||
+								!form.state.values.instanceUrl ||
+								!form.state.values.tenantId
+							}
+						>
+							{isTesting ? (
+								<>
+									<IconLoader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+									{t("settings.payrollExport.workday.testing", "Testing...")}
+								</>
+							) : (
+								<>
+									<IconPlugConnected className="mr-2 h-4 w-4" aria-hidden="true" />
+									{t(
+										"settings.payrollExport.workday.testConnection",
+										"Test Connection",
+									)}
+								</>
+							)}
+						</Button>
+					</CardFooter>
+				</form>
+			</Card>
+		</div>
+	);
+}

--- a/apps/webapp/src/lib/payroll-export/connectors/personio-connector.test.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/personio-connector.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IPayrollExporter } from "../types";
+import { createPersonioConnector } from "./personio-connector";
+
+vi.mock("../exporters/personio", () => ({
+	personioExporter: createExporterStub({}),
+}));
+
+describe("createPersonioConnector", () => {
+	it("delegates validateConfig to the underlying exporter", async () => {
+		const validateConfig = vi.fn().mockResolvedValue({ valid: true });
+		const exporter = createExporterStub({ validateConfig });
+		const connector = createPersonioConnector(exporter);
+
+		const config = { employeeMatchStrategy: "employeeNumber" };
+		await expect(connector.validateConfig(config)).resolves.toEqual({ valid: true });
+		expect(validateConfig).toHaveBeenCalledWith(config);
+	});
+
+	it("delegates testConnection to the underlying exporter", async () => {
+		const testConnection = vi.fn().mockResolvedValue({ success: true });
+		const exporter = createExporterStub({ testConnection });
+		const connector = createPersonioConnector(exporter);
+
+		const organizationId = "org_123";
+		const config = { apiTimeoutMs: 5000 };
+		await expect(connector.testConnection(organizationId, config)).resolves.toEqual({
+			success: true,
+		});
+		expect(testConnection).toHaveBeenCalledWith(organizationId, config);
+	});
+
+	it("delegates export to the underlying exporter", async () => {
+		const exportResult = {
+			success: true,
+			totalRecords: 0,
+			syncedRecords: 0,
+			failedRecords: 0,
+			skippedRecords: 0,
+			errors: [],
+			metadata: {
+				employeeCount: 0,
+				dateRange: { start: "", end: "" },
+				apiCallCount: 0,
+				durationMs: 0,
+			},
+		};
+		const exportFn = vi.fn().mockResolvedValue(exportResult);
+		const exporter = createExporterStub({ export: exportFn });
+		const connector = createPersonioConnector(exporter);
+
+		const organizationId = "org_123";
+		const workPeriods = [];
+		const absences = [];
+		const mappings = [];
+		const config = { batchSize: 100 };
+
+		await expect(
+			connector.export(organizationId, workPeriods, absences, mappings, config),
+		).resolves.toEqual(exportResult);
+		expect(exportFn).toHaveBeenCalledWith(
+			organizationId,
+			workPeriods,
+			absences,
+			mappings,
+			config,
+		);
+	});
+
+	it("delegates getSyncThreshold to the underlying exporter", () => {
+		const getSyncThreshold = vi.fn().mockReturnValue(750);
+		const exporter = createExporterStub({ getSyncThreshold });
+		const connector = createPersonioConnector(exporter);
+
+		expect(connector.getSyncThreshold()).toBe(750);
+		expect(getSyncThreshold).toHaveBeenCalledTimes(1);
+	});
+});
+
+function createExporterStub(overrides: Partial<IPayrollExporter>): IPayrollExporter {
+	return {
+		exporterId: "personio",
+		exporterName: "Personio",
+		version: "1.0.0",
+		validateConfig: async () => ({ valid: true }),
+		testConnection: async () => ({ success: true }),
+		export: async () => ({
+			success: true,
+			totalRecords: 0,
+			syncedRecords: 0,
+			failedRecords: 0,
+			skippedRecords: 0,
+			errors: [],
+			metadata: {
+				employeeCount: 0,
+				dateRange: { start: "", end: "" },
+				apiCallCount: 0,
+				durationMs: 0,
+			},
+		}),
+		getSyncThreshold: () => 500,
+		...overrides,
+	};
+}

--- a/apps/webapp/src/lib/payroll-export/connectors/personio-connector.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/personio-connector.ts
@@ -1,0 +1,39 @@
+import { personioExporter } from "../exporters/personio";
+import type {
+	AbsenceData,
+	ApiExportResult,
+	IPayrollExporter,
+	WageTypeMapping,
+	WorkPeriodData,
+} from "../types";
+
+export function createPersonioConnector(exporter: IPayrollExporter = personioExporter): IPayrollExporter {
+	return {
+		exporterId: exporter.exporterId,
+		exporterName: exporter.exporterName,
+		version: exporter.version,
+		validateConfig(config: Record<string, unknown>): Promise<{ valid: boolean; errors?: string[] }> {
+			return exporter.validateConfig(config);
+		},
+		testConnection(
+			organizationId: string,
+			config: Record<string, unknown>,
+		): Promise<{ success: boolean; error?: string }> {
+			return exporter.testConnection(organizationId, config);
+		},
+		export(
+			organizationId: string,
+			workPeriods: WorkPeriodData[],
+			absences: AbsenceData[],
+			mappings: WageTypeMapping[],
+			config: Record<string, unknown>,
+		): Promise<ApiExportResult> {
+			return exporter.export(organizationId, workPeriods, absences, mappings, config);
+		},
+		getSyncThreshold(): number {
+			return exporter.getSyncThreshold();
+		},
+	};
+}
+
+export const personioConnector = createPersonioConnector();

--- a/apps/webapp/src/lib/payroll-export/connectors/registry.test.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { PayrollApiConnector } from "./types";
+import { PayrollConnectorRegistry } from "./registry";
+
+function createConnector(id: string): PayrollApiConnector {
+	return {
+		exporterId: id,
+		exporterName: `Connector ${id}`,
+		version: "1.0.0",
+		validateConfig: async () => ({ valid: true }),
+		testConnection: async () => ({ success: true }),
+		export: async () => ({
+			success: true,
+			totalRecords: 0,
+			syncedRecords: 0,
+			failedRecords: 0,
+			skippedRecords: 0,
+			errors: [],
+			metadata: {
+				employeeCount: 0,
+				dateRange: { start: "", end: "" },
+				apiCallCount: 0,
+				durationMs: 0,
+			},
+		}),
+		getSyncThreshold: () => 500,
+	};
+}
+
+describe("PayrollConnectorRegistry", () => {
+	it("registers and gets a connector", () => {
+		const registry = new PayrollConnectorRegistry();
+		const connector = createConnector("personio");
+
+		registry.register(connector);
+
+		expect(registry.get("personio")).toBe(connector);
+	});
+
+	it("lists registered connectors", () => {
+		const registry = new PayrollConnectorRegistry();
+		const first = createConnector("personio");
+		const second = createConnector("successfactors");
+
+		registry.register(first);
+		registry.register(second);
+
+		expect(registry.list()).toEqual([first, second]);
+	});
+
+	it("checks connector availability", () => {
+		const registry = new PayrollConnectorRegistry();
+		registry.register(createConnector("personio"));
+
+		expect(registry.has("personio")).toBe(true);
+		expect(registry.has("missing")).toBe(false);
+	});
+});

--- a/apps/webapp/src/lib/payroll-export/connectors/registry.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/registry.ts
@@ -1,0 +1,21 @@
+import { getPayrollApiConnectorId, type PayrollApiConnector } from "./types";
+
+export class PayrollConnectorRegistry {
+	private readonly connectors = new Map<string, PayrollApiConnector>();
+
+	register(connector: PayrollApiConnector): void {
+		this.connectors.set(getPayrollApiConnectorId(connector), connector);
+	}
+
+	get(connectorId: string): PayrollApiConnector | undefined {
+		return this.connectors.get(connectorId);
+	}
+
+	list(): PayrollApiConnector[] {
+		return Array.from(this.connectors.values());
+	}
+
+	has(connectorId: string): boolean {
+		return this.connectors.has(connectorId);
+	}
+}

--- a/apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.test.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IPayrollExporter } from "../types";
+import { createSuccessFactorsConnector } from "./successfactors-connector";
+
+vi.mock("../exporters/successfactors", () => ({
+	successFactorsExporter: createExporterStub({}),
+}));
+
+describe("createSuccessFactorsConnector", () => {
+	it("delegates validateConfig to the underlying exporter", async () => {
+		const validateConfig = vi.fn().mockResolvedValue({ valid: false, errors: ["invalid"] });
+		const exporter = createExporterStub({ validateConfig });
+		const connector = createSuccessFactorsConnector(exporter);
+
+		const config = { companyId: "ACME" };
+		await expect(connector.validateConfig(config)).resolves.toEqual({
+			valid: false,
+			errors: ["invalid"],
+		});
+		expect(validateConfig).toHaveBeenCalledWith(config);
+	});
+
+	it("delegates testConnection to the underlying exporter", async () => {
+		const testConnection = vi
+			.fn()
+			.mockResolvedValue({ success: false, error: "Network unavailable" });
+		const exporter = createExporterStub({ testConnection });
+		const connector = createSuccessFactorsConnector(exporter);
+
+		const organizationId = "org_123";
+		const config = { instanceUrl: "https://example.successfactors.com" };
+		await expect(connector.testConnection(organizationId, config)).resolves.toEqual({
+			success: false,
+			error: "Network unavailable",
+		});
+		expect(testConnection).toHaveBeenCalledWith(organizationId, config);
+	});
+
+	it("delegates export to the underlying exporter", async () => {
+		const exportResult = {
+			success: true,
+			totalRecords: 3,
+			syncedRecords: 2,
+			failedRecords: 1,
+			skippedRecords: 0,
+			errors: [],
+			metadata: {
+				employeeCount: 2,
+				dateRange: { start: "2026-01-01", end: "2026-01-31" },
+				apiCallCount: 4,
+				durationMs: 42,
+			},
+		};
+		const exportFn = vi.fn().mockResolvedValue(exportResult);
+		const exporter = createExporterStub({ export: exportFn });
+		const connector = createSuccessFactorsConnector(exporter);
+
+		const organizationId = "org_123";
+		const workPeriods = [];
+		const absences = [];
+		const mappings = [];
+		const config = { batchSize: 10 };
+
+		await expect(
+			connector.export(organizationId, workPeriods, absences, mappings, config),
+		).resolves.toEqual(exportResult);
+		expect(exportFn).toHaveBeenCalledWith(
+			organizationId,
+			workPeriods,
+			absences,
+			mappings,
+			config,
+		);
+	});
+
+	it("delegates getSyncThreshold to the underlying exporter", () => {
+		const getSyncThreshold = vi.fn().mockReturnValue(250);
+		const exporter = createExporterStub({ getSyncThreshold });
+		const connector = createSuccessFactorsConnector(exporter);
+
+		expect(connector.getSyncThreshold()).toBe(250);
+		expect(getSyncThreshold).toHaveBeenCalledTimes(1);
+	});
+});
+
+function createExporterStub(overrides: Partial<IPayrollExporter>): IPayrollExporter {
+	return {
+		exporterId: "successfactors_api",
+		exporterName: "SAP SuccessFactors (API)",
+		version: "1.0.0",
+		validateConfig: async () => ({ valid: true }),
+		testConnection: async () => ({ success: true }),
+		export: async () => ({
+			success: true,
+			totalRecords: 0,
+			syncedRecords: 0,
+			failedRecords: 0,
+			skippedRecords: 0,
+			errors: [],
+			metadata: {
+				employeeCount: 0,
+				dateRange: { start: "", end: "" },
+				apiCallCount: 0,
+				durationMs: 0,
+			},
+		}),
+		getSyncThreshold: () => 500,
+		...overrides,
+	};
+}

--- a/apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.ts
@@ -1,0 +1,41 @@
+import { successFactorsExporter } from "../exporters/successfactors";
+import type {
+	AbsenceData,
+	ApiExportResult,
+	IPayrollExporter,
+	WageTypeMapping,
+	WorkPeriodData,
+} from "../types";
+
+export function createSuccessFactorsConnector(
+	exporter: IPayrollExporter = successFactorsExporter,
+): IPayrollExporter {
+	return {
+		exporterId: exporter.exporterId,
+		exporterName: exporter.exporterName,
+		version: exporter.version,
+		validateConfig(config: Record<string, unknown>): Promise<{ valid: boolean; errors?: string[] }> {
+			return exporter.validateConfig(config);
+		},
+		testConnection(
+			organizationId: string,
+			config: Record<string, unknown>,
+		): Promise<{ success: boolean; error?: string }> {
+			return exporter.testConnection(organizationId, config);
+		},
+		export(
+			organizationId: string,
+			workPeriods: WorkPeriodData[],
+			absences: AbsenceData[],
+			mappings: WageTypeMapping[],
+			config: Record<string, unknown>,
+		): Promise<ApiExportResult> {
+			return exporter.export(organizationId, workPeriods, absences, mappings, config);
+		},
+		getSyncThreshold(): number {
+			return exporter.getSyncThreshold();
+		},
+	};
+}
+
+export const successFactorsConnector = createSuccessFactorsConnector();

--- a/apps/webapp/src/lib/payroll-export/connectors/types.ts
+++ b/apps/webapp/src/lib/payroll-export/connectors/types.ts
@@ -1,0 +1,11 @@
+import type { IPayrollExporter } from "../types";
+
+/**
+ * API connector contract for payroll exports.
+ * Connector is currently an alias of the existing exporter contract.
+ */
+export type PayrollApiConnector = IPayrollExporter;
+
+export function getPayrollApiConnectorId(connector: PayrollApiConnector): string {
+	return connector.exporterId;
+}

--- a/apps/webapp/src/lib/payroll-export/export-service.ts
+++ b/apps/webapp/src/lib/payroll-export/export-service.ts
@@ -21,6 +21,7 @@ import { personioConnector } from "./connectors/personio-connector";
 import {
 	successFactorsFormatter,
 } from "./exporters/successfactors";
+import { workdayConnector } from "./exporters/workday/workday-connector";
 import { successFactorsConnector } from "./connectors/successfactors-connector";
 import { PayrollConnectorRegistry } from "./connectors/registry";
 import type {
@@ -64,6 +65,9 @@ connectorRegistry.register(personioConnector);
 
 // Register SAP SuccessFactors exporter (API mode)
 connectorRegistry.register(successFactorsConnector);
+
+// Register Workday exporter (API mode)
+connectorRegistry.register(workdayConnector);
 
 // Register SAP SuccessFactors formatter (CSV mode)
 formatters.set(successFactorsFormatter.formatId, successFactorsFormatter);

--- a/apps/webapp/src/lib/payroll-export/export-service.ts
+++ b/apps/webapp/src/lib/payroll-export/export-service.ts
@@ -17,11 +17,11 @@ import {
 import { DatevLohnFormatter } from "./formatters/datev-lohn-formatter";
 import { LexwareLohnFormatter } from "./formatters/lexware-lohn-formatter";
 import { SageLohnFormatter } from "./formatters/sage-lohn-formatter";
-import { personioExporter } from "./exporters/personio";
+import { personioConnector } from "./connectors/personio-connector";
 import {
-	successFactorsExporter,
 	successFactorsFormatter,
 } from "./exporters/successfactors";
+import { successFactorsConnector } from "./connectors/successfactors-connector";
 import { PayrollConnectorRegistry } from "./connectors/registry";
 import type {
 	IPayrollExportFormatter,
@@ -60,10 +60,10 @@ const sageFormatter = new SageLohnFormatter();
 formatters.set(sageFormatter.formatId, sageFormatter);
 
 // Register Personio exporter
-connectorRegistry.register(personioExporter);
+connectorRegistry.register(personioConnector);
 
 // Register SAP SuccessFactors exporter (API mode)
-connectorRegistry.register(successFactorsExporter);
+connectorRegistry.register(successFactorsConnector);
 
 // Register SAP SuccessFactors formatter (CSV mode)
 formatters.set(successFactorsFormatter.formatId, successFactorsFormatter);

--- a/apps/webapp/src/lib/payroll-export/export-service.ts
+++ b/apps/webapp/src/lib/payroll-export/export-service.ts
@@ -22,6 +22,7 @@ import {
 	successFactorsExporter,
 	successFactorsFormatter,
 } from "./exporters/successfactors";
+import { PayrollConnectorRegistry } from "./connectors/registry";
 import type {
 	IPayrollExportFormatter,
 	IPayrollExporter,
@@ -44,7 +45,7 @@ const formatters = new Map<string, IPayrollExportFormatter>();
 /**
  * Registry of available API-based exporters (Personio, etc.)
  */
-const exporters = new Map<string, IPayrollExporter>();
+const connectorRegistry = new PayrollConnectorRegistry();
 
 // Register DATEV formatter
 const datevFormatter = new DatevLohnFormatter();
@@ -59,10 +60,10 @@ const sageFormatter = new SageLohnFormatter();
 formatters.set(sageFormatter.formatId, sageFormatter);
 
 // Register Personio exporter
-exporters.set(personioExporter.exporterId, personioExporter);
+connectorRegistry.register(personioExporter);
 
 // Register SAP SuccessFactors exporter (API mode)
-exporters.set(successFactorsExporter.exporterId, successFactorsExporter);
+connectorRegistry.register(successFactorsExporter);
 
 // Register SAP SuccessFactors formatter (CSV mode)
 formatters.set(successFactorsFormatter.formatId, successFactorsFormatter);
@@ -85,21 +86,21 @@ export function getAvailableFormatters(): IPayrollExportFormatter[] {
  * Get exporter by ID
  */
 export function getExporter(exporterId: string): IPayrollExporter | undefined {
-	return exporters.get(exporterId);
+	return connectorRegistry.get(exporterId);
 }
 
 /**
  * Get all available exporters
  */
 export function getAvailableExporters(): IPayrollExporter[] {
-	return Array.from(exporters.values());
+	return connectorRegistry.list();
 }
 
 /**
  * Check if a format is API-based (exporter) or file-based (formatter)
  */
 export function isApiBasedExport(formatId: string): boolean {
-	return exporters.has(formatId);
+	return connectorRegistry.has(formatId);
 }
 
 /**
@@ -122,7 +123,7 @@ export async function createExportJob(params: {
 
 	// Check both formatters (file-based) and exporters (API-based)
 	const formatter = formatters.get(params.formatId);
-	const exporter = exporters.get(params.formatId);
+	const exporter = connectorRegistry.get(params.formatId);
 
 	if (!formatter && !exporter) {
 		throw new Error(`Unknown export format: ${params.formatId}`);
@@ -209,7 +210,7 @@ export async function processExportJob(jobId: string): Promise<{
 
 		// Check if this is a file-based formatter or API-based exporter
 		const formatter = formatters.get(job.config.formatId);
-		const exporter = exporters.get(job.config.formatId);
+		const exporter = connectorRegistry.get(job.config.formatId);
 
 		if (!formatter && !exporter) {
 			throw new Error(`Unknown format/exporter: ${job.config.formatId}`);

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorkdayApiClient } from "./api-client";
+
+describe("WorkdayApiClient", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("retrieves an OAuth2 token", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					access_token: "token_123",
+					token_type: "Bearer",
+					expires_in: 3600,
+				}),
+				{ status: 200 },
+			),
+		);
+
+		const client = new WorkdayApiClient({
+			instanceUrl: "https://example.workday.com",
+			tenantId: "acme",
+			timeoutMs: 5000,
+		});
+
+		const token = await client.getOAuthToken({
+			clientId: "client_123",
+			clientSecret: "secret_123",
+			scope: "system",
+		});
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://example.workday.com/ccx/oauth2/acme/token",
+			expect.objectContaining({
+				method: "POST",
+				headers: expect.objectContaining({
+					"Content-Type": "application/x-www-form-urlencoded",
+				}),
+			}),
+		);
+		expect(token.accessToken).toBe("token_123");
+		expect(token.tokenType).toBe("Bearer");
+		expect(token.expiresAt).toBeTypeOf("number");
+	});
+
+	it("tests connectivity with a lightweight ping", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), { status: 200 }),
+		);
+
+		const client = new WorkdayApiClient({
+			instanceUrl: "https://example.workday.com",
+			tenantId: "acme",
+			timeoutMs: 5000,
+		});
+
+		await expect(client.testConnection("token_123")).resolves.toEqual({ success: true });
+	});
+
+	it("returns connection error details when ping fails", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ message: "unauthorized" }), { status: 401 }),
+		);
+
+		const client = new WorkdayApiClient({
+			instanceUrl: "https://example.workday.com",
+			tenantId: "acme",
+			timeoutMs: 5000,
+		});
+
+		await expect(client.testConnection("token_123")).resolves.toEqual({
+			success: false,
+			error: "Workday API ping failed with status 401",
+		});
+	});
+});

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts
@@ -1,0 +1,105 @@
+import type {
+	WorkdayAuthToken,
+	WorkdayOAuthCredentials,
+} from "./types";
+
+interface WorkdayApiClientOptions {
+	instanceUrl: string;
+	tenantId: string;
+	timeoutMs?: number;
+}
+
+interface WorkdayTokenResponse {
+	access_token: string;
+	token_type?: string;
+	expires_in?: number;
+}
+
+export class WorkdayApiClient {
+	private readonly instanceUrl: string;
+	private readonly tenantId: string;
+	private readonly timeoutMs: number;
+
+	constructor(options: WorkdayApiClientOptions) {
+		this.instanceUrl = options.instanceUrl.replace(/\/$/, "");
+		this.tenantId = options.tenantId;
+		this.timeoutMs = options.timeoutMs ?? 30000;
+	}
+
+	async getOAuthToken(credentials: WorkdayOAuthCredentials): Promise<WorkdayAuthToken> {
+		const body = new URLSearchParams({
+			grant_type: "client_credentials",
+			client_id: credentials.clientId,
+			client_secret: credentials.clientSecret,
+		});
+
+		if (credentials.scope) {
+			body.set("scope", credentials.scope);
+		}
+
+		const response = await fetch(this.getTokenUrl(), {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/x-www-form-urlencoded",
+				Accept: "application/json",
+			},
+			body,
+			signal: AbortSignal.timeout(this.timeoutMs),
+		});
+
+		if (!response.ok) {
+			throw new Error(`Workday OAuth token request failed with status ${response.status}`);
+		}
+
+		const payload = (await response.json()) as WorkdayTokenResponse;
+		if (!payload.access_token) {
+			throw new Error("Workday OAuth token response did not include access_token");
+		}
+
+		const expiresInMs = (payload.expires_in ?? 3600) * 1000;
+		return {
+			accessToken: payload.access_token,
+			tokenType: payload.token_type ?? "Bearer",
+			expiresAt: Date.now() + expiresInMs,
+		};
+	}
+
+	async testConnection(accessToken?: string): Promise<{ success: boolean; error?: string }> {
+		try {
+			const response = await fetch(this.getPingUrl(), {
+				method: "GET",
+				headers: {
+					Accept: "application/json",
+					...(accessToken
+						? {
+							Authorization: `Bearer ${accessToken}`,
+						}
+						: {}),
+				},
+				signal: AbortSignal.timeout(this.timeoutMs),
+			});
+
+			if (!response.ok) {
+				return {
+					success: false,
+					error: `Workday API ping failed with status ${response.status}`,
+				};
+			}
+
+			return { success: true };
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : "Unknown error",
+			};
+		}
+	}
+
+	private getTokenUrl(): string {
+		return `${this.instanceUrl}/ccx/oauth2/${this.tenantId}/token`;
+	}
+
+	private getPingUrl(): string {
+		return `${this.instanceUrl}/ccx/api/v1/${this.tenantId}/workers?limit=1`;
+	}
+}

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/index.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/index.ts
@@ -1,0 +1,3 @@
+export { WorkdayApiClient } from "./api-client";
+export { WorkdayConnector, workdayConnector } from "./workday-connector";
+export * from "./types";

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/types.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Workday-specific types and configurations
+ */
+
+export type WorkdayEmployeeMatchStrategy = "employeeNumber" | "email";
+
+/**
+ * Workday API configuration
+ * Secrets are stored outside this config (Vault/settings).
+ */
+export interface WorkdayConfig {
+	instanceUrl: string;
+	tenantId: string;
+	employeeMatchStrategy: WorkdayEmployeeMatchStrategy;
+	includeZeroHours: boolean;
+	batchSize: number;
+	apiTimeoutMs: number;
+}
+
+export const DEFAULT_WORKDAY_CONFIG: WorkdayConfig = {
+	instanceUrl: "",
+	tenantId: "",
+	employeeMatchStrategy: "employeeNumber",
+	includeZeroHours: false,
+	batchSize: 100,
+	apiTimeoutMs: 30000,
+};
+
+export interface WorkdayOAuthCredentials {
+	clientId: string;
+	clientSecret: string;
+	scope?: string;
+}
+
+export interface WorkdayAuthToken {
+	accessToken: string;
+	tokenType: string;
+	expiresAt: number;
+}

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
@@ -196,6 +196,7 @@ describe("WorkdayConnector", () => {
 
 	it("returns stable sync threshold", () => {
 		const connector = new WorkdayConnector();
+		expect(connector.exporterId).toBe("workday_api");
 		expect(connector.getSyncThreshold()).toBe(500);
 	});
 });

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
@@ -1,0 +1,201 @@
+import { DateTime } from "luxon";
+import { describe, expect, it, vi } from "vitest";
+import type { AbsenceData, WorkPeriodData } from "../../types";
+import { WorkdayConnector } from "./workday-connector";
+import { DEFAULT_WORKDAY_CONFIG } from "./types";
+
+describe("WorkdayConnector", () => {
+	it("validates required config fields and ranges", async () => {
+		const connector = new WorkdayConnector();
+
+		await expect(
+			connector.validateConfig({
+				instanceUrl: "",
+				tenantId: "",
+				employeeMatchStrategy: "externalId",
+				batchSize: 0,
+				apiTimeoutMs: 999,
+			}),
+		).resolves.toEqual({
+			valid: false,
+			errors: [
+				"instanceUrl is required",
+				"tenantId is required",
+				"employeeMatchStrategy must be 'employeeNumber' or 'email'",
+				"batchSize must be between 1 and 500",
+				"apiTimeoutMs must be between 1000 and 120000",
+			],
+		});
+	});
+
+	it("returns validation errors for malformed config types", async () => {
+		const connector = new WorkdayConnector();
+
+		await expect(
+			connector.validateConfig({
+				instanceUrl: 123,
+				tenantId: true,
+				employeeMatchStrategy: ["employeeNumber"],
+				batchSize: "100",
+				apiTimeoutMs: null,
+			}),
+		).resolves.toEqual({
+			valid: false,
+			errors: [
+				"instanceUrl must be a string",
+				"tenantId must be a string",
+				"employeeMatchStrategy must be 'employeeNumber' or 'email'",
+				"batchSize must be a number",
+				"apiTimeoutMs must be a number",
+			],
+		});
+	});
+
+	it("tests connection with org-scoped credentials and oauth token", async () => {
+		const getCredentials = vi.fn().mockResolvedValue({
+			clientId: "client_123",
+			clientSecret: "secret_123",
+			scope: "system",
+		});
+		const getOAuthToken = vi.fn().mockResolvedValue({
+			accessToken: "token_123",
+			tokenType: "Bearer",
+			expiresAt: Date.now() + 3600_000,
+		});
+		const testConnection = vi.fn().mockResolvedValue({ success: true });
+		const connector = new WorkdayConnector({
+			getCredentials,
+			createApiClient: () => ({ getOAuthToken, testConnection }),
+		});
+
+		const response = await connector.testConnection("org_123", {
+			...DEFAULT_WORKDAY_CONFIG,
+			instanceUrl: "https://example.workday.com",
+			tenantId: "acme",
+		});
+
+		expect(response).toEqual({ success: true });
+		expect(getCredentials).toHaveBeenCalledWith("org_123");
+		expect(getOAuthToken).toHaveBeenCalledWith({
+			clientId: "client_123",
+			clientSecret: "secret_123",
+			scope: "system",
+		});
+		expect(testConnection).toHaveBeenCalledWith("token_123");
+		expect(testConnection).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns credential error when org-scoped secrets are missing", async () => {
+		const connector = new WorkdayConnector({
+			getCredentials: vi.fn().mockResolvedValue(null),
+		});
+
+		await expect(
+			connector.testConnection("org_123", {
+				...DEFAULT_WORKDAY_CONFIG,
+				instanceUrl: "https://example.workday.com",
+				tenantId: "acme",
+			}),
+		).resolves.toEqual({
+			success: false,
+			error:
+				"Workday credentials not configured. Please enter your Client ID and Client Secret.",
+		});
+	});
+
+	it("returns safe v1 export result when records are not pushed", async () => {
+		const testConnection = vi.fn().mockResolvedValue({ success: true });
+		const getOAuthToken = vi.fn().mockResolvedValue({
+			accessToken: "token_123",
+			tokenType: "Bearer",
+			expiresAt: Date.now() + 3600_000,
+		});
+		const connector = new WorkdayConnector({
+			getCredentials: vi.fn().mockResolvedValue({
+				clientId: "client_123",
+				clientSecret: "secret_123",
+			}),
+			createApiClient: () => ({ getOAuthToken, testConnection }),
+		});
+
+		const workPeriods: WorkPeriodData[] = [
+			{
+				id: "wp_1",
+				employeeId: "emp_1",
+				employeeNumber: "1001",
+				firstName: "Ada",
+				lastName: "Lovelace",
+				startTime: DateTime.fromISO("2026-01-10T08:00:00Z"),
+				endTime: DateTime.fromISO("2026-01-10T12:00:00Z"),
+				durationMinutes: 240,
+				workCategoryId: null,
+				workCategoryName: null,
+				workCategoryFactor: null,
+				projectId: null,
+				projectName: null,
+			},
+		];
+
+		const absences: AbsenceData[] = [
+			{
+				id: "abs_1",
+				employeeId: "emp_2",
+				employeeNumber: "1002",
+				firstName: "Grace",
+				lastName: "Hopper",
+				startDate: "2026-01-11",
+				endDate: "2026-01-11",
+				absenceCategoryId: "cat_1",
+				absenceCategoryName: "Vacation",
+				absenceType: "vacation",
+				status: "approved",
+			},
+		];
+
+		const result = await connector.export(
+			"org_123",
+			workPeriods,
+			absences,
+			[],
+			{
+				...DEFAULT_WORKDAY_CONFIG,
+				instanceUrl: "https://example.workday.com",
+				tenantId: "acme",
+			},
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.totalRecords).toBe(2);
+		expect(result.syncedRecords).toBe(0);
+		expect(result.failedRecords).toBe(2);
+		expect(result.skippedRecords).toBe(0);
+		expect(result.errors).toEqual([
+			{
+				recordId: "wp_1",
+				recordType: "attendance",
+				employeeId: "emp_1",
+				errorMessage: "Workday export placeholder is not implemented; record was not synced.",
+				isRetryable: false,
+			},
+			{
+				recordId: "abs_1",
+				recordType: "absence",
+				employeeId: "emp_2",
+				errorMessage: "Workday export placeholder is not implemented; record was not synced.",
+				isRetryable: false,
+			},
+		]);
+		expect(result.metadata.employeeCount).toBe(2);
+		expect(result.metadata.dateRange).toEqual({
+			start: "2026-01-10",
+			end: "2026-01-11",
+		});
+		expect(result.metadata.apiCallCount).toBe(0);
+		expect(testConnection).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns stable sync threshold", () => {
+		const connector = new WorkdayConnector();
+		expect(connector.getSyncThreshold()).toBe(500);
+	});
+});

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
@@ -27,7 +27,7 @@ interface WorkdayConnectorDeps {
 }
 
 export class WorkdayConnector implements IPayrollExporter {
-	readonly exporterId = "workday";
+	readonly exporterId = "workday_api";
 	readonly exporterName = "Workday";
 	readonly version = "1.0.0";
 

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
@@ -1,0 +1,298 @@
+import { DateTime } from "luxon";
+import type {
+	AbsenceData,
+	ApiExportResult,
+	IPayrollExporter,
+	WageTypeMapping,
+	WorkPeriodData,
+} from "../../types";
+import { WorkdayApiClient } from "./api-client";
+import {
+	DEFAULT_WORKDAY_CONFIG,
+	type WorkdayConfig,
+	type WorkdayOAuthCredentials,
+} from "./types";
+
+const SYNC_THRESHOLD = 500;
+const WORKDAY_VAULT_KEY_CLIENT_ID = "payroll/workday/client_id";
+const WORKDAY_VAULT_KEY_CLIENT_SECRET = "payroll/workday/client_secret";
+const WORKDAY_VAULT_KEY_SCOPE = "payroll/workday/scope";
+
+interface WorkdayConnectorDeps {
+	getCredentials?: (organizationId: string) => Promise<WorkdayOAuthCredentials | null>;
+	createApiClient?: (config: WorkdayConfig) => {
+		getOAuthToken: (credentials: WorkdayOAuthCredentials) => Promise<{ accessToken: string }>;
+		testConnection: (accessToken?: string) => Promise<{ success: boolean; error?: string }>;
+	};
+}
+
+export class WorkdayConnector implements IPayrollExporter {
+	readonly exporterId = "workday";
+	readonly exporterName = "Workday";
+	readonly version = "1.0.0";
+
+	private readonly createApiClient: NonNullable<WorkdayConnectorDeps["createApiClient"]>;
+	private readonly getCredentials: NonNullable<WorkdayConnectorDeps["getCredentials"]>;
+
+	constructor(deps: WorkdayConnectorDeps = {}) {
+		this.getCredentials = deps.getCredentials ?? this.getCredentialsFromVault;
+		this.createApiClient =
+			deps.createApiClient ??
+			((config) =>
+				new WorkdayApiClient({
+					instanceUrl: config.instanceUrl,
+					tenantId: config.tenantId,
+					timeoutMs: config.apiTimeoutMs,
+				}));
+	}
+
+	getSyncThreshold(): number {
+		return SYNC_THRESHOLD;
+	}
+
+	async validateConfig(config: Record<string, unknown>): Promise<{
+		valid: boolean;
+		errors?: string[];
+	}> {
+		const { errors } = this.parseConfig(config);
+
+		return {
+			valid: errors.length === 0,
+			errors: errors.length > 0 ? errors : undefined,
+		};
+	}
+
+	async testConnection(
+		organizationId: string,
+		config: Record<string, unknown>,
+	): Promise<{
+		success: boolean;
+		error?: string;
+	}> {
+		const { config: workdayConfig, errors } = this.parseConfig(config);
+		if (errors.length > 0 || !workdayConfig) {
+			return {
+				success: false,
+				error: errors.join(", ") || "Invalid Workday configuration",
+			};
+		}
+
+		try {
+			const credentials = await this.getCredentials(organizationId);
+			if (!credentials) {
+				return {
+					success: false,
+					error:
+						"Workday credentials not configured. Please enter your Client ID and Client Secret.",
+				};
+			}
+
+			const client = this.createApiClient(workdayConfig);
+			const token = await client.getOAuthToken(credentials);
+			return await client.testConnection(token.accessToken);
+		} catch (error) {
+			return {
+				success: false,
+				error: error instanceof Error ? error.message : "Unknown error",
+			};
+		}
+	}
+
+	async export(
+		organizationId: string,
+		workPeriods: WorkPeriodData[],
+		absences: AbsenceData[],
+		_mappings: WageTypeMapping[],
+		config: Record<string, unknown>,
+	): Promise<ApiExportResult> {
+		const startedAt = Date.now();
+		const connectionResult = await this.testConnection(organizationId, config);
+
+		if (!connectionResult.success) {
+			throw new Error(connectionResult.error ?? "Workday connection test failed");
+		}
+
+		const dateRange = this.getDateRange(workPeriods, absences);
+		const employeeCount = new Set([
+			...workPeriods.map((period) => period.employeeId),
+			...absences.map((absence) => absence.employeeId),
+		]).size;
+		const totalRecords = workPeriods.length + absences.length;
+		const errorMessage =
+			"Workday export placeholder is not implemented; record was not synced.";
+		const errors: ApiExportResult["errors"] = [
+			...workPeriods.map((period) => ({
+				recordId: period.id,
+				recordType: "attendance" as const,
+				employeeId: period.employeeId,
+				errorMessage,
+				isRetryable: false,
+			})),
+			...absences.map((absence) => ({
+				recordId: absence.id,
+				recordType: "absence" as const,
+				employeeId: absence.employeeId,
+				errorMessage,
+				isRetryable: false,
+			})),
+		];
+
+		return {
+			success: false,
+			totalRecords,
+			syncedRecords: 0,
+			failedRecords: totalRecords,
+			skippedRecords: 0,
+			errors,
+			metadata: {
+				employeeCount,
+				dateRange,
+				apiCallCount: 0,
+				durationMs: Date.now() - startedAt,
+			},
+		};
+	}
+
+	private parseConfig(rawConfig: Record<string, unknown>): {
+		config?: WorkdayConfig;
+		errors: string[];
+	} {
+		const config = { ...DEFAULT_WORKDAY_CONFIG };
+		const errors: string[] = [];
+
+		const instanceUrl = rawConfig.instanceUrl;
+		if (instanceUrl === undefined) {
+			errors.push("instanceUrl is required");
+		} else if (typeof instanceUrl !== "string") {
+			errors.push("instanceUrl must be a string");
+		} else if (!instanceUrl.trim()) {
+			errors.push("instanceUrl is required");
+		} else {
+			config.instanceUrl = instanceUrl;
+		}
+
+		const tenantId = rawConfig.tenantId;
+		if (tenantId === undefined) {
+			errors.push("tenantId is required");
+		} else if (typeof tenantId !== "string") {
+			errors.push("tenantId must be a string");
+		} else if (!tenantId.trim()) {
+			errors.push("tenantId is required");
+		} else {
+			config.tenantId = tenantId;
+		}
+
+		const employeeMatchStrategy = rawConfig.employeeMatchStrategy;
+		if (employeeMatchStrategy !== undefined) {
+			if (typeof employeeMatchStrategy !== "string") {
+				errors.push("employeeMatchStrategy must be 'employeeNumber' or 'email'");
+			} else if (!this.isValidEmployeeMatchStrategy(employeeMatchStrategy)) {
+				errors.push("employeeMatchStrategy must be 'employeeNumber' or 'email'");
+			} else {
+				config.employeeMatchStrategy = employeeMatchStrategy;
+			}
+		}
+
+		const includeZeroHours = rawConfig.includeZeroHours;
+		if (includeZeroHours !== undefined) {
+			if (typeof includeZeroHours !== "boolean") {
+				errors.push("includeZeroHours must be a boolean");
+			} else {
+				config.includeZeroHours = includeZeroHours;
+			}
+		}
+
+		const batchSize = rawConfig.batchSize;
+		if (batchSize !== undefined) {
+			if (typeof batchSize !== "number" || !Number.isFinite(batchSize)) {
+				errors.push("batchSize must be a number");
+			} else if (batchSize < 1 || batchSize > 500) {
+				errors.push("batchSize must be between 1 and 500");
+			} else {
+				config.batchSize = batchSize;
+			}
+		}
+
+		const apiTimeoutMs = rawConfig.apiTimeoutMs;
+		if (apiTimeoutMs !== undefined) {
+			if (typeof apiTimeoutMs !== "number" || !Number.isFinite(apiTimeoutMs)) {
+				errors.push("apiTimeoutMs must be a number");
+			} else if (apiTimeoutMs < 1000 || apiTimeoutMs > 120000) {
+				errors.push("apiTimeoutMs must be between 1000 and 120000");
+			} else {
+				config.apiTimeoutMs = apiTimeoutMs;
+			}
+		}
+
+		return {
+			config: errors.length === 0 ? config : undefined,
+			errors,
+		};
+	}
+
+	private async getCredentialsFromVault(
+		organizationId: string,
+	): Promise<WorkdayOAuthCredentials | null> {
+		const { getOrgSecret } = await import("@/lib/vault/secrets");
+		const [clientId, clientSecret, scope] = await Promise.all([
+			getOrgSecret(organizationId, WORKDAY_VAULT_KEY_CLIENT_ID),
+			getOrgSecret(organizationId, WORKDAY_VAULT_KEY_CLIENT_SECRET),
+			getOrgSecret(organizationId, WORKDAY_VAULT_KEY_SCOPE),
+		]);
+
+		if (!clientId || !clientSecret) {
+			return null;
+		}
+
+		return {
+			clientId,
+			clientSecret,
+			scope: scope || undefined,
+		};
+	}
+
+	private isValidEmployeeMatchStrategy(
+		strategy: string,
+	): strategy is WorkdayConfig["employeeMatchStrategy"] {
+		return strategy === "employeeNumber" || strategy === "email";
+	}
+
+	private getDateRange(
+		workPeriods: WorkPeriodData[],
+		absences: AbsenceData[],
+	): { start: string; end: string } {
+		let start: DateTime | null = null;
+		let end: DateTime | null = null;
+
+		for (const period of workPeriods) {
+			if (!start || period.startTime < start) {
+				start = period.startTime;
+			}
+
+			const periodEnd = period.endTime ?? period.startTime;
+			if (!end || periodEnd > end) {
+				end = periodEnd;
+			}
+		}
+
+		for (const absence of absences) {
+			const absenceStart = DateTime.fromISO(absence.startDate);
+			const absenceEnd = DateTime.fromISO(absence.endDate);
+
+			if (!start || absenceStart < start) {
+				start = absenceStart;
+			}
+
+			if (!end || absenceEnd > end) {
+				end = absenceEnd;
+			}
+		}
+
+		return {
+			start: start?.toISODate() ?? "",
+			end: end?.toISODate() ?? "",
+		};
+	}
+}
+
+export const workdayConnector = new WorkdayConnector();

--- a/apps/webapp/src/lib/payroll-export/index.ts
+++ b/apps/webapp/src/lib/payroll-export/index.ts
@@ -59,3 +59,7 @@ export type {
 	SuccessFactorsConfig,
 	SuccessFactorsCredentials,
 } from "./exporters/successfactors";
+
+// Workday API connector
+export { WorkdayConnector, workdayConnector } from "./exporters/workday";
+export type { WorkdayConfig } from "./exporters/workday";

--- a/apps/webapp/src/lib/payroll-export/index.ts
+++ b/apps/webapp/src/lib/payroll-export/index.ts
@@ -5,6 +5,8 @@
 
 // Types
 export * from "./types";
+export * from "./connectors/types";
+export * from "./connectors/registry";
 
 // Data fetcher functions
 export {

--- a/apps/webapp/src/lib/payroll-export/types.ts
+++ b/apps/webapp/src/lib/payroll-export/types.ts
@@ -83,6 +83,13 @@ export type {
 } from "./exporters/successfactors/types";
 export { DEFAULT_SUCCESSFACTORS_CONFIG } from "./exporters/successfactors/types";
 
+// Workday types - re-exported from exporter module
+export type {
+	WorkdayConfig,
+	WorkdayEmployeeMatchStrategy,
+} from "./exporters/workday/types";
+export { DEFAULT_WORKDAY_CONFIG } from "./exporters/workday/types";
+
 // ============================================
 // WAGE TYPE MAPPING TYPES
 // ============================================

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "node",
-		include: ["src/**/*.test.ts"],
+		include: ["src/**/*.test.{ts,tsx}"],
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
 			"@/db": path.resolve(__dirname, "./src/db"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,13 +291,13 @@ importers:
         version: 3.995.0
       '@better-auth/passkey':
         specifier: 1.4.18
-        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)
+        version: 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)
       '@better-auth/scim':
         specifier: ^1.4.18
-        version: 1.4.18(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 1.4.18(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@better-auth/sso':
         specifier: 1.4.18
-        version: 1.4.18(@better-auth/utils@0.3.0)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 1.4.18(@better-auth/utils@0.3.0)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@bprogress/core':
         specifier: ^1.3.4
         version: 1.3.4
@@ -528,7 +528,7 @@ importers:
         version: 2.0.8(@upstash/redis@1.36.2)
       better-auth:
         specifier: ^1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       botbuilder:
         specifier: ^4.23.3
         version: 4.23.3
@@ -701,6 +701,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.2.0
         version: 4.2.0
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/canvas-confetti':
         specifier: ^1.9.0
         version: 1.9.0
@@ -730,7 +733,7 @@ importers:
         version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       axios:
         specifier: ^1.13.5
         version: 1.13.5
@@ -743,6 +746,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0(@noble/hashes@2.0.1)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -757,7 +763,7 @@ importers:
         version: 7.2.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -769,6 +775,9 @@ packages:
       graphql:
         optional: true
 
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -776,6 +785,16 @@ packages:
   '@antfu/ni@25.0.0':
     resolution: {integrity: sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==}
     hasBin: true
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@authenio/xml-encryption@2.0.2':
     resolution: {integrity: sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg==}
@@ -1621,6 +1640,10 @@ packages:
   '@bprogress/core@1.3.4':
     resolution: {integrity: sha512-q/AqpurI/1uJzOrQROuZWixn/+ARekh+uvJGwLCP6HQ/EqAX4SkvNf618tSBxL4NysC0MwqAppb/mRw6Tzi61w==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@casl/ability@6.8.0':
     resolution: {integrity: sha512-Ipt4mzI4gSgnomFdaPjaLgY2MWuXqAEZLrU6qqWBB7khGiBBuuEp6ytYDnq09bRXqcjaeeHiaCvCGFbBA2SpvA==}
 
@@ -1629,6 +1652,37 @@ packages:
 
   '@clack/prompts@1.0.1':
     resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28':
+    resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -2324,6 +2378,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@expo/cli@54.0.23':
     resolution: {integrity: sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g==}
@@ -5481,6 +5544,25 @@ packages:
   '@tauri-apps/plugin-store@2.4.2':
     resolution: {integrity: sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -5526,6 +5608,9 @@ packages:
   '@tus/utils@0.6.0':
     resolution: {integrity: sha512-GpMpAQfVdC4UDhpsZrRPjGpdXg+JW5MquqMqtObUVsORwLBV6XI67iTT5be+z98THdqb6dl3bTLIElIdgPeo2g==}
     engines: {node: '>=20.19.0'}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/aws-lambda@8.10.160':
     resolution: {integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==}
@@ -6007,6 +6092,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -6758,10 +6846,18 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssstyle@6.1.0:
+    resolution: {integrity: sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==}
+    engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -6824,6 +6920,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-bengali-revised@2.0.2:
     resolution: {integrity: sha512-q9iDru4+TSA9k4zfm0CFHJj6nBsxP7AYgWC/qodK/i7oOIlj5K2z5IcQDtESfs/Qwqt/xJYaP86tkazd/vRptg==}
@@ -6988,6 +7088,9 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -8027,6 +8130,10 @@ packages:
   hsl-to-rgb-for-reals@1.1.1:
     resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -8251,6 +8358,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -8410,6 +8520,15 @@ packages:
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -8719,6 +8838,10 @@ packages:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -8803,6 +8926,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   media-engine@1.0.3:
     resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
@@ -9490,6 +9616,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -9703,6 +9832,10 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -9866,6 +9999,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -10249,6 +10385,10 @@ packages:
   saxes@5.0.1:
     resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
     engines: {node: '>=10'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.25.0-rc-603e6108-20241029:
     resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
@@ -10650,6 +10790,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -10775,6 +10918,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   traverse@0.3.9:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
@@ -10909,6 +11056,10 @@ packages:
   undici@6.23.0:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -11164,6 +11315,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -11195,12 +11350,24 @@ packages:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
 
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -11301,6 +11468,10 @@ packages:
 
   xml-escape@1.1.0:
     resolution: {integrity: sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
 
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
@@ -11430,6 +11601,8 @@ snapshots:
     optionalDependencies:
       graphql: 16.12.0
 
+  '@acemir/cssom@0.9.31': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@antfu/ni@25.0.0':
@@ -11438,6 +11611,24 @@ snapshots:
       fzf: 0.5.2
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -12671,30 +12862,30 @@ snapshots:
       nanostores: 1.1.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)':
+  '@better-auth/passkey@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(better-call@1.1.8(zod@4.3.6))(nanostores@1.1.0)':
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.2
-      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.1.8(zod@4.3.6)
       nanostores: 1.1.0
       zod: 4.3.6
 
-  '@better-auth/scim@1.4.18(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@better-auth/scim@1.4.18(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@better-auth/utils': 0.3.0
-      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-call: 1.1.8(zod@4.3.6)
       zod: 4.3.6
 
-  '@better-auth/sso@1.4.18(@better-auth/utils@0.3.0)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@better-auth/sso@1.4.18(@better-auth/utils@0.3.0)(better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       fast-xml-parser: 5.3.7
       jose: 6.1.3
       samlify: 2.10.2
@@ -12749,6 +12940,10 @@ snapshots:
 
   '@bprogress/core@1.3.4': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.1.0
+
   '@casl/ability@6.8.0':
     dependencies:
       '@ucast/mongo2js': 1.4.1
@@ -12763,6 +12958,28 @@ snapshots:
       '@clack/core': 1.0.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -13214,6 +13431,10 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.3': {}
+
+  '@exodus/bytes@1.14.1(@noble/hashes@2.0.1)':
+    optionalDependencies:
+      '@noble/hashes': 2.0.1
 
   '@expo/cli@54.0.23(expo-router@6.0.23)(expo@54.0.33)(graphql@16.12.0)(react-native@0.84.0(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))':
     dependencies:
@@ -16945,6 +17166,27 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -17011,6 +17253,8 @@ snapshots:
       - supports-color
 
   '@tus/utils@0.6.0': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/aws-lambda@8.10.160': {}
 
@@ -17375,7 +17619,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -17387,7 +17631,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -17556,6 +17800,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   asap@2.0.6: {}
 
@@ -17822,7 +18070,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.2)(kysely@0.28.11)(pg@8.18.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -17843,7 +18091,7 @@ snapshots:
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   better-call@1.1.8(zod@4.3.6):
     dependencies:
@@ -18394,7 +18642,19 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  cssstyle@6.1.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.28
+      css-tree: 3.1.0
+      lru-cache: 11.2.6
 
   csstype@3.2.3: {}
 
@@ -18445,6 +18705,13 @@ snapshots:
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  data-urls@7.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-bengali-revised@2.0.2: {}
 
@@ -18560,6 +18827,8 @@ snapshots:
   diff@8.0.3: {}
 
   dijkstrajs@1.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -19761,6 +20030,12 @@ snapshots:
 
   hsl-to-rgb-for-reals@1.1.1: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.14.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
@@ -19969,6 +20244,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -20144,6 +20421,33 @@ snapshots:
   jsbn@0.1.1: {}
 
   jsc-safe-url@0.2.4: {}
+
+  jsdom@28.1.0(@noble/hashes@2.0.1):
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1(@noble/hashes@2.0.1)
+      cssstyle: 6.1.0
+      data-urls: 7.0.0(@noble/hashes@2.0.1)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.0.1)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsesc@3.1.0: {}
 
@@ -20405,6 +20709,8 @@ snapshots:
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -20597,6 +20903,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.12.2: {}
 
   media-engine@1.0.3: {}
 
@@ -21565,6 +21873,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -21786,6 +22098,12 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -21999,6 +22317,8 @@ snapshots:
       react: 19.2.4
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -22504,6 +22824,10 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.27.0: {}
@@ -22999,6 +23323,8 @@ snapshots:
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  symbol-tree@3.2.4: {}
+
   tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -23141,6 +23467,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   traverse@0.3.9: {}
 
   trim-lines@3.0.1: {}
@@ -23254,6 +23584,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@6.23.0: {}
+
+  undici@7.22.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -23475,7 +23807,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -23500,6 +23832,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
+      jsdom: 28.1.0(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - jiti
       - less
@@ -23514,6 +23847,10 @@ snapshots:
       - yaml
 
   vlq@1.0.1: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walker@1.0.8:
     dependencies:
@@ -23545,13 +23882,25 @@ snapshots:
 
   webidl-conversions@5.0.0: {}
 
+  webidl-conversions@8.0.1: {}
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@5.0.0: {}
 
   whatwg-url-without-unicode@8.0.0-3:
     dependencies:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
+
+  whatwg-url@16.0.1(@noble/hashes@2.0.1):
+    dependencies:
+      '@exodus/bytes': 1.14.1(@noble/hashes@2.0.1)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -23631,6 +23980,8 @@ snapshots:
       xpath: 0.0.33
 
   xml-escape@1.1.0: {}
+
+  xml-name-validator@5.0.0: {}
 
   xml2js@0.6.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add a connector registry abstraction for API-based payroll exports and adapt Personio + SAP SuccessFactors integrations to it
- add Workday API support end-to-end (connector, org-scoped server actions, settings tab/form, export target selection, and docs)
- remove DATEV-only export gating so Workday-only orgs can run exports; align Workday format id across UI/action/service paths

## Test Plan
- [x] `pnpm --filter webapp exec vitest run src/lib/payroll-export/exporters/workday/workday-connector.test.ts src/lib/payroll-export/exporters/workday/api-client.test.ts`
- [x] `pnpm --filter webapp exec vitest run src/components/settings/payroll-export/workday-config-form.test.tsx`
- [x] `pnpm --filter webapp exec vitest run src/components/settings/payroll-export/export-form.test.tsx \"src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts\"`
- [x] `pnpm --filter webapp exec vitest run \"src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts\"`
- [ ] `pnpm --filter webapp test -- src/lib/payroll-export src/components/settings/payroll-export \"src/app/[locale]/(app)/settings/payroll-export\"` *(fails due pre-existing unrelated env/notification/authorization suites in branch baseline)*