### PR TITLE
fix(webapp): restore build compatibility after better-auth update

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -19,6 +19,7 @@
 		"@aws-sdk/client-s3": "^3.1002.0",
 		"@aws-sdk/s3-request-presigner": "^3.1002.0",
 		"@better-auth/api-key": "^1.5.3",
+		"@better-auth/drizzle-adapter": "1.5.3",
 		"@better-auth/passkey": "1.5.3",
 		"@better-auth/scim": "^1.5.3",
 		"@better-auth/sso": "1.5.3",

--- a/apps/webapp/src/app/[locale]/(app)/settings/enterprise/api-keys/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/enterprise/api-keys/actions.ts
@@ -69,6 +69,23 @@ function toISOString(value: unknown): string | null {
 	return null;
 }
 
+function extractApiKeys(result: unknown): unknown[] {
+	if (Array.isArray(result)) {
+		return result;
+	}
+
+	if (
+		result &&
+		typeof result === "object" &&
+		"apiKeys" in result &&
+		Array.isArray((result as { apiKeys?: unknown[] }).apiKeys)
+	) {
+		return (result as { apiKeys: unknown[] }).apiKeys;
+	}
+
+	return [];
+}
+
 /**
  * Verify that the current user has admin/owner permissions for the organization
  * Returns session and member record if authorized
@@ -229,7 +246,7 @@ export async function listApiKeys(
 							const result = await auth.api.listApiKeys({
 								headers: await headers(),
 							});
-							return result || [];
+							return extractApiKeys(result);
 						},
 						catch: (error) => {
 							logger.error({ error }, "Failed to list API keys via auth API");
@@ -316,7 +333,7 @@ export async function createApiKey(
 							const result = await auth.api.listApiKeys({
 								headers: await headers(),
 							});
-							return transformApiKeysResponse((result || []) as unknown[], organizationId);
+							return transformApiKeysResponse(extractApiKeys(result), organizationId);
 						},
 						catch: (error) => {
 							logger.error({ error, organizationId }, "Failed to check existing API keys");

--- a/apps/webapp/src/app/[locale]/onboarding/wellness/page.tsx
+++ b/apps/webapp/src/app/[locale]/onboarding/wellness/page.tsx
@@ -78,11 +78,15 @@ export default function WellnessPage() {
 
 	// Sync form state to component state for conditional rendering
 	useEffect(() => {
-		return form.store.subscribe(() => {
+		const subscription = form.store.subscribe(() => {
 			const values = form.store.state.values;
 			setIsEnabled(values.enableWaterReminder);
 			setSelectedPreset(values.waterReminderPreset);
 		});
+
+		return () => {
+			subscription.unsubscribe();
+		};
 	}, [form.store]);
 
 	function handlePresetChange(preset: WaterReminderPreset) {

--- a/apps/webapp/src/components/settings/wellness-settings-form.tsx
+++ b/apps/webapp/src/components/settings/wellness-settings-form.tsx
@@ -52,11 +52,15 @@ export function WellnessSettingsForm({ initialSettings }: WellnessSettingsFormPr
 
 	// Sync form state to component state for conditional rendering
 	useEffect(() => {
-		return form.store.subscribe(() => {
+		const subscription = form.store.subscribe(() => {
 			const state = form.store.state;
 			setIsEnabled(state.values.enabled);
 			setIsDirty(state.isDirty);
 		});
+
+		return () => {
+			subscription.unsubscribe();
+		};
 	}, [form.store]);
 
 	return (

--- a/apps/webapp/src/lib/auth-client.ts
+++ b/apps/webapp/src/lib/auth-client.ts
@@ -2,9 +2,9 @@
 
 import { passkeyClient } from "@better-auth/passkey/client";
 import { ssoClient } from "@better-auth/sso/client";
+import { apiKeyClient } from "@better-auth/api-key/client";
 import {
 	adminClient,
-	apiKeyClient,
 	inferAdditionalFields,
 	inferOrgAdditionalFields,
 	organizationClient,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,16 +291,19 @@ importers:
         version: 3.1002.0
       '@better-auth/api-key':
         specifier: ^1.5.3
-        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))
+        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))
+      '@better-auth/drizzle-adapter':
+        specifier: 1.5.3
+        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(@upstash/redis@1.36.3)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
       '@better-auth/passkey':
         specifier: 1.5.3
-        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@better-auth/scim':
         specifier: ^1.5.3
-        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))
+        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))
       '@better-auth/sso':
         specifier: 1.5.3
-        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))(better-call@1.3.2(zod@4.3.6))
       '@bprogress/core':
         specifier: ^1.3.4
         version: 1.3.4
@@ -531,7 +534,7 @@ importers:
         version: 2.0.8(@upstash/redis@1.36.3)
       better-auth:
         specifier: ^1.5.3
-        version: 1.5.3(799c546ca68486a4f5e3d78d2e666b02)
+        version: 1.5.3(8cdbb952ae301321b634e90e6394f820)
       botbuilder:
         specifier: ^4.23.3
         version: 4.23.3
@@ -1535,6 +1538,13 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  '@better-auth/drizzle-adapter@1.5.3':
+    resolution: {integrity: sha512-dib9V1vpwDu+TKLC+L+8Q5bLNS0uE3JCT4pGotw52pnpiQF8msoMK4eEfri19f8DtNltpb2F2yzyIsTugBBYNQ==}
+    peerDependencies:
+      '@better-auth/core': 1.5.3
+      '@better-auth/utils': ^0.3.0
+      drizzle-orm: '>=0.41.0'
 
   '@better-auth/kysely-adapter@1.5.3':
     resolution: {integrity: sha512-eAm1KPrlPXkH/qXUXnGBcHPDgCX153b6BSlc2QJ2IeqmiWym9D/6XORqBIZOl71JiP0Cifzocr2GLpnz0gt31Q==}
@@ -13027,11 +13037,11 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/api-key@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))':
+  '@better-auth/api-key@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.3(799c546ca68486a4f5e3d78d2e666b02)
+      better-auth: 1.5.3(8cdbb952ae301321b634e90e6394f820)
       zod: 4.3.6
 
   '@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)':
@@ -13045,6 +13055,12 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
 
+  '@better-auth/drizzle-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(@upstash/redis@1.36.3)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))':
+    dependencies:
+      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
+      '@better-auth/utils': 0.3.1
+      drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(@upstash/redis@1.36.3)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+
   '@better-auth/kysely-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
@@ -13056,32 +13072,32 @@ snapshots:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/passkey@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.5.3(799c546ca68486a4f5e3d78d2e666b02)
+      better-auth: 1.5.3(8cdbb952ae301321b634e90e6394f820)
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/scim@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))':
+  '@better-auth/scim@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.3(799c546ca68486a4f5e3d78d2e666b02)
+      better-auth: 1.5.3(8cdbb952ae301321b634e90e6394f820)
       better-call: 1.3.2(zod@4.3.6)
       zod: 4.3.6
 
-  '@better-auth/sso@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.3(799c546ca68486a4f5e3d78d2e666b02)
+      better-auth: 1.5.3(8cdbb952ae301321b634e90e6394f820)
       better-call: 1.3.2(zod@4.3.6)
       fast-xml-parser: 5.4.2
       jose: 6.1.3
@@ -18424,7 +18440,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.5.3(799c546ca68486a4f5e3d78d2e666b02):
+  better-auth@1.5.3(8cdbb952ae301321b634e90e6394f820):
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
@@ -18441,6 +18457,7 @@ snapshots:
       nanostores: 1.1.1
       zod: 4.3.6
     optionalDependencies:
+      '@better-auth/drizzle-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(@upstash/redis@1.36.3)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
       '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       drizzle-kit: 0.31.9
       drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.18.0)(@upstash/redis@1.36.3)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))


### PR DESCRIPTION
## Summary
- align Better Auth client integration with v1.5.3 by importing `apiKeyClient` from `@better-auth/api-key/client` and adding the `@better-auth/drizzle-adapter` dependency
- normalize API key list response handling in enterprise settings actions so both array and object payload shapes are handled safely
- fix TanStack form store subscription cleanup typing in wellness onboarding/settings components to satisfy React effect callback expectations

## Notes
- full webapp build now passes compile and type checks for these code paths, then stops on missing required environment variables in this local agent context (`BETTER_AUTH_SECRET`, S3 vars)