### PR TITLE
fix(logging): disable otel transport without exporter

### DIFF
--- a/apps/webapp/src/lib/logger.ts
+++ b/apps/webapp/src/lib/logger.ts
@@ -1,23 +1,27 @@
 import { trace } from "@opentelemetry/api";
 import pino from "pino";
-import { env } from "@/env";
 
 const isDev = process.env.NODE_ENV === "development";
+const hasRemoteOtel = Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT);
+
+const transport = isDev
+	? {
+			target: "pino-pretty",
+			options: {
+				colorize: true,
+				translateTime: "HH:MM:ss Z",
+				ignore: "pid,hostname",
+			},
+		}
+	: hasRemoteOtel
+		? {
+				target: "pino-opentelemetry-transport",
+			}
+		: undefined;
 
 export const logger = pino({
 	level: process.env.LOG_LEVEL || (isDev ? "debug" : "info"),
-	transport: isDev
-		? {
-				target: "pino-pretty",
-				options: {
-					colorize: true,
-					translateTime: "HH:MM:ss Z",
-					ignore: "pid,hostname",
-				},
-			}
-		: {
-				target: "pino-opentelemetry-transport",
-			},
+	transport,
 	mixin() {
 		const span = trace.getActiveSpan();
 		if (!span) return {};


### PR DESCRIPTION
## Summary
- avoid enabling the OpenTelemetry pino transport unless an OTLP exporter endpoint is configured
- fall back to plain structured production logs when remote OTEL export is not configured
- prevent login-path diagnostics from tripping the broken stream transport in production