### PR TITLE
Add Clockin import workflow and stabilize webapp operations

### DIFF
--- a/.agents/skills/z8-k8s-deployment/SKILL.md
+++ b/.agents/skills/z8-k8s-deployment/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: z8-k8s-deployment
+description: Manage the Z8 Kubernetes deployment, manifests, and Hetzner infrastructure for this repo. Use this whenever the user asks to refresh GHCR images, rollout restart workloads, scale deployments, rerun `drizzle-migrate`, update ingress or Traefik middleware, manage RustFS routes, inspect cert-manager or rollout state, or make Hetzner/OpenTofu changes for the existing cluster. Prefer this skill even if the user only mentions `kubectl`, `app-prod`, `drizzle-migrate`, `kubeconfig.recovered.yaml`, Traefik, ingress, middleware, RustFS, `rustfs.z8-time.app`, `s3.z8-time.app`, telemetry, marketing, cert-manager, GHCR, Hetzner, `hcloud`, `tofu`, or deployment refreshes without explicitly asking for a “skill.”
+---
+
+# Z8 K8s Deployment
+
+Operate the Z8 production cluster using the repo's real deployment workflow.
+
+This skill is repo-specific. It is not a generic Kubernetes tutorial. Use the repo layout, existing manifests, current workload names, and the live verification patterns already used in this codebase.
+
+## What this skill covers
+
+- Refresh `web`, `worker`, and `drizzle-migrate` images from GHCR
+- Restart, scale, and inspect workloads in `app-prod`
+- Recreate and verify migration jobs
+- Add or modify Kubernetes manifests under `infra/hetzner-k8s/k8s`
+- Manage Traefik ingress, middleware, cert-manager, RustFS, and related routing changes
+- Inspect cluster state with `kubectl`
+- Perform Hetzner/OpenTofu operations for the existing cluster under `infra/hetzner-k8s/tofu`
+
+## Hard safety rules
+
+- Never store tokens, private keys, kubeconfig contents, or secret values in the skill.
+- Never hardcode credentials into manifests, docs, or commands.
+- Never print secret values unless the user explicitly asks to inspect an existing secret.
+- Never guess missing credentials. Report exactly which environment variables are required.
+- Prefer the least destructive path. Inspect first, change second, verify third.
+- For persistent config changes, update manifests first. Use direct `kubectl` operations for day-2 actions like restarts, scaling, and one-off migration reruns.
+- For destructive infra actions such as deleting Hetzner resources, tearing down OpenTofu state, or removing cluster resources, stop and ask only if the action is irreversible or ambiguous.
+
+## Prerequisites
+
+### Tools
+
+- `kubectl` for cluster operations
+- `hcloud` for Hetzner inspection or changes
+- `tofu` or `terraform` for repo-managed infra changes
+- `gh` for GitHub PR/package checks when needed
+
+### Environment variables
+
+- `KUBECONFIG` (optional)
+  - Use when the user wants an explicit kubeconfig or the repo-default path should be overridden.
+- `HCLOUD_TOKEN` (required for Hetzner or OpenTofu actions)
+  - Needed for `hcloud` and repo infra changes under `infra/hetzner-k8s/tofu`.
+- `GH_TOKEN` (optional)
+  - Needed when GitHub package or PR inspection requires authenticated access.
+
+### Repo defaults
+
+- Kubernetes manifests live in `infra/hetzner-k8s/k8s`
+- Hetzner/OpenTofu lives in `infra/hetzner-k8s/tofu`
+- A repo-local kubeconfig path may exist at `infra/hetzner-k8s/kubeconfig.recovered.yaml`
+
+If a task needs cluster access and `KUBECONFIG` is unset, first check whether the repo-local kubeconfig exists. Use the path only; never print its contents.
+
+## Repo map
+
+Use these paths as your first stop:
+
+- `infra/hetzner-k8s/k8s/kustomization.yaml` - top-level app manifest set
+- `infra/hetzner-k8s/k8s/app/web-deployment.yaml` - web deployment
+- `infra/hetzner-k8s/k8s/app/worker-deployment.yaml` - worker deployment
+- `infra/hetzner-k8s/k8s/app/migration-job.yaml` - migration job
+- `infra/hetzner-k8s/k8s/app/web-ingress.yaml` - UI ingress
+- `infra/hetzner-k8s/k8s/app/marketing-ingress.yaml` - marketing ingress
+- `infra/hetzner-k8s/k8s/app/rustfs.yaml` - RustFS service, deployment, and ingress resources
+- `infra/hetzner-k8s/tofu/main.tf` - Hetzner cluster topology
+- `infra/hetzner-k8s/tofu/variables.tf` - required infra inputs
+
+## Execution modes
+
+Classify every request before acting.
+
+### 1. Inspect
+
+Use for read-only tasks.
+
+Examples:
+- check current pod image digests
+- inspect ingress, certificates, or middleware
+- verify whether a deployment rolled out
+- inspect Hetzner cluster resources
+
+Workflow:
+1. Verify tool access.
+2. Gather current state.
+3. Summarize concrete resource names, live status, and blockers.
+
+### 2. Operate
+
+Use for day-2 cluster operations.
+
+Examples:
+- refresh latest GHCR images
+- rollout restart `web` and `worker`
+- rerun `drizzle-migrate`
+- scale a deployment
+- apply manifest changes under `infra/hetzner-k8s/k8s`
+
+Workflow:
+1. Inspect current state first.
+2. Update manifests if the change should persist.
+3. Apply or operate with `kubectl`.
+4. Verify rollout, job completion, ingress state, cert state, or image digests.
+
+### 3. Infra
+
+Use for Hetzner/OpenTofu changes.
+
+Examples:
+- update server/network/load balancer/firewall settings
+- inspect SSH key usage in Hetzner
+- review OpenTofu-managed cluster inputs
+
+Workflow:
+1. Confirm `HCLOUD_TOKEN` is available.
+2. Inspect current infra or run a plan first.
+3. Prefer `tofu plan` before `tofu apply` when changing repo-managed infra.
+4. Verify resulting Hetzner resources after the change.
+
+## Core playbooks
+
+### Refresh web, worker, and migration images
+
+Use this when the user says a new image was published to GHCR.
+
+1. Restart `deployment/web` and `deployment/worker` in `app-prod`.
+2. Wait for both rollouts to complete.
+3. Delete and recreate `job/drizzle-migrate` from `infra/hetzner-k8s/k8s/app/migration-job.yaml`.
+4. Wait for the job to complete.
+5. Report the live image digests for `web`, `worker`, and the migration pod.
+
+Why: `:latest` tags only become real after new pods are created, and the migration job must be recreated to pull the new image.
+
+### Scale workloads
+
+1. Inspect the current deployment state.
+2. Scale the deployment to the requested replica count.
+3. Wait for rollout or readiness.
+4. Report the resulting deployment status and pods.
+
+### Apply manifest changes
+
+1. Edit files under `infra/hetzner-k8s/k8s`.
+2. Prefer `kubectl apply -k infra/hetzner-k8s/k8s` when the resource is part of the kustomization.
+3. If a resource is intentionally outside `kustomization.yaml`, apply that file directly and say so.
+4. Verify the live resources after apply.
+
+### Ingress, Traefik middleware, and cert-manager changes
+
+1. Inspect existing ingress and middleware before changing them.
+2. Keep middleware and ingress wiring explicit in manifests.
+3. After apply, verify:
+   - ingress host/path rules
+   - attached middleware
+   - certificate readiness when TLS hosts changed
+4. If routing fails, inspect the live ingress YAML, middleware, service ports, and cert-manager resources before proposing a fix.
+
+### RustFS changes
+
+1. Treat `infra/hetzner-k8s/k8s/app/rustfs.yaml` as the source of truth.
+2. Distinguish between:
+   - S3 API route (`9000`)
+   - Web UI route (`9001`)
+3. If the Web UI is exposed publicly, use IP allowlist middleware unless the user explicitly wants it open.
+4. Verify both ingress resources and certificate status after changes.
+
+### Hetzner/OpenTofu changes
+
+1. Inspect `infra/hetzner-k8s/tofu/main.tf` and `variables.tf` first.
+2. Use `tofu plan` before `tofu apply` for repo-managed changes.
+3. Use `hcloud` for live inspection or for tasks outside the current OpenTofu state only when appropriate.
+4. Report which env vars were required and whether they were present.
+
+## Failure investigation
+
+If an operation fails, gather evidence before changing anything else.
+
+Examples of evidence to collect:
+- `kubectl get deployment,pods,job,ingress,svc -n app-prod`
+- rollout status and pod image IDs
+- relevant workload logs
+- ingress and middleware YAML
+- certificate, challenge, and order status
+- Hetzner resource lists or `tofu plan` output
+
+Do not guess. Identify the failing layer first: image pull, rollout, service routing, TLS issuance, or infra provisioning.
+
+## Verification checklist
+
+Always verify based on the task type.
+
+### After deployment refresh
+
+- rollout completed
+- new pods running
+- image digests reported
+
+### After migration rerun
+
+- job recreated
+- job reached `Complete`
+- latest migration image reported
+
+### After scaling
+
+- deployment shows requested replicas
+- pods are ready or explain why not
+
+### After ingress or middleware updates
+
+- manifests applied successfully
+- ingress and middleware visible live
+- TLS certificate status checked when relevant
+
+### After infra changes
+
+- `tofu plan/apply` or `hcloud` result summarized
+- changed Hetzner resources confirmed live
+
+## Output style
+
+Report concise, concrete results:
+- what changed
+- what commands/actions were taken
+- what is now live
+- any blockers or missing prerequisites
+
+Always include exact resource names and, for refreshed images, the live image digests.
+
+## Missing prerequisite behavior
+
+If a task cannot proceed because of missing env vars or tools, do all safe read-only work first, then report the exact missing prerequisite.
+
+Examples:
+- "Need `HCLOUD_TOKEN` to inspect Hetzner SSH keys."
+- "Need `kubectl` and a valid kubeconfig to refresh app-prod workloads."
+- "Need authenticated GitHub access via `GH_TOKEN` for private package metadata."
+
+## Example prompts this skill should handle
+
+- "refresh webapp, worker and migration from the latest GH image"
+- "scale marketing to 0 and verify it stayed down"
+- "add an IP allowlist to the rustfs webui ingress"
+- "route telemetry through Traefik to an external VM and verify TLS"
+- "check which Hetzner ssh keys can access the control planes"
+- "update the k8s deployment and pull the newest webapp images"

--- a/.agents/skills/z8-k8s-deployment/evals/evals.json
+++ b/.agents/skills/z8-k8s-deployment/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "z8-k8s-deployment",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "there is a new image on gh refresh webapp, migration and worker. do not execute anything yet - inspect this repo and tell me the exact safe sequence of commands and checks you would run in this environment, including how you would verify live digests afterwards",
+      "expected_output": "Inspects the repo-specific deployment workflow, proposes the correct web/worker restart plus migration-job recreation sequence, and includes concrete verification steps for live image digests without executing the changes.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "i want rustfs.z8-time.app restricted to office ips. do not apply anything yet - inspect the manifests in this repo and tell me exactly which files you would change, what resources you would add, and how you would verify ingress and certificate state afterwards",
+      "expected_output": "Finds the RustFS manifest source of truth, proposes an ingress plus Traefik IP allowlist update, and explains the post-change ingress and cert-manager verification steps without touching the cluster.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "check whether the current hetzner setup uses the ssh key i just mentioned for the control planes. inspect the repo first, do not guess, and if live hetzner access is required tell me exactly which env var is missing",
+      "expected_output": "Uses the repo-managed Hetzner/OpenTofu context first, distinguishes repo knowledge from live cloud state, and explicitly names `HCLOUD_TOKEN` if live verification is required.",
+      "files": []
+    }
+  ]
+}

--- a/apps/webapp/src/lib/rate-limit.ts
+++ b/apps/webapp/src/lib/rate-limit.ts
@@ -15,7 +15,7 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { createLogger } from "@/lib/logger";
-import { valkey } from "@/lib/valkey";
+import { ensureValkeyReady, valkey } from "@/lib/valkey";
 import { env } from "@/env";
 
 /**
@@ -238,7 +238,7 @@ export async function checkRateLimit(
 		}
 
 		// Check if Valkey is available
-		if (valkey.status !== "ready") {
+		if (!(await ensureValkeyReady())) {
 			logger.warn({ identifier, endpoint }, "Rate limiting unavailable - Valkey not connected");
 			return {
 				allowed: true,

--- a/apps/webapp/src/lib/rate-limit.ts
+++ b/apps/webapp/src/lib/rate-limit.ts
@@ -64,6 +64,89 @@ function parseRateLimitEnv(
 
 const logger = createLogger("RateLimit");
 
+const SLIDING_WINDOW_LIMIT_SCRIPT = `
+  local currentKey  = KEYS[1]           -- identifier including prefixes
+  local previousKey = KEYS[2]           -- key of the previous bucket
+  local dynamicLimitKey = KEYS[3]       -- optional: key for dynamic limit in redis
+  local tokens      = tonumber(ARGV[1]) -- default tokens per window
+  local now         = ARGV[2]           -- current timestamp in milliseconds
+  local window      = ARGV[3]           -- interval in milliseconds
+  local incrementBy = tonumber(ARGV[4]) -- increment rate per request at a given value, default is 1
+
+  -- Check for dynamic limit
+  local effectiveLimit = tokens
+  if dynamicLimitKey ~= "" then
+    local dynamicLimit = redis.call("GET", dynamicLimitKey)
+    if dynamicLimit then
+      effectiveLimit = tonumber(dynamicLimit)
+    end
+  end
+
+  local requestsInCurrentWindow = redis.call("GET", currentKey)
+  if requestsInCurrentWindow == false then
+    requestsInCurrentWindow = 0
+  end
+
+  local requestsInPreviousWindow = redis.call("GET", previousKey)
+  if requestsInPreviousWindow == false then
+    requestsInPreviousWindow = 0
+  end
+  local percentageInCurrent = ( now % window ) / window
+  -- weighted requests to consider from the previous window
+  requestsInPreviousWindow = math.floor(( 1 - percentageInCurrent ) * requestsInPreviousWindow)
+
+  -- Only check limit if not refunding (negative rate)
+  if incrementBy > 0 and requestsInPreviousWindow + requestsInCurrentWindow >= effectiveLimit then
+    return {-1, effectiveLimit}
+  end
+
+  local newValue = redis.call("INCRBY", currentKey, incrementBy)
+  if newValue == incrementBy then
+    -- The first time this key is set, the value will be equal to incrementBy.
+    -- So we only need the expire command once
+    redis.call("PEXPIRE", currentKey, window * 2 + 1000) -- Enough time to overlap with a new window + 1 second
+  end
+  return {effectiveLimit - ( newValue + requestsInPreviousWindow ), effectiveLimit}
+`;
+
+let slidingWindowScriptLoaded = false;
+let slidingWindowScriptLoadPromise: Promise<void> | null = null;
+
+valkey.on("connect", () => {
+	slidingWindowScriptLoaded = false;
+	slidingWindowScriptLoadPromise = null;
+});
+
+export async function ensureRateLimitRedisReady(): Promise<boolean> {
+	if (!(await ensureValkeyReady())) {
+		return false;
+	}
+
+	if (slidingWindowScriptLoaded) {
+		return true;
+	}
+
+	if (!slidingWindowScriptLoadPromise) {
+		slidingWindowScriptLoadPromise = valkey
+			.script("LOAD", SLIDING_WINDOW_LIMIT_SCRIPT)
+			.then(() => {
+				slidingWindowScriptLoaded = true;
+			})
+			.catch((error) => {
+				slidingWindowScriptLoadPromise = null;
+				throw error;
+			});
+	}
+
+	try {
+		await slidingWindowScriptLoadPromise;
+		return true;
+	} catch (error) {
+		logger.warn({ error }, "Failed to preload rate limiting script");
+		return false;
+	}
+}
+
 /**
  * Minimal Redis interface required by @upstash/ratelimit
  * Includes both evalsha and eval for NOSCRIPT fallback handling
@@ -238,7 +321,7 @@ export async function checkRateLimit(
 		}
 
 		// Check if Valkey is available
-		if (!(await ensureValkeyReady())) {
+		if (!(await ensureRateLimitRedisReady())) {
 			logger.warn({ identifier, endpoint }, "Rate limiting unavailable - Valkey not connected");
 			return {
 				allowed: true,

--- a/apps/webapp/src/lib/teams/commands/middleware/rate-limit.middleware.ts
+++ b/apps/webapp/src/lib/teams/commands/middleware/rate-limit.middleware.ts
@@ -7,8 +7,8 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { createLogger } from "@/lib/logger";
-import { ensureValkeyReady, valkey } from "@/lib/valkey";
-import { isRateLimitDisabled } from "@/lib/rate-limit";
+import { valkey } from "@/lib/valkey";
+import { ensureRateLimitRedisReady, isRateLimitDisabled } from "@/lib/rate-limit";
 import type { BotCommandContext, BotCommandResponse } from "../../types";
 
 const logger = createLogger("TeamsRateLimit");
@@ -166,7 +166,7 @@ export async function checkCommandRateLimit(
 		}
 
 		// Check Valkey connection
-		if (!(await ensureValkeyReady())) {
+		if (!(await ensureRateLimitRedisReady())) {
 			logger.warn({ commandName }, "Rate limiting unavailable - Valkey not connected");
 			return {
 				allowed: true,

--- a/apps/webapp/src/lib/teams/commands/middleware/rate-limit.middleware.ts
+++ b/apps/webapp/src/lib/teams/commands/middleware/rate-limit.middleware.ts
@@ -7,7 +7,7 @@
 
 import { Ratelimit } from "@upstash/ratelimit";
 import { createLogger } from "@/lib/logger";
-import { valkey } from "@/lib/valkey";
+import { ensureValkeyReady, valkey } from "@/lib/valkey";
 import { isRateLimitDisabled } from "@/lib/rate-limit";
 import type { BotCommandContext, BotCommandResponse } from "../../types";
 
@@ -166,7 +166,7 @@ export async function checkCommandRateLimit(
 		}
 
 		// Check Valkey connection
-		if (valkey.status !== "ready") {
+		if (!(await ensureValkeyReady())) {
 			logger.warn({ commandName }, "Rate limiting unavailable - Valkey not connected");
 			return {
 				allowed: true,

--- a/apps/webapp/src/lib/valkey.ts
+++ b/apps/webapp/src/lib/valkey.ts
@@ -28,6 +28,18 @@ const globalForValkey = globalThis as unknown as {
 	valkeyPub: Redis | undefined;
 };
 
+type ValkeyStatus = Redis["status"];
+
+const activeStatuses = new Set<ValkeyStatus>(["ready", "connect", "connecting"]);
+
+function isAlreadyConnectingError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.message.includes("already connecting") ||
+			error.message.includes("Connection is closed"))
+	);
+}
+
 function createValkeyClient(): Redis {
 	const host = env.VALKEY_HOST || env.REDIS_HOST || "localhost";
 	const port = Number(env.VALKEY_PORT || env.REDIS_PORT || 6379);
@@ -69,16 +81,51 @@ function createValkeyClient(): Redis {
 
 export const valkey = shouldDisableValkeyDuringBuild
 	? noopValkeyClient
-	: globalForValkey.valkey ?? createValkeyClient();
+	: (() => {
+		if (!globalForValkey.valkey) {
+			globalForValkey.valkey = createValkeyClient();
+		}
+
+		return globalForValkey.valkey;
+	})();
 
 // Dedicated publisher client for pub/sub (pub/sub clients can't be used for regular commands)
 export const valkeyPub = shouldDisableValkeyDuringBuild
 	? noopValkeyClient
-	: globalForValkey.valkeyPub ?? createValkeyClient();
+	: (() => {
+		if (!globalForValkey.valkeyPub) {
+			globalForValkey.valkeyPub = createValkeyClient();
+		}
 
-if (env.NODE_ENV !== "production") {
-	globalForValkey.valkey = valkey;
-	globalForValkey.valkeyPub = valkeyPub;
+		return globalForValkey.valkeyPub;
+	})();
+
+export async function ensureValkeyReady(): Promise<boolean> {
+	if (shouldDisableValkeyDuringBuild) {
+		return false;
+	}
+
+	if (activeStatuses.has(valkey.status)) {
+		return true;
+	}
+
+	if (valkey.status === "wait" || valkey.status === "end") {
+		try {
+			await valkey.connect();
+		} catch (error) {
+			if (!isAlreadyConnectingError(error)) {
+				logger.warn({ error, status: valkey.status }, "Failed to start Valkey connection");
+			}
+		}
+	}
+
+	try {
+		await valkey.ping();
+		return true;
+	} catch (error) {
+		logger.warn({ error, status: valkey.status }, "Valkey readiness check failed");
+		return false;
+	}
 }
 
 /**

--- a/docs/plans/2026-03-13-z8-k8s-deployment-skill-design.md
+++ b/docs/plans/2026-03-13-z8-k8s-deployment-skill-design.md
@@ -1,0 +1,170 @@
+# Z8 K8s Deployment Skill Design
+
+**Goal:** Create a repo-specific skill that safely manages Z8's Kubernetes deployments, cluster manifests, and Hetzner-backed infrastructure without embedding secrets.
+
+**Context**
+
+The repository already uses a combined workflow:
+- OpenTofu/Hetzner infrastructure under `infra/hetzner-k8s/tofu`
+- Kubernetes manifests under `infra/hetzner-k8s/k8s`
+- Day-2 operational commands via `kubectl` for rollouts, scaling, migration jobs, ingress checks, and cert verification
+
+The new skill should capture this real workflow instead of teaching generic Kubernetes practices.
+
+## Scope
+
+The skill will cover full infrastructure and deployment management for this repo:
+- Inspect current cluster and workload state
+- Refresh GHCR-based web, worker, and migration workloads
+- Scale deployments and verify rollout results
+- Update and apply manifests for services, ingresses, middleware, jobs, and related app resources
+- Recreate and verify migration jobs
+- Inspect and manage RustFS, Traefik, cert-manager, and deployment-related cluster resources
+- Support Hetzner/OpenTofu operations for the existing cluster layout
+
+The skill will explicitly avoid embedding sensitive values. It will document required environment variables and external prerequisites instead.
+
+## Recommended Skill Shape
+
+Use a single repo-specific skill rather than splitting the workflow across multiple smaller skills.
+
+**Why this approach fits best:**
+- The repo's operational flow already crosses Kubernetes, manifests, and Hetzner infra in one task stream
+- Users frequently ask for mixed tasks such as applying manifests, rolling deployments, re-running jobs, and validating cloud-side state
+- A single skill can encode repo-specific defaults, file locations, and post-change verification without forcing the model to compose multiple generic skills
+
+## Skill Responsibilities
+
+The skill should trigger when users ask to:
+- deploy or refresh images
+- restart workloads
+- rerun migrations
+- scale workloads
+- update/apply k8s manifests
+- add or change ingress, middleware, services, certificates, or RustFS routing
+- inspect rollout status, pods, logs, image digests, cert-manager resources, or cluster health
+- change Hetzner cluster infrastructure already managed in this repo
+
+## Skill Structure
+
+The skill should include these sections:
+
+1. **Trigger description**
+   - Pushy, specific description covering deployment, rollout, migration, ingress, RustFS, Traefik, and Hetzner infra requests.
+
+2. **Environment and tools**
+   - Required or optional env vars
+   - Required CLIs
+   - What happens when any prerequisite is missing
+
+3. **Repo map**
+   - `infra/hetzner-k8s/tofu`
+   - `infra/hetzner-k8s/k8s`
+   - kubeconfig conventions
+   - common manifest files for web, worker, migration, ingress, middleware, and RustFS
+
+4. **Execution modes**
+   - `inspect`
+   - `operate`
+   - `infra`
+
+5. **Safety rules**
+   - secret handling
+   - non-destructive defaults
+   - verification requirements
+
+6. **Task playbooks**
+   - image refresh
+   - migration rerun
+   - scaling
+   - ingress/middleware changes
+   - RustFS routes
+   - OpenTofu/Hetzner changes
+
+7. **Output expectations**
+   - concise report of what changed, what was applied, and what is now live
+
+## Documented Environment Variables
+
+The skill should document, but never store, these values:
+
+- `KUBECONFIG` (optional if using repo-default kubeconfig path)
+  - Used for cluster operations when not relying on the checked-in kubeconfig path convention
+- `HCLOUD_TOKEN`
+  - Required for Hetzner `hcloud` or OpenTofu operations against Hetzner Cloud
+- `GH_TOKEN` (optional)
+  - Needed when inspecting GitHub package metadata, PRs, or private package details beyond unauthenticated access
+
+The skill should state that missing env vars are not fatal unless the requested task actually needs them.
+
+## Expected Workflow
+
+For each task, the skill should guide the model to:
+
+1. Classify the request as `inspect`, `operate`, or `infra`
+2. Check whether required tools and env vars exist
+3. Inspect current state before making changes
+4. Choose the least surprising path:
+   - manifest edits for persistent config changes
+   - direct `kubectl` operations for operational refreshes
+   - Hetzner/OpenTofu commands only for infra-level requests
+5. Perform the change
+6. Verify the result using live cluster or infra state
+7. Report the result with concrete resource names and image digests where relevant
+
+## Safety and Guardrails
+
+The skill should instruct the model to:
+- never write tokens, private keys, or secret values into the skill
+- never print secret values unless the user explicitly asks to inspect an existing secret
+- stop early and list missing prerequisites if required tools or env vars are absent
+- avoid destructive operations like deleting infra, force-applying unsafe changes, or tearing down state unless explicitly requested
+- gather evidence first on failures: rollout state, pods, jobs, ingresses, middleware, certificates, logs, and image IDs as appropriate
+
+## Verification Rules
+
+After each operation, the skill should verify outcomes by default:
+
+- **Deployment refresh**
+  - rollout status
+  - live pod image digests
+
+- **Migration rerun**
+  - job recreated
+  - completion state reached
+
+- **Scaling**
+  - deployment replica counts
+  - pod readiness
+
+- **Ingress/middleware/cert changes**
+  - manifests applied
+  - live ingress and middleware state
+  - certificate issuance state when relevant
+
+- **Hetzner/OpenTofu changes**
+  - `tofu plan/apply` or `hcloud` verification output summarized
+  - resulting resource state reported
+
+## Initial Skill Test Cases
+
+The first evaluation set should include prompts such as:
+- refresh the latest webapp, worker, and migration images and verify live digests
+- add or update ingress and middleware safely, then verify cert-manager status
+- scale a deployment and confirm resulting pod health
+- inspect prerequisites for Hetzner infra changes and clearly report missing env vars instead of guessing
+
+## Implementation Notes
+
+The first version likely only needs a single `SKILL.md`. If the prompt grows too large, split supporting detail into references for:
+- common repo paths
+- env/tool prerequisites
+- playbooks for image refresh, ingress changes, and Hetzner/OpenTofu workflows
+
+## Non-Goals
+
+This skill is not meant to:
+- store credentials
+- replace Phase or Kubernetes secrets handling
+- serve as a generic Kubernetes tutorial disconnected from this repo
+- infer destructive infra intent without explicit user direction

--- a/docs/plans/2026-03-13-z8-k8s-deployment-skill-implementation.md
+++ b/docs/plans/2026-03-13-z8-k8s-deployment-skill-implementation.md
@@ -1,0 +1,63 @@
+# Z8 K8s Deployment Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a repo-specific skill for Z8 that manages Kubernetes day-2 operations, manifest updates, and Hetzner/OpenTofu infrastructure with strong secret-handling guardrails.
+
+**Architecture:** Create a new skill under `.agents/skills/z8-k8s-deployment/` with a single `SKILL.md` that documents trigger conditions, required tools/env vars, repo-specific paths, safe execution modes, operational playbooks, and verification rules. Keep the first version lean and self-contained so it is easy to audit, then add eval prompts in a companion JSON file for future iteration.
+
+**Tech Stack:** Markdown skill format, repo-local Kubernetes manifests, OpenTofu/Hetzner conventions, kubectl/hcloud/gh CLI workflows.
+
+---
+
+### Task 1: Add the skill definition
+
+**Files:**
+- Create: `.agents/skills/z8-k8s-deployment/SKILL.md`
+
+**Step 1: Write the skill frontmatter and trigger description**
+
+Describe the skill as the default choice for Z8 deployment, rollout, migration, ingress, RustFS, Traefik, and Hetzner/OpenTofu tasks.
+
+**Step 2: Add repo map and prerequisites**
+
+Document relevant directories, kubeconfig expectations, required tools, and env vars such as `HCLOUD_TOKEN`, optional `GH_TOKEN`, and `KUBECONFIG`.
+
+**Step 3: Add safe execution modes and playbooks**
+
+Define `inspect`, `operate`, and `infra` flows, with concrete guidance for image refreshes, migration jobs, scaling, ingress updates, RustFS changes, and Hetzner/OpenTofu actions.
+
+**Step 4: Add verification and safety rules**
+
+Require post-change verification, evidence gathering on failures, and strict no-secrets-in-skill handling.
+
+### Task 2: Add starter eval prompts for later skill iteration
+
+**Files:**
+- Create: `.agents/skills/z8-k8s-deployment/evals/evals.json`
+
+**Step 1: Add realistic prompts**
+
+Cover image refreshes, ingress/middleware changes, scaling, and missing-env-var infra inspection behavior.
+
+**Step 2: Keep expected outputs descriptive**
+
+Document what a good run should achieve without overconstraining the first draft.
+
+### Task 3: Validate structure and review content
+
+**Files:**
+- Modify: `.agents/skills/z8-k8s-deployment/SKILL.md`
+- Modify: `.agents/skills/z8-k8s-deployment/evals/evals.json`
+
+**Step 1: Review for secret safety**
+
+Ensure no tokens, keys, or sensitive literal values are present.
+
+**Step 2: Review for repo-specific accuracy**
+
+Confirm paths and workflows match `infra/hetzner-k8s/tofu`, `infra/hetzner-k8s/k8s`, and current kubectl-driven operations.
+
+**Step 3: Summarize next evaluation steps**
+
+Be ready to run iterative skill tests later if the user wants refinement.


### PR DESCRIPTION
## Summary
- add the new Clockin import hub, orchestration layer, duplicate detection, settings UI, and supporting tests/docs so teams can bring Clockin data into Z8 from the app
- add the repo-specific Z8 Kubernetes deployment skill and related design/implementation docs, while also unblocking the typed webapp build changes already on this branch
- harden Valkey-backed rate limiting by reusing global clients, waiting for readiness before enforcement, and preloading the Lua script so production traffic no longer falls back to unavailable/NOSCRIPT states

## Verification
- pnpm --filter webapp test
- production verification in `app-prod` after rollout of `sha-4529ee8` and `sha-3f878f5` confirmed healthy cache connectivity and clean rate-limit logs