### PR TITLE
ci(marketing): add GHCR publish workflow and Bun image target

### DIFF
--- a/.github/workflows/publish-marketing-image.yml
+++ b/.github/workflows/publish-marketing-image.yml
@@ -1,0 +1,135 @@
+name: Publish Marketing Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-marketing-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-native:
+    name: Build Native (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push marketing image by digest
+        id: build_marketing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: marketing
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/umami-creative-gmbh/z8-marketing,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest artifact
+        env:
+          MARKETING_DIGEST: ${{ steps.build_marketing.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests/marketing
+          touch "/tmp/digests/marketing/${MARKETING_DIGEST#sha256:}"
+
+      - name: Upload marketing digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-marketing-${{ matrix.arch }}
+          path: /tmp/digests/marketing/*
+          if-no-files-found: error
+
+  publish-manifest:
+    name: Publish Manifest
+    needs: build-native
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-marketing-amd64
+          path: /tmp/digests/amd64
+
+      - name: Download arm64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-marketing-arm64
+          path: /tmp/digests/arm64
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/umami-creative-gmbh/z8-marketing
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+
+      - name: Create and push multi-arch manifests
+        env:
+          IMAGE_NAME: ghcr.io/umami-creative-gmbh/z8-marketing
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          set -- /tmp/digests/amd64/*
+          AMD64_DIGEST="sha256:${1##*/}"
+
+          set -- /tmp/digests/arm64/*
+          ARM64_DIGEST="sha256:${1##*/}"
+
+          for tag in $TAGS; do
+            docker buildx imagetools create \
+              -t "$tag" \
+              "$IMAGE_NAME@$AMD64_DIGEST" \
+              "$IMAGE_NAME@$ARM64_DIGEST"
+          done

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "next dev -p 3003",
 		"build": "next build",
-		"start": "next start -p 3003"
+		"start": "next start -p 3000"
 	},
 	"dependencies": {
 		"@tabler/icons-react": "^3.37.1",
@@ -13,7 +13,8 @@
 		"next": "16.1.6",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
-		"tailwind-merge": "^3.5.0"
+		"tailwind-merge": "^3.5.0",
+		"typescript": "^5.9.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.4",
@@ -23,7 +24,6 @@
 		"@types/react-dom": "^19.2.3",
 		"postcss": "^8.5.6",
 		"tailwindcss": "^4.2.0",
-		"typescript": "^5.9.3",
 		"ultracite": "^7.2.3"
 	}
 }

--- a/docs/plans/2026-03-01-marketing-image-workflow-design.md
+++ b/docs/plans/2026-03-01-marketing-image-workflow-design.md
@@ -1,0 +1,72 @@
+# Marketing Docker Publish Workflow Design
+
+Date: 2026-03-01
+Status: Approved
+
+## Goal
+
+Create a dedicated GitHub Actions workflow to build and publish a multi-architecture Docker image for the marketing app to GHCR as `ghcr.io/umami-creative-gmbh/z8-marketing`.
+
+## Constraints and Decisions
+
+- Outcome: build and push image to GHCR.
+- Trigger strategy: run on pushes to `main`, version tags (`v*.*.*`), and manual dispatch.
+- Naming: use `ghcr.io/umami-creative-gmbh/z8-marketing`.
+- Scope: workflow design only (no deployment step, no scan integration, no refactor of existing publish workflows).
+
+## Approach Options Considered
+
+1. Dedicated workflow for marketing only (selected)
+   - Pros: low risk to existing publish pipelines, clear ownership, minimal blast radius.
+   - Cons: duplicates some publish logic.
+
+2. Extend existing `publish-images.yml`
+   - Pros: shared logic in one file.
+   - Cons: increases risk to webapp/worker/migration publishing path.
+
+3. Reusable workflow + thin callers
+   - Pros: best long-term maintainability.
+   - Cons: larger upfront refactor not required for current goal.
+
+## Selected Design
+
+### Architecture
+
+- Add `.github/workflows/publish-marketing-image.yml`.
+- Keep existing `.github/workflows/publish-images.yml` unchanged.
+- Build from monorepo root context (`.`) so workspace and pnpm dependency resolution remain consistent.
+- Use a dedicated Docker build target for marketing image creation.
+
+### Components and Data Flow
+
+- Job 1 (`build-native`): matrix build for `linux/amd64` and `linux/arm64`.
+  - Build and push image by digest using `docker/build-push-action`.
+  - Save each architecture digest as artifact.
+- Job 2 (`publish-manifest`): download digests and publish multi-arch manifest tags.
+  - Use `docker/metadata-action` to produce tags:
+    - `latest` for default branch
+    - `sha-*`
+    - semver tags for release tags (`vX.Y.Z`, `vX.Y`, `vX`)
+  - Create manifest list tags that reference amd64 and arm64 digest images.
+
+### Error Handling and Safety
+
+- Add workflow concurrency by ref to avoid duplicate publishes for the same ref.
+- Use strict permissions: `contents: read`, `packages: write`.
+- Set `if-no-files-found: error` for digest artifact handling.
+- Use strict shell flags (`set -euo pipefail`) in manifest publish step.
+- Keep matrix `fail-fast: true` and explicit timeouts per job.
+
+### Testing and Verification
+
+- CI run verifies cross-architecture image builds and manifest assembly.
+- Post-run verification checks:
+  - `ghcr.io/umami-creative-gmbh/z8-marketing:latest` exists on default branch runs.
+  - Semver tags exist on version tag runs.
+  - Manifest includes both `linux/amd64` and `linux/arm64`.
+
+## Out of Scope (YAGNI)
+
+- Runtime deployment automation.
+- Security scanning additions.
+- Consolidation of existing image workflows into reusable workflow modules.

--- a/docs/plans/2026-03-01-marketing-image-workflow-implementation.md
+++ b/docs/plans/2026-03-01-marketing-image-workflow-implementation.md
@@ -1,0 +1,201 @@
+# Marketing Image Publish Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a dedicated GitHub Actions pipeline that builds and publishes a multi-arch Docker image for the marketing app to `ghcr.io/umami-creative-gmbh/z8-marketing` on `main`, semver tags, and manual dispatch.
+
+**Architecture:** Add a dedicated `marketing` build target in the root `Dockerfile`, then create a separate workflow that mirrors the existing digest-based publish pattern: per-arch native builds push immutable digests, then a manifest job publishes multi-arch tags (`latest`, `sha-*`, semver). Keep this isolated from the existing publish workflow to minimize blast radius.
+
+**Tech Stack:** GitHub Actions, Docker Buildx, GHCR, `docker/build-push-action`, `docker/metadata-action`, pnpm monorepo, Next.js marketing app (`apps/marketing`).
+
+---
+
+### Task 1: Add Docker Build Support for Marketing App
+
+**Files:**
+- Modify: `Dockerfile`
+- Test: `Dockerfile`
+
+**Step 1: Add marketing prune/build/runtime stages**
+
+Implement dedicated stages equivalent in structure to existing app targets:
+
+- `RUN turbo prune marketing --docker`
+- install deps for pruned workspace
+- build with `pnpm --filter marketing exec next build`
+- runtime stage copies `apps/marketing/.next`, `apps/marketing/public`, and required workspace files
+- runtime command uses `pnpm start` from `apps/marketing`
+
+Use target name `marketing` so CI can call `--target marketing`.
+
+**Step 2: Build locally to validate target exists**
+
+Run: `docker build --target marketing -t z8-marketing:local .`
+Expected: PASS and image builds successfully.
+
+**Step 3: Commit Dockerfile target change**
+
+```bash
+git add Dockerfile
+git commit -m "build(docker): add marketing image target"
+```
+
+### Task 2: Create Dedicated Marketing Publish Workflow Skeleton
+
+**Files:**
+- Create: `.github/workflows/publish-marketing-image.yml`
+- Test: `.github/workflows/publish-marketing-image.yml`
+
+**Step 1: Add workflow metadata, triggers, permissions, and concurrency**
+
+Include:
+
+```yaml
+name: Publish Marketing Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-marketing-image-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+**Step 2: Add a placeholder job and lint workflow syntax**
+
+Run: `pnpm dlx actionlint .github/workflows/publish-marketing-image.yml`
+Expected: PASS with no syntax or action errors.
+
+**Step 3: Commit workflow skeleton**
+
+```bash
+git add .github/workflows/publish-marketing-image.yml
+git commit -m "ci: add marketing image workflow skeleton"
+```
+
+### Task 3: Implement Native Per-Architecture Digest Builds
+
+**Files:**
+- Modify: `.github/workflows/publish-marketing-image.yml`
+- Test: `.github/workflows/publish-marketing-image.yml`
+
+**Step 1: Add `build-native` matrix job for amd64 and arm64**
+
+Include matrix entries:
+
+- amd64 -> `linux/amd64` on `ubuntu-latest`
+- arm64 -> `linux/arm64` on `ubuntu-24.04-arm`
+
+Add steps for checkout, buildx setup, GHCR login, and build/push by digest:
+
+```yaml
+- name: Build and push marketing by digest
+  id: build_marketing
+  uses: docker/build-push-action@v6
+  with:
+    context: .
+    file: ./Dockerfile
+    target: marketing
+    platforms: ${{ matrix.platform }}
+    outputs: type=image,name=ghcr.io/umami-creative-gmbh/z8-marketing,push-by-digest=true,name-canonical=true,push=true
+```
+
+Export/upload digest artifact per architecture.
+
+**Step 2: Validate syntax**
+
+Run: `pnpm dlx actionlint .github/workflows/publish-marketing-image.yml`
+Expected: PASS.
+
+**Step 3: Commit native build job**
+
+```bash
+git add .github/workflows/publish-marketing-image.yml
+git commit -m "ci: add native digest builds for marketing image"
+```
+
+### Task 4: Publish Multi-Arch Manifest Tags
+
+**Files:**
+- Modify: `.github/workflows/publish-marketing-image.yml`
+- Test: `.github/workflows/publish-marketing-image.yml`
+
+**Step 1: Add `publish-manifest` job dependent on `build-native`**
+
+Add steps to:
+
+- download amd64/arm64 digest artifacts
+- compute tags via `docker/metadata-action@v5`
+- publish manifest list with both digests
+
+Required tags:
+
+```yaml
+tags: |
+  type=raw,value=latest,enable={{is_default_branch}}
+  type=sha,prefix=sha-
+  type=semver,pattern=v{{version}}
+  type=semver,pattern=v{{major}}.{{minor}}
+  type=semver,pattern=v{{major}}
+```
+
+Use strict shell flags in manifest script (`set -euo pipefail`).
+
+**Step 2: Validate syntax again**
+
+Run: `pnpm dlx actionlint .github/workflows/publish-marketing-image.yml`
+Expected: PASS.
+
+**Step 3: Commit manifest publish job**
+
+```bash
+git add .github/workflows/publish-marketing-image.yml
+git commit -m "ci: publish multi-arch marketing image manifests"
+```
+
+### Task 5: Verify End-to-End Behavior and Document Outcomes
+
+**Files:**
+- Test: `.github/workflows/publish-marketing-image.yml`
+- Optional Modify: `docs/plans/2026-03-01-marketing-image-workflow-implementation.md`
+
+**Step 1: Dry-run review of workflow delta**
+
+Run: `git diff -- .github/workflows/publish-marketing-image.yml Dockerfile`
+Expected: Only marketing Docker target and new workflow changes are present.
+
+**Step 2: Trigger workflow on main (or `workflow_dispatch`)**
+
+Run: trigger `Publish Marketing Image` in GitHub Actions.
+Expected: `build-native` succeeds for both architectures; `publish-manifest` succeeds.
+
+**Step 3: Verify published image and platforms**
+
+Run:
+
+```bash
+docker buildx imagetools inspect ghcr.io/umami-creative-gmbh/z8-marketing:latest
+```
+
+Expected: Manifest includes both `linux/amd64` and `linux/arm64`.
+
+**Step 4: Verify semver tags on release tag event**
+
+Run: push tag `vX.Y.Z` and inspect GHCR tags.
+Expected: `vX.Y.Z`, `vX.Y`, `vX`, and `sha-*` tags are present.
+
+**Step 5: Commit verification notes if docs were updated**
+
+```bash
+git add docs/plans/2026-03-01-marketing-image-workflow-implementation.md
+git commit -m "docs(ci): record marketing image publish verification"
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.4
@@ -228,9 +231,6 @@ importers:
       tailwindcss:
         specifier: ^4.2.0
         version: 4.2.0
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
       ultracite:
         specifier: ^7.2.3
         version: 7.2.3


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to build and publish `ghcr.io/umami-creative-gmbh/z8-marketing` as multi-arch (`amd64`/`arm64`) with `latest`, `sha-*`, and semver tags
- add a new `marketing` target in the root `Dockerfile` using the monorepo prune/build pattern and a Bun-based runtime image
- align marketing runtime startup on port `3000` and include production TypeScript dependency so `next.config.ts` loads correctly in container runtime

## Validation
- `docker build --target marketing -t z8-marketing:local .`
- container smoke test on `http://127.0.0.1:3000`
- `pnpm dlx node-actionlint .github/workflows/publish-marketing-image.yml` (reports unknown `ubuntu-24.04-arm` label in local linter, matching existing repo workflow runner label usage)