### PR TITLE
fix(build): unblock webapp build and reduce build-time Redis noise

### DIFF
--- a/apps/desktop/src/components/IdleDialog.tsx
+++ b/apps/desktop/src/components/IdleDialog.tsx
@@ -1,4 +1,4 @@
-import { Coffee, Briefcase, X } from "lucide-react";
+import { Coffee, Briefcase } from "lucide-react";
 import { formatIdleDuration, cn } from "../lib/utils";
 import type { IdleEvent } from "../types";
 

--- a/apps/desktop/src/hooks/useOrganizations.ts
+++ b/apps/desktop/src/hooks/useOrganizations.ts
@@ -68,14 +68,13 @@ export function useOrganizations() {
     staleTime: 30000,
   });
 
-  const switchMutation = useMutation({
+  const switchMutation = useMutation<void, Error, string>({
     mutationFn: async (organizationId: string) => {
       const session = await invoke<SessionResponse>("get_session");
       if (!session.token || !settings?.webappUrl) {
         throw new Error("Not authenticated");
       }
       await switchOrganization(settings.webappUrl, session.token, organizationId);
-      return organizationId;
     },
     onSuccess: async () => {
       // Force immediate refetch to get updated activeOrganizationId

--- a/apps/desktop/src/hooks/useSettings.ts
+++ b/apps/desktop/src/hooks/useSettings.ts
@@ -25,9 +25,9 @@ export function useSettings() {
     };
   }, []);
 
-  const saveMutation = useMutation({
+  const saveMutation = useMutation<void, Error, Omit<Settings, "version">>({
     mutationFn: (settings: Omit<Settings, "version">) =>
-      invoke("save_settings", settings),
+      invoke<void>("save_settings", settings),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["settings"] });
     },

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -26,12 +26,12 @@ export const storage = {
   // Settings
   async getSettings(): Promise<ExtensionSettings> {
     try {
-      const result = await chrome.storage.sync.get([
+      const result = (await chrome.storage.sync.get([
         "webappUrl",
         "notificationsEnabled",
         "notifyOnClockIn",
         "notifyOnClockOut",
-      ]);
+      ])) as Partial<ExtensionSettings>;
       return {
         webappUrl: result.webappUrl || DEFAULT_SETTINGS.webappUrl,
         notificationsEnabled: result.notificationsEnabled ?? DEFAULT_SETTINGS.notificationsEnabled,
@@ -72,7 +72,9 @@ export const storage = {
   // Offline Queue
   async getQueuedActions(): Promise<QueuedAction[]> {
     try {
-      const result = await chrome.storage.local.get(["actionQueue"]);
+      const result = (await chrome.storage.local.get(["actionQueue"])) as {
+        actionQueue?: QueuedAction[];
+      };
       return result.actionQueue || [];
     } catch {
       return [];
@@ -104,7 +106,9 @@ export const storage = {
   // Optimistic state for offline mode
   async getOptimisticState(): Promise<{ isClockedIn: boolean; startTime: string | null } | null> {
     try {
-      const result = await chrome.storage.local.get(["optimisticState"]);
+      const result = (await chrome.storage.local.get(["optimisticState"])) as {
+        optimisticState?: { isClockedIn: boolean; startTime: string | null } | null;
+      };
       return result.optimisticState || null;
     } catch {
       return null;

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
@@ -973,7 +973,7 @@ export async function deleteSuccessFactorsCredentialsAction(
 // WORKDAY CONFIGURATION TYPES
 // ============================================
 
-export const WORKDAY_FORMAT_ID = "workday_api";
+const WORKDAY_FORMAT_ID = "workday_api";
 
 const WORKDAY_VAULT_KEY_CLIENT_ID = "payroll/workday/client_id";
 const WORKDAY_VAULT_KEY_CLIENT_SECRET = "payroll/workday/client_secret";

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts
@@ -153,13 +153,14 @@ vi.mock("@/lib/effect/result", async () => {
 });
 
 const {
-	WORKDAY_FORMAT_ID,
 	deleteWorkdayCredentialsAction,
 	getWorkdayConfigAction,
 	saveWorkdayConfigAction,
 	saveWorkdayCredentialsAction,
 	testWorkdayConnectionAction,
 } = await import("./actions");
+
+const WORKDAY_FORMAT_ID = "workday_api";
 
 describe("payroll export workday actions", () => {
 	beforeEach(() => {

--- a/apps/webapp/src/lib/queue/index.ts
+++ b/apps/webapp/src/lib/queue/index.ts
@@ -319,6 +319,3 @@ export async function isQueueHealthy(): Promise<boolean> {
 		return false;
 	}
 }
-
-// Export the queue for direct access if needed
-export const jobQueue = getJobQueue();

--- a/docs/plans/2026-03-01-platform-vs-org-admin-routing-implementation-plan.md
+++ b/docs/plans/2026-03-01-platform-vs-org-admin-routing-implementation-plan.md
@@ -1,0 +1,394 @@
+# Platform vs Org Admin Routing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rename ambiguous admin paths into explicit scope-based namespaces by moving platform UI to `/platform-admin`, moving org-admin APIs to `/api/org-admin`, and using `/api/platform-admin` for platform-level APIs.
+
+**Architecture:** Apply a hard cutover with no compatibility redirects. Keep authorization behavior the same, but align route/API taxonomy to permission boundaries (`platform-admin` vs `org-admin`) so responsibilities are self-documenting. Enforce scope with tests and a guardrail that blocks reintroducing legacy `/admin` and `/api/admin` literals.
+
+**Tech Stack:** Next.js App Router, TypeScript, Effect services, Tolgee i18n, Vitest, pnpm/turbo.
+
+---
+
+### Task 1: Add route-namespace tests before changes
+
+**Files:**
+- Create: `apps/webapp/src/tolgee/__tests__/shared-route-namespaces.test.ts`
+- Modify: `apps/webapp/src/tolgee/shared.ts`
+- Test: `apps/webapp/src/tolgee/__tests__/shared-route-namespaces.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { getNamespacesForRoute } from "@/tolgee/shared";
+
+describe("route namespaces", () => {
+  it("loads admin namespaces for /platform-admin", () => {
+    expect(getNamespacesForRoute("/platform-admin")).toEqual(["common", "admin"]);
+  });
+
+  it("loads admin+settings namespaces for /platform-admin/worker-queue", () => {
+    expect(getNamespacesForRoute("/platform-admin/worker-queue")).toEqual([
+      "common",
+      "admin",
+      "settings",
+    ]);
+  });
+
+  it("does not special-case legacy /admin", () => {
+    expect(getNamespacesForRoute("/admin")).toEqual(["common"]);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/tolgee/__tests__/shared-route-namespaces.test.ts`
+Expected: FAIL because `shared.ts` still maps `/admin` and not `/platform-admin`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// in ROUTE_NAMESPACES
+"/platform-admin": ["common", "admin"],
+"/platform-admin/worker-queue": ["common", "admin", "settings"],
+// remove legacy /admin mappings
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/tolgee/__tests__/shared-route-namespaces.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/tolgee/shared.ts apps/webapp/src/tolgee/__tests__/shared-route-namespaces.test.ts
+git commit -m "test(i18n): lock platform admin route namespace mapping"
+```
+
+### Task 2: Move platform UI links/routes to `/platform-admin`
+
+**Files:**
+- Modify: `apps/webapp/src/app/[locale]/(admin)/layout.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/page.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/billing/page.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/users/page.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/users/actions.ts`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/organizations/page.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/organizations/actions.ts`
+- Modify: `apps/webapp/src/app/[locale]/(admin)/admin/settings/page.tsx`
+
+**Step 1: Write the failing test**
+
+Create a literal-path guard test that fails if platform UI still contains `/admin` links.
+
+```ts
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("platform admin route literals", () => {
+  it("uses /platform-admin in platform layout", () => {
+    const source = readFileSync(
+      "src/app/[locale]/(admin)/layout.tsx",
+      "utf8",
+    );
+    expect(source.includes('"/admin')).toBe(false);
+    expect(source.includes('"/platform-admin')).toBe(true);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/app/[locale]/(admin)/__tests__/platform-admin-paths.test.ts`
+Expected: FAIL because layout still points to `/admin`.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// example replacements
+href: "/platform-admin"
+href: "/platform-admin/users"
+redirect("/platform-admin")
+revalidatePath("/platform-admin/users")
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/app/[locale]/(admin)/__tests__/platform-admin-paths.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/app/[locale]/(admin)/layout.tsx apps/webapp/src/app/[locale]/(admin)/admin
+git commit -m "refactor(platform-admin): move UI route links to /platform-admin"
+```
+
+### Task 3: Rename org-admin APIs from `/api/admin` to `/api/org-admin`
+
+**Files:**
+- Move: `apps/webapp/src/app/api/admin/billing/route.ts` -> `apps/webapp/src/app/api/org-admin/billing/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holiday-categories/route.ts` -> `apps/webapp/src/app/api/org-admin/holiday-categories/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holiday-categories/[id]/route.ts` -> `apps/webapp/src/app/api/org-admin/holiday-categories/[id]/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holidays/route.ts` -> `apps/webapp/src/app/api/org-admin/holidays/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holidays/[id]/route.ts` -> `apps/webapp/src/app/api/org-admin/holidays/[id]/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holidays/import/route.ts` -> `apps/webapp/src/app/api/org-admin/holidays/import/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holidays/preview/route.ts` -> `apps/webapp/src/app/api/org-admin/holidays/preview/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holiday-presets/route.ts` -> `apps/webapp/src/app/api/org-admin/holiday-presets/route.ts`
+- Move: `apps/webapp/src/app/api/admin/holiday-presets/[id]/route.ts` -> `apps/webapp/src/app/api/org-admin/holiday-presets/[id]/route.ts`
+
+**Step 1: Write the failing test**
+
+Add a guard test for route-path literals in org settings callers.
+
+```ts
+expect(source.includes("/api/admin/")).toBe(false);
+expect(source.includes("/api/org-admin/")).toBe(true);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/components/settings/__tests__/org-admin-endpoints.test.ts`
+Expected: FAIL because current callers still use `/api/admin/...`.
+
+**Step 3: Write minimal implementation**
+
+Move the route directories and keep route handler logic unchanged.
+
+```ts
+// before: src/app/api/admin/.../route.ts
+// after:  src/app/api/org-admin/.../route.ts
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/components/settings/__tests__/org-admin-endpoints.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/app/api/org-admin apps/webapp/src/app/api/admin
+git commit -m "refactor(org-admin): move org settings APIs to /api/org-admin"
+```
+
+### Task 4: Update org settings API callers to `/api/org-admin`
+
+**Files:**
+- Modify: `apps/webapp/src/components/settings/holiday-dialog.tsx`
+- Modify: `apps/webapp/src/components/settings/holiday-import-dialog.tsx`
+- Modify: `apps/webapp/src/components/settings/category-dialog.tsx`
+- Modify: any additional callers found via grep for `"/api/admin/"`
+
+**Step 1: Write the failing test**
+
+Create a file-scan test over settings components to forbid `/api/admin/` literals.
+
+```ts
+const forbidden = "/api/admin/";
+expect(source.includes(forbidden)).toBe(false);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/components/settings/__tests__/forbid-legacy-admin-api-literals.test.ts`
+Expected: FAIL with matches in holiday/category components.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// examples
+fetch("/api/org-admin/holidays")
+fetch(`/api/org-admin/holidays/${id}`)
+fetch(`/api/org-admin/holidays/preview?${params}`)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/components/settings/__tests__/forbid-legacy-admin-api-literals.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/components/settings
+git commit -m "refactor(settings): use /api/org-admin endpoints"
+```
+
+### Task 5: Establish `/api/platform-admin` namespace
+
+**Files:**
+- Create/Move as needed under: `apps/webapp/src/app/api/platform-admin/*`
+- Modify callers in platform-admin pages/actions if any API fetches exist
+- Test: `apps/webapp/src/lib/__tests__/admin-scope-paths.test.ts`
+
+**Step 1: Write the failing test**
+
+Add assertions that platform-admin API calls (if present) use `/api/platform-admin/` and not `/api/admin/`.
+
+```ts
+expect(source.includes("/api/platform-admin/")).toBe(true);
+expect(source.includes("/api/admin/")).toBe(false);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/admin-scope-paths.test.ts`
+Expected: FAIL if any platform API caller still uses legacy namespace.
+
+**Step 3: Write minimal implementation**
+
+Create/relocate platform API handlers and update callers.
+
+```ts
+// canonical platform API root
+const PLATFORM_ADMIN_API_ROOT = "/api/platform-admin";
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/admin-scope-paths.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/app/api/platform-admin apps/webapp/src/lib apps/webapp/src/app/[locale]/(admin)
+git commit -m "refactor(platform-admin): adopt /api/platform-admin namespace"
+```
+
+### Task 6: Update platform-admin wording and docs
+
+**Files:**
+- Modify: `apps/webapp/messages/admin/en.json`
+- Modify: `apps/webapp/messages/admin/de.json`
+- Modify: `apps/webapp/messages/admin/es.json`
+- Modify: `apps/webapp/messages/admin/fr.json`
+- Modify: `apps/webapp/messages/admin/it.json`
+- Modify: `apps/webapp/messages/admin/pt.json`
+- Modify: `apps/docs/content/docs/guide/admin-guide/platform-admin.mdx`
+
+**Step 1: Write the failing test**
+
+Add a docs/content assertion for platform entrypoint text.
+
+```ts
+expect(doc.includes("Navigate to `/platform-admin`")).toBe(true);
+expect(doc.includes("Navigate to `/admin`")).toBe(false);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/platform-admin-wording.test.ts`
+Expected: FAIL until wording and route text are updated.
+
+**Step 3: Write minimal implementation**
+
+Update copy from generic admin labels to platform-specific wording where scope is platform-level.
+
+```json
+{
+  "admin": {
+    "layout": {
+      "title": "Platform Admin Console"
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/platform-admin-wording.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/messages/admin apps/docs/content/docs/guide/admin-guide/platform-admin.mdx
+git commit -m "docs(i18n): rename platform scope wording and access path"
+```
+
+### Task 7: Add hard-cutover guardrail against legacy paths
+
+**Files:**
+- Create: `apps/webapp/src/lib/__tests__/legacy-admin-path-guard.test.ts`
+
+**Step 1: Write the failing test**
+
+Create a test that scans app code for forbidden literals:
+
+```ts
+const forbidden = ["/admin", "/api/admin/"];
+// allowlist only comments/test fixtures if needed
+expect(matches).toEqual([]);
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/legacy-admin-path-guard.test.ts`
+Expected: FAIL while legacy literals still exist.
+
+**Step 3: Write minimal implementation**
+
+Finish remaining path updates until guard test is green.
+
+```ts
+// maintain a tiny allowlist for non-runtime docs or migration notes if necessary
+const ALLOWLIST: string[] = [];
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/lib/__tests__/legacy-admin-path-guard.test.ts`
+Expected: PASS with zero runtime path matches.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/lib/__tests__/legacy-admin-path-guard.test.ts apps/webapp/src
+git commit -m "test(routing): block reintroduction of legacy admin paths"
+```
+
+### Task 8: Full verification and final cleanup
+
+**Files:**
+- Modify: any touched files required by lint/test fixes
+
+**Step 1: Write the failing test**
+
+No new test. Use full suite verification as acceptance gate.
+
+**Step 2: Run test to verify failures (if any)**
+
+Run: `pnpm --filter webapp test`
+Expected: PASS. If FAIL, capture failing specs and fix minimally.
+
+**Step 3: Write minimal implementation**
+
+Apply only targeted fixes for failing tests or type errors.
+
+```ts
+// minimal fix only; no opportunistic refactors
+```
+
+**Step 4: Run final verification**
+
+Run: `pnpm --filter webapp test && pnpm --filter webapp build`
+Expected: PASS for both commands.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp apps/docs
+git commit -m "refactor(routing): split platform-admin and org-admin namespaces"
+```
+
+## Post-Implementation Checks
+
+- Manually verify platform-admin navigation resolves only under `/platform-admin`.
+- Manually verify org settings pages perform successful requests against `/api/org-admin/*`.
+- Confirm runtime logs show no requests to `/admin` or `/api/admin` after deployment.
+- Update release notes: hard cutover with no legacy aliases.

--- a/docs/plans/2026-03-01-workday-export-implementation.md
+++ b/docs/plans/2026-03-01-workday-export-implementation.md
@@ -1,0 +1,459 @@
+# Workday Payroll Export Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Workday API export (attendance + absences) to Payroll Export with org-configurable employee matching (`employeeNumber` or `email`), alongside existing export options.
+
+**Architecture:** Introduce an API connector abstraction for payroll exporters, adapt Personio and SAP SuccessFactors API to that contract, and implement Workday as a new connector. Keep file-based formatters on the existing path. Update settings actions/UI to configure and test Workday, and update export flow to select target format instead of hardcoded DATEV.
+
+**Tech Stack:** TypeScript, Next.js App Router, Effect runtime, Drizzle ORM, Vitest, React + @tanstack/react-form, Luxon, pnpm.
+
+---
+
+## Implementation Notes
+
+- Follow @test-driven-development for each task (write failing test first).
+- Keep YAGNI: do not add Workday CSV support in this plan.
+- Preserve multi-tenancy: every action/query/export remains scoped by `organizationId`.
+- Keep secrets in org vault only (no env vars for tenant-specific credentials).
+
+### Task 1: Add API connector contract and registry
+
+**Files:**
+- Create: `apps/webapp/src/lib/payroll-export/connectors/types.ts`
+- Create: `apps/webapp/src/lib/payroll-export/connectors/registry.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/export-service.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/index.ts`
+- Test: `apps/webapp/src/lib/payroll-export/connectors/registry.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createConnectorRegistry } from "./registry";
+
+describe("connector registry", () => {
+  it("registers and resolves connectors by id", () => {
+    const registry = createConnectorRegistry();
+    const connector = {
+      connectorId: "workday_api",
+      connectorName: "Workday",
+      version: "1.0.0",
+      validateConfig: async () => ({ valid: true }),
+      testConnection: async () => ({ success: true }),
+      export: async () => ({
+        success: true,
+        totalRecords: 0,
+        syncedRecords: 0,
+        failedRecords: 0,
+        skippedRecords: 0,
+        errors: [],
+        metadata: { employeeCount: 0, dateRange: { start: "", end: "" }, apiCallCount: 0, durationMs: 0 },
+      }),
+      getSyncThreshold: () => 500,
+    };
+
+    registry.register(connector);
+    expect(registry.get("workday_api")?.connectorName).toBe("Workday");
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/connectors/registry.test.ts`
+Expected: FAIL with module/file not found for `connectors/registry`.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// connectors/types.ts
+export interface IPayrollApiConnector {
+  readonly connectorId: string;
+  readonly connectorName: string;
+  readonly version: string;
+  validateConfig(config: Record<string, unknown>): Promise<{ valid: boolean; errors?: string[] }>;
+  testConnection(organizationId: string, config: Record<string, unknown>): Promise<{ success: boolean; error?: string }>;
+  export(
+    organizationId: string,
+    workPeriods: import("../types").WorkPeriodData[],
+    absences: import("../types").AbsenceData[],
+    mappings: import("../types").WageTypeMapping[],
+    config: Record<string, unknown>,
+  ): Promise<import("../types").ApiExportResult>;
+  getSyncThreshold(): number;
+}
+
+// connectors/registry.ts
+export function createConnectorRegistry() {
+  const map = new Map<string, import("./types").IPayrollApiConnector>();
+  return {
+    register: (connector: import("./types").IPayrollApiConnector) => map.set(connector.connectorId, connector),
+    get: (connectorId: string) => map.get(connectorId),
+    list: () => Array.from(map.values()),
+    has: (connectorId: string) => map.has(connectorId),
+  };
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/connectors/registry.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/lib/payroll-export/connectors/types.ts apps/webapp/src/lib/payroll-export/connectors/registry.ts apps/webapp/src/lib/payroll-export/connectors/registry.test.ts apps/webapp/src/lib/payroll-export/export-service.ts apps/webapp/src/lib/payroll-export/index.ts
+git commit -m "refactor(payroll): add API connector registry contract"
+```
+
+### Task 2: Add adapters for existing API exporters
+
+**Files:**
+- Create: `apps/webapp/src/lib/payroll-export/connectors/personio-connector.ts`
+- Create: `apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/export-service.ts`
+- Test: `apps/webapp/src/lib/payroll-export/connectors/personio-connector.test.ts`
+- Test: `apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.test.ts`
+
+**Step 1: Write failing tests**
+
+```ts
+it("delegates Personio connector calls to personioExporter", async () => {
+  const result = await personioConnector.validateConfig({});
+  expect(result.valid).toBeTypeOf("boolean");
+});
+```
+
+```ts
+it("delegates SuccessFactors connector calls to successFactorsExporter", async () => {
+  const result = await successFactorsConnector.testConnection("org_1", {});
+  expect(result.success).toBeTypeOf("boolean");
+});
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/connectors/personio-connector.test.ts src/lib/payroll-export/connectors/successfactors-connector.test.ts`
+Expected: FAIL with missing connector adapters.
+
+**Step 3: Implement adapters and wire registry**
+
+```ts
+export const personioConnector: IPayrollApiConnector = {
+  connectorId: personioExporter.exporterId,
+  connectorName: personioExporter.exporterName,
+  version: personioExporter.version,
+  validateConfig: (config) => personioExporter.validateConfig(config),
+  testConnection: (organizationId, config) => personioExporter.testConnection(organizationId, config),
+  export: (organizationId, workPeriods, absences, mappings, config) =>
+    personioExporter.export(organizationId, workPeriods, absences, mappings, config),
+  getSyncThreshold: () => personioExporter.getSyncThreshold(),
+};
+```
+
+**Step 4: Run tests to verify pass and no regression**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/connectors/personio-connector.test.ts src/lib/payroll-export/connectors/successfactors-connector.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/lib/payroll-export/connectors/personio-connector.ts apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.ts apps/webapp/src/lib/payroll-export/export-service.ts apps/webapp/src/lib/payroll-export/connectors/personio-connector.test.ts apps/webapp/src/lib/payroll-export/connectors/successfactors-connector.test.ts
+git commit -m "refactor(payroll): adapt Personio and SAP to connector layer"
+```
+
+### Task 3: Implement Workday connector (types, config, API client, transformer)
+
+**Files:**
+- Create: `apps/webapp/src/lib/payroll-export/exporters/workday/types.ts`
+- Create: `apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts`
+- Create: `apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts`
+- Create: `apps/webapp/src/lib/payroll-export/exporters/workday/index.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/types.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/index.ts`
+- Test: `apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts`
+- Test: `apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts`
+
+**Step 1: Write failing tests**
+
+```ts
+it("validates required Workday config", async () => {
+  const result = await workdayConnector.validateConfig({ employeeMatchStrategy: "email" });
+  expect(result.valid).toBe(false);
+  expect(result.errors?.[0]).toContain("instanceUrl");
+});
+
+it("maps employee by configurable strategy", async () => {
+  const matched = matchWorkdayEmployee(
+    [{ employeeNumber: "E100", email: "a@b.com" }],
+    { employeeNumber: "E100", email: "other@b.com" },
+    "employeeNumber",
+  );
+  expect(matched).toBeTruthy();
+});
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/exporters/workday/workday-connector.test.ts src/lib/payroll-export/exporters/workday/api-client.test.ts`
+Expected: FAIL with missing Workday modules.
+
+**Step 3: Implement minimal Workday connector**
+
+```ts
+export interface WorkdayConfig {
+  instanceUrl: string;
+  tenantId: string;
+  employeeMatchStrategy: "employeeNumber" | "email";
+  includeZeroHours: boolean;
+  batchSize: number;
+  apiTimeoutMs: number;
+}
+
+export const DEFAULT_WORKDAY_CONFIG: WorkdayConfig = {
+  instanceUrl: "",
+  tenantId: "",
+  employeeMatchStrategy: "employeeNumber",
+  includeZeroHours: false,
+  batchSize: 100,
+  apiTimeoutMs: 60000,
+};
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/exporters/workday/workday-connector.test.ts src/lib/payroll-export/exporters/workday/api-client.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/lib/payroll-export/exporters/workday/types.ts apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts apps/webapp/src/lib/payroll-export/exporters/workday/index.ts apps/webapp/src/lib/payroll-export/types.ts apps/webapp/src/lib/payroll-export/index.ts apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts
+git commit -m "feat(payroll): add Workday API connector"
+```
+
+### Task 4: Add Workday server actions and format/config bootstrap
+
+**Files:**
+- Modify: `apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/export-service.ts`
+- Test: `apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts`
+
+**Step 1: Write failing tests**
+
+```ts
+it("saves and returns Workday config for org", async () => {
+  const result = await saveWorkdayConfigAction({
+    organizationId: "org_1",
+    config: {
+      instanceUrl: "https://impl.workday.com",
+      tenantId: "tenant_1",
+      employeeMatchStrategy: "employeeNumber",
+      includeZeroHours: false,
+      batchSize: 100,
+      apiTimeoutMs: 60000,
+    },
+  });
+  expect(result.success).toBe(true);
+});
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `pnpm --filter webapp test -- "src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts"`
+Expected: FAIL with missing action exports.
+
+**Step 3: Implement actions and format bootstrap**
+
+```ts
+const WORKDAY_FORMAT_ID = "workday_api";
+const WORKDAY_VAULT_KEY_CLIENT_ID = "payroll/workday/client_id";
+const WORKDAY_VAULT_KEY_CLIENT_SECRET = "payroll/workday/client_secret";
+
+export async function getWorkdayConfigAction(organizationId: string) { /* admin check + get config */ }
+export async function saveWorkdayConfigAction(input: SaveWorkdayConfigInput) { /* upsert format + config */ }
+export async function saveWorkdayCredentialsAction(input: SaveWorkdayCredentialsInput) { /* vault store */ }
+export async function deleteWorkdayCredentialsAction(organizationId: string) { /* vault delete */ }
+export async function testWorkdayConnectionAction(input: { organizationId: string; config: WorkdayConfig }) { /* connector test */ }
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `pnpm --filter webapp test -- "src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add "apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts" apps/webapp/src/lib/payroll-export/export-service.ts "apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.workday.test.ts"
+git commit -m "feat(payroll): add Workday settings server actions"
+```
+
+### Task 5: Add Workday settings UI tab
+
+**Files:**
+- Create: `apps/webapp/src/components/settings/payroll-export/workday-config-form.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx`
+- Modify: `apps/webapp/src/components/settings/payroll-export/index.ts`
+- Test: `apps/webapp/src/components/settings/payroll-export/workday-config-form.test.tsx`
+
+**Step 1: Write failing test**
+
+```tsx
+it("renders Workday config fields and submits", async () => {
+  render(<WorkdayConfigForm organizationId="org_1" initialConfig={null} />);
+  expect(screen.getByLabelText(/Instance URL/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Tenant ID/i)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /Save Configuration/i })).toBeInTheDocument();
+});
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `pnpm --filter webapp test -- src/components/settings/payroll-export/workday-config-form.test.tsx`
+Expected: FAIL with missing component.
+
+**Step 3: Implement minimal UI and page wiring**
+
+```tsx
+<TabsTrigger value="workday">{t("settings.payrollExport.tabs.workday", "Workday")}</TabsTrigger>
+...
+<TabsContent value="workday" className="mt-4">
+  <WorkdayConfigForm organizationId={organizationId} initialConfig={workdayConfig} />
+</TabsContent>
+```
+
+**Step 4: Run test to verify pass**
+
+Run: `pnpm --filter webapp test -- src/components/settings/payroll-export/workday-config-form.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/components/settings/payroll-export/workday-config-form.tsx apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx apps/webapp/src/components/settings/payroll-export/index.ts apps/webapp/src/components/settings/payroll-export/workday-config-form.test.tsx
+git commit -m "feat(payroll-ui): add Workday configuration tab"
+```
+
+### Task 6: Make Export tab format-selectable and support Workday start export
+
+**Files:**
+- Modify: `apps/webapp/src/components/settings/payroll-export/export-form.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts`
+- Modify: `apps/webapp/src/lib/payroll-export/export-service.ts`
+- Test: `apps/webapp/src/components/settings/payroll-export/export-form.test.tsx`
+- Test: `apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts`
+
+**Step 1: Write failing tests**
+
+```tsx
+it("sends selected format to startExportAction", async () => {
+  render(<ExportForm organizationId="org_1" config={{} as never} />);
+  // select Workday and submit
+  // assert startExportAction called with formatId: "workday_api"
+});
+```
+
+```ts
+it("uses input formatId instead of hardcoded datev_lohn", async () => {
+  const result = await startExportAction({
+    organizationId: "org_1",
+    formatId: "workday_api",
+    startDate: "2026-01-01",
+    endDate: "2026-01-31",
+  });
+  expect(result.success).toBe(true);
+});
+```
+
+**Step 2: Run tests to verify failure**
+
+Run: `pnpm --filter webapp test -- src/components/settings/payroll-export/export-form.test.tsx "src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts"`
+Expected: FAIL due to missing `formatId` support and hardcoded format.
+
+**Step 3: Implement minimal format-selection flow**
+
+```ts
+export interface StartExportInput {
+  organizationId: string;
+  formatId: string;
+  startDate: string;
+  endDate: string;
+  employeeIds?: string[];
+  teamIds?: string[];
+  projectIds?: string[];
+}
+
+// startExportAction -> createExportJob({ formatId: input.formatId, ... })
+```
+
+**Step 4: Run tests to verify pass**
+
+Run: `pnpm --filter webapp test -- src/components/settings/payroll-export/export-form.test.tsx "src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/webapp/src/components/settings/payroll-export/export-form.tsx "apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts" apps/webapp/src/lib/payroll-export/export-service.ts apps/webapp/src/components/settings/payroll-export/export-form.test.tsx "apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.start-export.test.ts"
+git commit -m "feat(payroll): make export target selectable including Workday"
+```
+
+### Task 7: Update docs and run full payroll-export verification
+
+**Files:**
+- Modify: `apps/docs/content/docs/guide/admin-guide/payroll-export.mdx`
+- Test: (verification command only)
+
+**Step 1: Write failing doc assertion test (optional lightweight guard)**
+
+```ts
+it("documents Workday integration", async () => {
+  const doc = await fs.readFile("apps/docs/content/docs/guide/admin-guide/payroll-export.mdx", "utf8");
+  expect(doc).toContain("Workday");
+});
+```
+
+**Step 2: Run check to verify it fails before edit (if test added)**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export/docs-smoke.test.ts`
+Expected: FAIL until docs mention Workday.
+
+**Step 3: Update documentation**
+
+```md
+**API Integrations:**
+- **Workday**: Direct API integration with Workday
+```
+
+Include:
+- setup steps
+- matching strategy (`employeeNumber`/`email`)
+- connection test flow
+- sync status semantics and retry behavior
+
+**Step 4: Run verification suite**
+
+Run: `pnpm --filter webapp test -- src/lib/payroll-export src/components/settings/payroll-export "src/app/[locale]/(app)/settings/payroll-export"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+git commit -m "docs(payroll): add Workday export guide"
+```
+
+## Final Validation Checklist
+
+Run these before opening PR:
+
+1. `pnpm --filter webapp test -- src/lib/payroll-export`
+2. `pnpm --filter webapp test -- src/components/settings/payroll-export`
+3. `pnpm --filter webapp test -- "src/app/[locale]/(app)/settings/payroll-export"`
+4. `pnpm --filter webapp build`
+
+Expected: all PASS.


### PR DESCRIPTION
## Summary
- fix TypeScript build blockers in desktop, extension, and payroll-export server action/test files so non-mobile packages build cleanly again
- reduce noisy Redis/Valkey connection errors during webapp static build by avoiding eager queue initialization and skipping startup checks during build phase
- include planning docs for platform-vs-org-admin routing and Workday export implementation

## Verification
- pnpm turbo build --filter=!mobile --filter=!webapp
- BETTER_AUTH_SECRET=... S3_*... pnpm --filter webapp build