### PR TITLE
fix(payroll-export): expose successfactors credential state

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/actions.ts
@@ -639,6 +639,7 @@ export interface SuccessFactorsConfigResult {
 	formatId: string;
 	config: SuccessFactorsConfig;
 	isActive: boolean;
+	hasCredentials: boolean;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -683,11 +684,25 @@ export async function getSuccessFactorsConfigAction(
 			return null;
 		}
 
+		const hasCredentials = yield* _(
+			Effect.promise(async () => {
+				const clientId = await getOrgSecret(organizationId, SF_VAULT_KEY_CLIENT_ID);
+				const clientSecret = await getOrgSecret(organizationId, SF_VAULT_KEY_CLIENT_SECRET);
+				return (
+					clientId !== null &&
+					clientSecret !== null &&
+					clientId.trim().length > 0 &&
+					clientSecret.trim().length > 0
+				);
+			}),
+		);
+
 		return {
 			id: configResult.config.id,
 			formatId: configResult.config.formatId,
 			config: configResult.config.config as unknown as SuccessFactorsConfig,
 			isActive: configResult.config.isActive,
+			hasCredentials,
 			createdAt: configResult.config.createdAt,
 			updatedAt: configResult.config.updatedAt,
 		};
@@ -805,6 +820,22 @@ export async function saveSuccessFactorsConfigAction(
 			}),
 		);
 
+		const hasCredentials = yield* _(
+			Effect.promise(async () => {
+				const clientId = await getOrgSecret(input.organizationId, SF_VAULT_KEY_CLIENT_ID);
+				const clientSecret = await getOrgSecret(
+					input.organizationId,
+					SF_VAULT_KEY_CLIENT_SECRET,
+				);
+				return (
+					clientId !== null &&
+					clientSecret !== null &&
+					clientId.trim().length > 0 &&
+					clientSecret.trim().length > 0
+				);
+			}),
+		);
+
 		revalidatePath("/settings/payroll-export");
 
 		return {
@@ -812,6 +843,7 @@ export async function saveSuccessFactorsConfigAction(
 			formatId: config.formatId,
 			config: config.config as unknown as SuccessFactorsConfig,
 			isActive: config.isActive,
+			hasCredentials,
 			createdAt: config.createdAt,
 			updatedAt: config.updatedAt,
 		};

--- a/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/settings/payroll-export/page.tsx
@@ -27,6 +27,11 @@ import {
 	getExportHistoryAction,
 } from "./actions";
 
+type ExportAvailabilityEntry = {
+	configured: boolean;
+	reason: "missingConfiguration" | "missingCredentials" | null;
+};
+
 async function PayrollExportContent() {
 	await connection(); // Mark as fully dynamic
 
@@ -68,7 +73,7 @@ async function PayrollExportContent() {
 	const successFactorsConfig = successFactorsConfigResult.success ? successFactorsConfigResult.data : null;
 	const workdayConfig = workdayConfigResult.success ? workdayConfigResult.data : null;
 	const exports = historyResult.success ? historyResult.data : [];
-	const exportAvailability = {
+	const exportAvailability: Record<string, ExportAvailabilityEntry> = {
 		datev_lohn: {
 			configured: Boolean(datevConfig),
 			reason: datevConfig ? null : "missingConfiguration",


### PR DESCRIPTION
## Summary
- return SuccessFactors `hasCredentials` from payroll export actions so the settings page can correctly enable API exports
- keep export availability typing narrow in the payroll export page to avoid build-time type widening
- fix the reported Next.js build failure in payroll export settings