### PR TITLE
fix(ci): pass webapp build hash into docker builds

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -54,6 +54,8 @@ jobs:
           context: .
           file: ./Dockerfile
           target: webapp
+          build-args: |
+            NEXT_PUBLIC_BUILD_HASH=${{ github.sha }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/umami-creative-gmbh/z8-webapp,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@
 ARG NODE_VERSION=22
 ARG PNPM_VERSION=10.28.0
 ARG ALPINE_VERSION=3.21
+ARG NEXT_PUBLIC_BUILD_HASH
 
 # =============================================================================
 # Stage 1: base - Alpine runtime with Node.js and pnpm
@@ -105,6 +106,9 @@ COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 # Stage 5: webapp-builder - Build Next.js webapp
 # =============================================================================
 FROM workspace AS webapp-builder
+
+ARG NEXT_PUBLIC_BUILD_HASH
+ENV NEXT_PUBLIC_BUILD_HASH=${NEXT_PUBLIC_BUILD_HASH}
 
 # Generate license report (required by build script)
 RUN pnpm --filter webapp run generate-licenses || echo "{}" > apps/webapp/src/data/licenses.json

--- a/apps/webapp/next.config.ts
+++ b/apps/webapp/next.config.ts
@@ -1,5 +1,5 @@
+import { execFileSync } from "node:child_process";
 import path from "node:path";
-import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
@@ -20,9 +20,10 @@ function getBuildHash() {
 	}
 
 	try {
-		return execSync("git rev-parse --short HEAD", {
+		return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
 			cwd: workspaceRoot,
 			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
 		}).trim();
 	} catch {
 		return "dev";


### PR DESCRIPTION
## Summary
- pass the GitHub commit SHA into the webapp Docker build so production images get a stable build version
- expose the build hash in the Docker webapp builder stage before `next build`
- make the Next.js fallback hash lookup fail quietly when `git` is unavailable in CI