### PR TITLE
fix(deploy): surface build version and auth startup diagnostics

### DIFF
--- a/apps/webapp/next.config.ts
+++ b/apps/webapp/next.config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
@@ -7,9 +8,35 @@ const withNextIntl = createNextIntlPlugin();
 const configDir = path.dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = path.resolve(configDir, "../..");
 
+function getBuildHash() {
+	const providedHash =
+		process.env.NEXT_PUBLIC_BUILD_HASH ??
+		process.env.VERCEL_GIT_COMMIT_SHA ??
+		process.env.GITHUB_SHA ??
+		process.env.CI_COMMIT_SHA;
+
+	if (providedHash) {
+		return providedHash.slice(0, 7);
+	}
+
+	try {
+		return execSync("git rev-parse --short HEAD", {
+			cwd: workspaceRoot,
+			encoding: "utf8",
+		}).trim();
+	} catch {
+		return "dev";
+	}
+}
+
+const buildHash = getBuildHash();
+
 const nextConfig: NextConfig = {
 	reactStrictMode: true,
 	reactCompiler: true,
+	env: {
+		NEXT_PUBLIC_BUILD_HASH: buildHash,
+	},
 	// Note: standalone output is not compatible with cacheComponents in Next.js 16
 	// Using standard build with full node_modules for Docker deployment
 	// Enable cache components for static dashboard shells and improved performance

--- a/apps/webapp/src/app/api/organizations/switch/route.ts
+++ b/apps/webapp/src/app/api/organizations/switch/route.ts
@@ -6,6 +6,11 @@ import { member } from "@/db/auth-schema";
 import { employee } from "@/db/schema";
 import { getDefaultAppBaseUrl } from "@/lib/app-url";
 import { auth } from "@/lib/auth";
+import { getAuthRequestDiagnostics } from "@/lib/diagnostics";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("OrganizationSwitchRoute");
+const shouldLogAuthDiagnostics = process.env.NODE_ENV === "production";
 
 function getCorsHeaders(origin: string | null): Record<string, string> {
 	const appUrl = getDefaultAppBaseUrl();
@@ -36,9 +41,19 @@ export async function POST(request: NextRequest) {
 	const origin = request.headers.get("origin");
 	const corsHeaders = getCorsHeaders(origin);
 	try {
-		const session = await auth.api.getSession({ headers: await headers() });
+		const resolvedHeaders = await headers();
+		const session = await auth.api.getSession({ headers: resolvedHeaders });
 
 		if (!session?.user) {
+			if (shouldLogAuthDiagnostics) {
+				logger.warn(
+					{
+						...getAuthRequestDiagnostics(resolvedHeaders),
+						requestOrigin: origin,
+					},
+					"Organization switch requested without an authenticated session",
+				);
+			}
 			return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: corsHeaders });
 		}
 
@@ -81,11 +96,24 @@ export async function POST(request: NextRequest) {
 
 		// Update the session's active organization
 		await auth.api.setActiveOrganization({
-			headers: await headers(),
+			headers: resolvedHeaders,
 			body: {
 				organizationId,
 			},
 		});
+
+		if (shouldLogAuthDiagnostics) {
+			logger.info(
+				{
+					...getAuthRequestDiagnostics(resolvedHeaders),
+					requestOrigin: origin,
+					userId: session.user.id,
+					organizationId,
+					hasEmployeeRecord: !!employeeRecord,
+				},
+				"Organization switched successfully",
+			);
+		}
 
 		return NextResponse.json(
 			{
@@ -95,7 +123,10 @@ export async function POST(request: NextRequest) {
 			},
 			{ headers: corsHeaders },
 		);
-	} catch (_error) {
+	} catch (error) {
+		if (shouldLogAuthDiagnostics) {
+			logger.error({ error, requestOrigin: origin }, "Failed to switch organization");
+		}
 		return NextResponse.json(
 			{ error: "Failed to switch organization" },
 			{ status: 500, headers: corsHeaders },

--- a/apps/webapp/src/app/api/session/organization-status/route.ts
+++ b/apps/webapp/src/app/api/session/organization-status/route.ts
@@ -1,7 +1,12 @@
 import { headers } from "next/headers";
-import { NextResponse, connection } from "next/server";
-import { getUserOrganizations, validateAppAccess } from "@/lib/auth-helpers";
+import { connection, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { getUserOrganizations, validateAppAccess } from "@/lib/auth-helpers";
+import { getAuthRequestDiagnostics } from "@/lib/diagnostics";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("SessionOrganizationStatusRoute");
+const shouldLogAuthDiagnostics = process.env.NODE_ENV === "production";
 
 /**
  * Returns the current session's organization status.
@@ -15,6 +20,14 @@ export async function GET() {
 		const session = await auth.api.getSession({ headers: resolvedHeaders });
 
 		if (!session?.user) {
+			if (shouldLogAuthDiagnostics) {
+				logger.warn(
+					{
+						...getAuthRequestDiagnostics(resolvedHeaders),
+					},
+					"Organization status requested without an authenticated session",
+				);
+			}
 			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 		}
 
@@ -34,6 +47,18 @@ export async function GET() {
 		const activeOrganizationId = session.session?.activeOrganizationId || null;
 		const organizations = await getUserOrganizations();
 
+		if (shouldLogAuthDiagnostics) {
+			logger.info(
+				{
+					...getAuthRequestDiagnostics(resolvedHeaders),
+					userId: session.user.id,
+					activeOrganizationId,
+					organizationCount: organizations.length,
+				},
+				"Organization status resolved",
+			);
+		}
+
 		return NextResponse.json({
 			hasActiveOrganization: !!activeOrganizationId,
 			activeOrganizationId,
@@ -43,7 +68,7 @@ export async function GET() {
 			})),
 		});
 	} catch (error) {
-		console.error("Failed to get organization status:", error);
+		logger.error({ error }, "Failed to get organization status");
 		return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 	}
 }

--- a/apps/webapp/src/components/info-footer.tsx
+++ b/apps/webapp/src/components/info-footer.tsx
@@ -1,17 +1,23 @@
 "use client";
 
 import { useTranslate } from "@tolgee/react";
+import { env } from "@/env";
 import { Link } from "@/navigation";
 
 export function InfoFooter() {
 	const { t } = useTranslate();
+	const buildHash = env.NEXT_PUBLIC_BUILD_HASH;
+
 	return (
-		<div className="text-balance text-center text-muted-foreground text-xs *:[a]:underline *:[a]:underline-offset-4 *:[a]:hover:text-primary">
-			<Link href="/terms">{t("auth.terms.service", "Terms of Service")}</Link>
-			{" · "}
-			<Link href="/privacy">{t("auth.terms.privacy", "Privacy Policy")}</Link>
-			{" · "}
-			<Link href="/licenses">Open Source Licenses</Link>
+		<div className="space-y-1 text-balance text-center text-muted-foreground text-xs">
+			<div className="*:[a]:underline *:[a]:underline-offset-4 *:[a]:hover:text-primary">
+				<Link href="/terms">{t("auth.terms.service", "Terms of Service")}</Link>
+				{" · "}
+				<Link href="/privacy">{t("auth.terms.privacy", "Privacy Policy")}</Link>
+				{" · "}
+				<Link href="/licenses">Open Source Licenses</Link>
+			</div>
+			{buildHash ? <div className="mt-2 text-[10px] opacity-40">Version {buildHash}</div> : null}
 		</div>
 	);
 }

--- a/apps/webapp/src/env.ts
+++ b/apps/webapp/src/env.ts
@@ -103,6 +103,7 @@ export const env = createEnv({
 	},
 	client: {
 		NEXT_PUBLIC_APP_URL: z.url().optional(),
+		NEXT_PUBLIC_BUILD_HASH: z.string().optional(),
 		NEXT_PUBLIC_TOLGEE_API_KEY: z.string().optional(),
 		NEXT_PUBLIC_TOLGEE_API_URL: z.url().optional(),
 	},
@@ -158,6 +159,7 @@ export const env = createEnv({
 		RATE_LIMIT_API: process.env.RATE_LIMIT_API,
 		RATE_LIMIT_EXPORT: process.env.RATE_LIMIT_EXPORT,
 		NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+		NEXT_PUBLIC_BUILD_HASH: process.env.NEXT_PUBLIC_BUILD_HASH,
 		MAIN_DOMAIN: process.env.MAIN_DOMAIN,
 		NEXT_PUBLIC_TOLGEE_API_KEY: process.env.NEXT_PUBLIC_TOLGEE_API_KEY,
 		NEXT_PUBLIC_TOLGEE_API_URL: process.env.NEXT_PUBLIC_TOLGEE_API_URL,

--- a/apps/webapp/src/lib/diagnostics.ts
+++ b/apps/webapp/src/lib/diagnostics.ts
@@ -1,0 +1,31 @@
+const SESSION_COOKIE_NAMES = [
+	"better-auth.session-token",
+	"better-auth.session_token",
+	"better-auth.session_data",
+] as const;
+
+type HeaderReader = Pick<Headers, "get">;
+
+function getCookieHeader(headers: HeaderReader): string {
+	return headers.get("cookie") ?? "";
+}
+
+export function getAuthRequestDiagnostics(headers: HeaderReader) {
+	const cookieHeader = getCookieHeader(headers);
+
+	return {
+		host: headers.get("host"),
+		origin: headers.get("origin"),
+		referer: headers.get("referer"),
+		xForwardedHost: headers.get("x-forwarded-host"),
+		xForwardedProto: headers.get("x-forwarded-proto"),
+		xForwardedFor: headers.get("x-forwarded-for"),
+		hasCookieHeader: cookieHeader.length > 0,
+		sessionCookies: Object.fromEntries(
+			SESSION_COOKIE_NAMES.map((cookieName) => [
+				cookieName,
+				cookieHeader.includes(`${cookieName}=`),
+			]),
+		),
+	};
+}

--- a/apps/webapp/src/lib/health.ts
+++ b/apps/webapp/src/lib/health.ts
@@ -1,9 +1,10 @@
 import { HeadBucketCommand } from "@aws-sdk/client-s3";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
+import { env } from "@/env";
 import { createLogger } from "@/lib/logger";
 import { isQueueHealthy } from "@/lib/queue";
-import { s3Client, S3_BUCKET } from "@/lib/storage/s3-client";
+import { S3_BUCKET, s3Client } from "@/lib/storage/s3-client";
 import { valkey } from "@/lib/valkey";
 
 const logger = createLogger("Health");
@@ -167,6 +168,18 @@ export async function checkHealth(): Promise<HealthCheckResult> {
  */
 export async function runStartupChecks(): Promise<boolean> {
 	logger.info("Running startup health checks...");
+	logger.info(
+		{
+			environment: env.NODE_ENV,
+			buildHash: env.NEXT_PUBLIC_BUILD_HASH ?? "unknown",
+			appUrlConfigured: Boolean(env.APP_URL || env.NEXT_PUBLIC_APP_URL),
+			mainDomainConfigured: Boolean(env.MAIN_DOMAIN),
+			valkeyConfigured: Boolean(env.VALKEY_HOST || env.REDIS_HOST),
+			turnstileConfigured: Boolean(env.TURNSTILE_SITE_KEY),
+			billingEnabled: env.BILLING_ENABLED === "true",
+		},
+		"Startup configuration summary",
+	);
 
 	const result = await checkHealth();
 
@@ -208,8 +221,7 @@ export async function runStartupChecks(): Promise<boolean> {
 
 	// Return true only if database AND storage are healthy (cache is optional)
 	const success =
-		result.services.database.status === "healthy" &&
-		result.services.storage.status === "healthy";
+		result.services.database.status === "healthy" && result.services.storage.status === "healthy";
 
 	if (success) {
 		logger.info({ status: result.status }, "Startup checks completed");

--- a/infra/hetzner-k8s/k8s/app/migration-job.yaml
+++ b/infra/hetzner-k8s/k8s/app/migration-job.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: migrate
           image: ghcr.io/umami-creative-gmbh/z8-migration:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: VALKEY_HOST
               value: valkey

--- a/infra/hetzner-k8s/k8s/app/web-deployment.yaml
+++ b/infra/hetzner-k8s/k8s/app/web-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: web
           image: ghcr.io/umami-creative-gmbh/z8-webapp:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: VALKEY_HOST
               value: valkey

--- a/infra/hetzner-k8s/k8s/app/web-forwarded-headers-middleware.yaml
+++ b/infra/hetzner-k8s/k8s/app/web-forwarded-headers-middleware.yaml
@@ -1,0 +1,10 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: web-forwarded-headers
+  namespace: app-prod
+spec:
+  headers:
+    customRequestHeaders:
+      X-Forwarded-Host: ui.z8-time.app
+      X-Forwarded-Proto: https

--- a/infra/hetzner-k8s/k8s/app/web-ingress.yaml
+++ b/infra/hetzner-k8s/k8s/app/web-ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: app-prod
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: app-prod-web-forwarded-headers@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:

--- a/infra/hetzner-k8s/k8s/app/worker-deployment.yaml
+++ b/infra/hetzner-k8s/k8s/app/worker-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: worker
           image: ghcr.io/umami-creative-gmbh/z8-worker:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: VALKEY_HOST
               value: valkey

--- a/infra/hetzner-k8s/k8s/kustomization.yaml
+++ b/infra/hetzner-k8s/k8s/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - app/web-service.yaml
   - app/marketing-service.yaml
   - app/telemetry-service.yaml
+  - app/web-forwarded-headers-middleware.yaml
   - app/www-redirect-middleware.yaml
   - app/web-ingress.yaml
   - app/marketing-ingress.yaml


### PR DESCRIPTION
## Summary
- show the current build hash in the auth footer so production deployments are easier to identify
- add production auth diagnostics around `/init` session resolution and organization switching
- update the Kubernetes web ingress/deploy manifests to always pull fresh images and apply forwarded header middleware