### PR TITLE
Refactor Docker image publishing flow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -20,11 +20,10 @@ env:
   DIGEST_ROOT: /tmp/digests
   IMAGE_NAMESPACE: umami-creative-gmbh
   REGISTRY: ghcr.io
-  SHARED_IMAGE: ghcr.io/umami-creative-gmbh/z8-webapp
 
 jobs:
   build-native:
-    name: Build Native (${{ matrix.arch }})
+    name: Build Native (${{ matrix.repository }} ${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
 
@@ -34,10 +33,34 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
+            repository: z8-webapp
             runner: ubuntu-latest
+            target: webapp
           - arch: arm64
             platform: linux/arm64
+            repository: z8-webapp
             runner: ubuntu-24.04-arm
+            target: webapp
+          - arch: amd64
+            platform: linux/amd64
+            repository: z8-worker
+            runner: ubuntu-latest
+            target: worker
+          - arch: arm64
+            platform: linux/arm64
+            repository: z8-worker
+            runner: ubuntu-24.04-arm
+            target: worker
+          - arch: amd64
+            platform: linux/amd64
+            repository: z8-migration
+            runner: ubuntu-latest
+            target: migration
+          - arch: arm64
+            platform: linux/arm64
+            repository: z8-migration
+            runner: ubuntu-24.04-arm
+            target: migration
 
     steps:
       - name: Checkout
@@ -53,19 +76,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push shared runtime by digest
+      - name: Build and push target by digest
         id: build_runtime
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          target: app-runtime
+          target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.SHARED_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.repository }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             NEXT_PUBLIC_BUILD_HASH=${{ github.sha }}
-          cache-from: type=gha,scope=app-runtime-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=app-runtime-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.target }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}-${{ matrix.arch }}
 
       - name: Export digest artifact
         env:
@@ -82,7 +105,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-shared-${{ matrix.arch }}
+          name: digests-${{ matrix.repository }}-${{ matrix.arch }}
           path: ${{ env.DIGEST_ROOT }}/shared/*
           if-no-files-found: error
 
@@ -114,13 +137,13 @@ jobs:
       - name: Download amd64 digest
         uses: actions/download-artifact@v4
         with:
-          name: digests-shared-amd64
+          name: digests-${{ matrix.repository }}-amd64
           path: ${{ env.DIGEST_ROOT }}/amd64
 
       - name: Download arm64 digest
         uses: actions/download-artifact@v4
         with:
-          name: digests-shared-arm64
+          name: digests-${{ matrix.repository }}-arm64
           path: ${{ env.DIGEST_ROOT }}/arm64
 
       - name: Docker metadata
@@ -150,6 +173,6 @@ jobs:
           for tag in $TAGS; do
             docker buildx imagetools create \
               -t "$tag" \
-              "${SHARED_IMAGE}@$AMD64_DIGEST" \
-              "${SHARED_IMAGE}@$ARM64_DIGEST"
+              "${REGISTRY}/${IMAGE_NAMESPACE}/${{ matrix.repository }}@$AMD64_DIGEST" \
+              "${REGISTRY}/${IMAGE_NAMESPACE}/${{ matrix.repository }}@$ARM64_DIGEST"
           done

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -16,6 +16,12 @@ concurrency:
   group: publish-images-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DIGEST_ROOT: /tmp/digests
+  IMAGE_NAMESPACE: umami-creative-gmbh
+  REGISTRY: ghcr.io
+  SHARED_IMAGE: ghcr.io/umami-creative-gmbh/z8-webapp
+
 jobs:
   build-native:
     name: Build Native (${{ matrix.arch }})
@@ -47,63 +53,41 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push all images by digest
-        id: bake
-        uses: docker/bake-action@v6
+      - name: Build and push shared runtime by digest
+        id: build_runtime
+        uses: docker/build-push-action@v6
         with:
-          source: .
-          files: ./docker-bake.hcl
-          set: |
-            *.platform=${{ matrix.platform }}
-            *.cache-from=type=gha,scope=${{ matrix.arch }}
-            *.cache-to=type=gha,mode=max,scope=${{ matrix.arch }}
-            *.provenance=false
-        env:
-          NEXT_PUBLIC_BUILD_HASH: ${{ github.sha }}
+          context: .
+          file: ./Dockerfile
+          target: app-runtime
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.SHARED_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            NEXT_PUBLIC_BUILD_HASH=${{ github.sha }}
+          cache-from: type=gha,scope=app-runtime-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=app-runtime-${{ matrix.arch }}
 
-      - name: Export digest artifacts
+      - name: Export digest artifact
         env:
-          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
+          IMAGE_DIGEST: ${{ steps.build_runtime.outputs.digest }}
         run: |
           set -euo pipefail
-          if [ -z "${BAKE_METADATA}" ]; then
-            echo "::error::bake metadata output is empty"
+          if [ -z "${IMAGE_DIGEST}" ]; then
+            echo "::error::image digest output is empty"
             exit 1
           fi
-          mkdir -p /tmp/digests/webapp /tmp/digests/worker /tmp/digests/migration
-          printf '%s' "$BAKE_METADATA" > /tmp/bake-metadata.json
-          for target in webapp worker migration; do
-            digest=$(jq -r ".\"$target\".\"containerimage.digest\"" /tmp/bake-metadata.json)
-            if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
-              echo "::error::missing digest for target ${target}"
-              exit 1
-            fi
-            touch "/tmp/digests/$target/${digest#sha256:}"
-          done
+          mkdir -p "${DIGEST_ROOT}/shared"
+          touch "${DIGEST_ROOT}/shared/${IMAGE_DIGEST#sha256:}"
 
-      - name: Upload webapp digest
+      - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-webapp-${{ matrix.arch }}
-          path: /tmp/digests/webapp/*
-          if-no-files-found: error
-
-      - name: Upload worker digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-worker-${{ matrix.arch }}
-          path: /tmp/digests/worker/*
-          if-no-files-found: error
-
-      - name: Upload migration digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-migration-${{ matrix.arch }}
-          path: /tmp/digests/migration/*
+          name: digests-shared-${{ matrix.arch }}
+          path: ${{ env.DIGEST_ROOT }}/shared/*
           if-no-files-found: error
 
   publish-manifests:
-    name: Publish Manifests (${{ matrix.image }})
+    name: Publish Manifests (${{ matrix.repository }})
     needs: build-native
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -111,13 +95,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - image: z8-webapp
-            artifact: webapp
-          - image: z8-worker
-            artifact: worker
-          - image: z8-migration
-            artifact: migration
+        repository:
+          - z8-webapp
+          - z8-worker
+          - z8-migration
 
     steps:
       - name: Set up Docker Buildx
@@ -133,20 +114,20 @@ jobs:
       - name: Download amd64 digest
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ matrix.artifact }}-amd64
-          path: /tmp/digests/amd64
+          name: digests-shared-amd64
+          path: ${{ env.DIGEST_ROOT }}/amd64
 
       - name: Download arm64 digest
         uses: actions/download-artifact@v4
         with:
-          name: digests-${{ matrix.artifact }}-arm64
-          path: /tmp/digests/arm64
+          name: digests-shared-arm64
+          path: ${{ env.DIGEST_ROOT }}/arm64
 
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/umami-creative-gmbh/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
@@ -156,20 +137,19 @@ jobs:
 
       - name: Create and push multi-arch manifests
         env:
-          IMAGE_NAME: ghcr.io/umami-creative-gmbh/${{ matrix.image }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
 
-          set -- /tmp/digests/amd64/*
+          set -- "${DIGEST_ROOT}/amd64"/*
           AMD64_DIGEST="sha256:${1##*/}"
 
-          set -- /tmp/digests/arm64/*
+          set -- "${DIGEST_ROOT}/arm64"/*
           ARM64_DIGEST="sha256:${1##*/}"
 
           for tag in $TAGS; do
             docker buildx imagetools create \
               -t "$tag" \
-              "$IMAGE_NAME@$AMD64_DIGEST" \
-              "$IMAGE_NAME@$ARM64_DIGEST"
+              "${SHARED_IMAGE}@$AMD64_DIGEST" \
+              "${SHARED_IMAGE}@$ARM64_DIGEST"
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,250 +1,146 @@
 # syntax=docker/dockerfile:1.4
 
-# =============================================================================
-# Z8 Multi-Stage Dockerfile
-# =============================================================================
-# Builds optimized containers for: webapp, marketing, migration, db-seed, worker
-# Supports both Alpine (debuggable) and Distroless (secure) variants
-#
-# Build targets:
-#   docker build --target webapp -t z8-webapp .
-#   docker build --target marketing -t z8-marketing .
-#   docker build --target webapp-distroless -t z8-webapp:distroless .
-#   docker build --target migration -t z8-migration .
-#   docker build --target db-seed -t z8-db-seed .
-#   docker build --target worker -t z8-worker .
-#   docker build --target worker-distroless -t z8-worker:distroless .
-# =============================================================================
-
-# Build arguments
+ARG ALPINE_VERSION=3.21
 ARG NODE_VERSION=22
 ARG PNPM_VERSION=10.28.0
-ARG ALPINE_VERSION=3.21
+ARG TURBO_VERSION=2.8.10
 ARG NEXT_PUBLIC_BUILD_HASH
 
-# =============================================================================
-# Stage 1: base - Alpine runtime with Node.js and pnpm
-# =============================================================================
+# Shared Node.js toolchain used by the webapp build graph and runtime targets.
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS base
 
-# Install runtime dependencies for native modules
 RUN apk add --no-cache \
+    ca-certificates \
+    curl \
     libc6-compat \
     libstdc++ \
-    ca-certificates \
-    tini \
-    curl
+    tini
 
-# Enable corepack and install pnpm
 ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
-# Configure pnpm global binaries path (required for pnpm add -g)
 ENV PNPM_HOME=/pnpm
-ENV PATH=$PNPM_HOME:$PATH
-RUN mkdir -p "$PNPM_HOME"
-
-# Set production environment
+ENV PATH=${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \
     HOSTNAME=0.0.0.0
 
+RUN mkdir -p "${PNPM_HOME}"
+
 WORKDIR /app
 
-# =============================================================================
-# Stage 2: pruner - Extract webapp workspace using Turbo
-# =============================================================================
-FROM base AS pruner
+# Shared monorepo snapshot used before pruning individual apps.
+FROM base AS turbo-source
 
-# Install turbo globally for workspace pruning
-RUN pnpm add -g turbo@2.8.10
+ARG TURBO_VERSION
+RUN pnpm add -g turbo@${TURBO_VERSION}
 
-# Copy workspace configuration files first (better caching)
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml turbo.json ./
-
-# Copy all workspace packages for turbo prune
 COPY apps ./apps
 COPY packages ./packages
 
-# Prune the monorepo to only webapp and its dependencies
-# This creates a minimal workspace in /app/out
+# Webapp build graph.
+FROM turbo-source AS pruner
 RUN turbo prune webapp --docker
 
-# =============================================================================
-# Stage 3: deps - Install dependencies (cached layer)
-# =============================================================================
 FROM base AS deps
-
-# Copy pruned workspace manifest files
 COPY --from=pruner /app/out/json/ ./
 COPY --from=pruner /app/out/pnpm-lock.yaml ./
-
-# Install all dependencies (including dev for build)
-# Use BuildKit cache mount for pnpm store
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
 
-# =============================================================================
-# Stage 4: workspace - Prepare pruned workspace
-# =============================================================================
 FROM base AS workspace
-
-# Skip strict env validation during image build.
-# Runtime containers still require real environment variables.
 ENV SKIP_ENV_VALIDATION=1
-
-# Copy installed dependencies
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/webapp/node_modules ./apps/webapp/node_modules
-
-# Copy source code from pruned workspace
 COPY --from=pruner /app/out/full/ ./
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 
-# =============================================================================
-# Stage 5: webapp-builder - Build Next.js webapp
-# =============================================================================
 FROM workspace AS webapp-builder
-
 ARG NEXT_PUBLIC_BUILD_HASH
 ENV NEXT_PUBLIC_BUILD_HASH=${NEXT_PUBLIC_BUILD_HASH}
-
-# Generate license report (required by build script)
 RUN pnpm --filter webapp run generate-licenses || echo "{}" > apps/webapp/src/data/licenses.json
-
-# Build the webapp (Turbopack)
 RUN --mount=type=cache,id=next-cache,target=/app/apps/webapp/.next/cache \
     pnpm --filter webapp exec next build
 
-# =============================================================================
-# Stage 6: prod-deps - Production dependencies only
-# =============================================================================
-FROM base AS prod-deps
+# Shared runtime published once and retagged for the webapp, worker, and
+# migration repositories.
+FROM base AS app-runtime
 
-# Copy pruned workspace manifest files
-COPY --from=pruner /app/out/json/ ./
-COPY --from=pruner /app/out/pnpm-lock.yaml ./
-
-# Install production dependencies only
-RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --frozen-lockfile --prod
-
-# =============================================================================
-# Stage 7: webapp - Production Next.js server (Alpine)
-# =============================================================================
-# Note: Using standard build (not standalone) because standalone is not
-# compatible with cacheComponents in Next.js 16. This results in larger
-# images (~500MB vs ~300MB) but ensures full compatibility.
-# =============================================================================
-FROM base AS webapp
-
-# Create non-root user
+RUN pnpm add -g tsx
 RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 nextjs
+    adduser --system --uid 1001 app
 
-# Copy production dependencies
-COPY --from=prod-deps --chown=nextjs:nodejs /app/node_modules ./node_modules
-COPY --from=prod-deps --chown=nextjs:nodejs /app/apps/webapp/node_modules ./apps/webapp/node_modules
+COPY --from=deps --chown=app:nodejs /app/node_modules ./node_modules
+COPY --from=deps --chown=app:nodejs /app/apps/webapp/node_modules ./apps/webapp/node_modules
 
-# Copy built application
-COPY --from=webapp-builder --chown=nextjs:nodejs /app/apps/webapp/.next ./apps/webapp/.next
-COPY --from=workspace --chown=nextjs:nodejs /app/apps/webapp/public ./apps/webapp/public
-COPY --from=workspace --chown=nextjs:nodejs /app/apps/webapp/package.json ./apps/webapp/
-COPY --from=workspace --chown=nextjs:nodejs /app/apps/webapp/next.config.ts ./apps/webapp/
+COPY --from=webapp-builder --chown=app:nodejs /app/apps/webapp/.next ./apps/webapp/.next
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/public ./apps/webapp/public
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/src ./apps/webapp/src
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/scripts ./apps/webapp/scripts
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/drizzle ./apps/webapp/drizzle
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/drizzle.config.ts ./apps/webapp/
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/next.config.ts ./apps/webapp/
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/package.json ./apps/webapp/
+COPY --from=workspace --chown=app:nodejs /app/apps/webapp/tsconfig.json ./apps/webapp/
 
-# Copy workspace config for pnpm/next to work correctly
-COPY --from=workspace --chown=nextjs:nodejs /app/package.json ./
-COPY --from=workspace --chown=nextjs:nodejs /app/pnpm-workspace.yaml ./
+COPY --from=workspace --chown=app:nodejs /app/package.json ./
+COPY --from=workspace --chown=app:nodejs /app/pnpm-workspace.yaml ./
 
 WORKDIR /app/apps/webapp
 
-USER nextjs
+USER app
 
 EXPOSE 3000
 
-# Health check for Kubernetes liveness/readiness probes
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["pnpm", "start"]
+
+FROM app-runtime AS webapp
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3000/api/health || exit 1
 
-# Use tini as PID 1 for proper signal handling
-ENTRYPOINT ["/sbin/tini", "--"]
+FROM app-runtime AS migration
+CMD ["node", "./scripts/migrate-with-lock.js"]
 
-# Start Next.js production server using next start
-CMD ["pnpm", "start"]
+FROM app-runtime AS worker
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.VALKEY_HOST||'localhost',port:process.env.VALKEY_PORT||6379,password:process.env.VALKEY_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
+CMD ["tsx", "src/worker.ts"]
 
-# =============================================================================
-# Note: webapp-distroless stage removed because distroless requires standalone
-# output mode, which is not compatible with cacheComponents in Next.js 16.
-# Use the Alpine-based webapp target instead - it's still secure (non-root user)
-# and only slightly larger.
-# =============================================================================
-
-# =============================================================================
-# Stage 8: marketing - Production Next.js server (Alpine)
-# =============================================================================
-FROM base AS marketing-pruner
-
-# Install turbo globally for workspace pruning
-RUN pnpm add -g turbo@2.8.10
-
-# Copy workspace configuration files first (better caching)
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml turbo.json ./
-
-# Copy all workspace packages for turbo prune
-COPY apps ./apps
-COPY packages ./packages
-
-# Prune the monorepo to only marketing and its dependencies
+# Marketing build graph.
+FROM turbo-source AS marketing-pruner
 RUN turbo prune marketing --docker
 
 FROM base AS marketing-deps
-
-# Copy pruned workspace manifest files
 COPY --from=marketing-pruner /app/out/json/ ./
 COPY --from=marketing-pruner /app/out/pnpm-lock.yaml ./
-
-# Install all dependencies (including dev for build)
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile
 
 FROM base AS marketing-workspace
-
-# Skip strict env validation during image build.
-# Runtime containers still require real environment variables.
 ENV SKIP_ENV_VALIDATION=1
-
-# Copy installed dependencies
 COPY --from=marketing-deps /app/node_modules ./node_modules
 COPY --from=marketing-deps /app/apps/marketing/node_modules ./apps/marketing/node_modules
-
-# Copy source code from pruned workspace
 COPY --from=marketing-pruner /app/out/full/ ./
 COPY --from=marketing-pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 
 FROM marketing-workspace AS marketing-builder
-
-# Build the marketing app
 RUN mkdir -p /app/apps/marketing/public
 RUN --mount=type=cache,id=next-cache-marketing,target=/app/apps/marketing/.next/cache \
     pnpm --filter marketing exec next build
 
-FROM base AS marketing-prod-deps
-
-# Copy pruned workspace manifest files
+FROM base AS marketing-runtime-deps
 COPY --from=marketing-pruner /app/out/json/ ./
 COPY --from=marketing-pruner /app/out/pnpm-lock.yaml ./
-
-# Install production dependencies only
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prod
 
-FROM oven/bun:1.2.22-alpine AS marketing
+FROM oven/bun:1.3.11-alpine AS marketing-base
 
-# Install runtime utilities
-RUN apk add --no-cache tini curl
+RUN apk add --no-cache curl tini
 
-# Set production environment
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \
@@ -252,21 +148,19 @@ ENV NODE_ENV=production \
 
 WORKDIR /app
 
-# Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 marketing
 
-# Copy production dependencies
-COPY --from=marketing-prod-deps --chown=marketing:nodejs /app/node_modules ./node_modules
-COPY --from=marketing-prod-deps --chown=marketing:nodejs /app/apps/marketing/node_modules ./apps/marketing/node_modules
+FROM marketing-base AS marketing
 
-# Copy built application
+COPY --from=marketing-runtime-deps --chown=marketing:nodejs /app/node_modules ./node_modules
+COPY --from=marketing-runtime-deps --chown=marketing:nodejs /app/apps/marketing/node_modules ./apps/marketing/node_modules
+
 COPY --from=marketing-builder --chown=marketing:nodejs /app/apps/marketing/.next ./apps/marketing/.next
 COPY --from=marketing-builder --chown=marketing:nodejs /app/apps/marketing/public ./apps/marketing/public
-COPY --from=marketing-workspace --chown=marketing:nodejs /app/apps/marketing/package.json ./apps/marketing/
 COPY --from=marketing-workspace --chown=marketing:nodejs /app/apps/marketing/next.config.ts ./apps/marketing/
+COPY --from=marketing-workspace --chown=marketing:nodejs /app/apps/marketing/package.json ./apps/marketing/
 
-# Copy workspace config for pnpm/next to work correctly
 COPY --from=marketing-workspace --chown=marketing:nodejs /app/package.json ./
 COPY --from=marketing-workspace --chown=marketing:nodejs /app/pnpm-workspace.yaml ./
 
@@ -276,108 +170,24 @@ USER marketing
 
 EXPOSE 3000
 
-# Health check for Kubernetes liveness/readiness probes
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3000 || exit 1
 
-# Use tini as PID 1 for proper signal handling
 ENTRYPOINT ["/sbin/tini", "--"]
-
-# Start Next.js production server
 CMD ["bun", "x", "next", "start", "-p", "3000"]
 
-# =============================================================================
-# Stage 9: migration - One-shot Drizzle migration runner
-# =============================================================================
-FROM base AS migration
-
-# Copy dependencies (including drizzle-kit)
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/apps/webapp/node_modules ./apps/webapp/node_modules
-
-# Copy webapp files needed for migration execution
-# Include full src to support path aliases (e.g. @/...) when drizzle reads schema files.
-COPY --from=workspace /app/apps/webapp/src ./apps/webapp/src
-COPY --from=pruner /app/apps/webapp/scripts ./apps/webapp/scripts
-COPY --from=pruner /app/apps/webapp/drizzle ./apps/webapp/drizzle
-COPY --from=workspace /app/apps/webapp/drizzle.config.ts ./apps/webapp/
-COPY --from=workspace /app/apps/webapp/package.json ./apps/webapp/
-COPY --from=workspace /app/apps/webapp/tsconfig.json ./apps/webapp/
-
-WORKDIR /app/apps/webapp
-
-# Run migrations under an advisory lock
-# Uses DATABASE_URL if provided, or falls back to POSTGRES_* variables.
-CMD ["node", "./scripts/migrate-with-lock.js"]
-
-# =============================================================================
-# Stage 10: db-seed - One-shot database seeder
-# =============================================================================
+# One-shot database seeder.
 FROM base AS db-seed
 
-# Install tsx for running TypeScript
 RUN pnpm add -g tsx
 
-# Copy dependencies
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/webapp/node_modules ./apps/webapp/node_modules
 
-# Copy database code and seed scripts
 COPY --from=workspace /app/apps/webapp/src ./apps/webapp/src
 COPY --from=workspace /app/apps/webapp/package.json ./apps/webapp/
 COPY --from=workspace /app/apps/webapp/tsconfig.json ./apps/webapp/
 
 WORKDIR /app/apps/webapp
 
-# Run the seeder
 CMD ["tsx", "src/db/seed/do-seed.ts"]
-
-# =============================================================================
-# Stage 11: worker - BullMQ worker with repeatable cron jobs (Alpine)
-# =============================================================================
-FROM base AS worker
-
-# Install tsx for running TypeScript
-RUN pnpm add -g tsx
-
-# Create non-root user
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 worker
-
-# Copy production dependencies
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=prod-deps /app/apps/webapp/node_modules ./apps/webapp/node_modules
-
-# Copy application source (worker needs access to lib modules)
-COPY --from=workspace /app/apps/webapp/src ./apps/webapp/src
-COPY --from=workspace /app/apps/webapp/package.json ./apps/webapp/
-COPY --from=workspace /app/apps/webapp/tsconfig.json ./apps/webapp/
-
-WORKDIR /app/apps/webapp
-
-USER worker
-
-# Health check - verify worker can connect to Redis/Valkey
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.VALKEY_HOST||'localhost',port:process.env.VALKEY_PORT||6379,password:process.env.VALKEY_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
-
-# Use tini as PID 1
-ENTRYPOINT ["/sbin/tini", "--"]
-
-# Start worker process
-CMD ["tsx", "src/worker.ts"]
-
-# =============================================================================
-# Stage 12: worker-distroless - Secure worker variant
-# =============================================================================
-# NOTE: Distroless worker is NOT recommended because:
-# 1. Worker uses tsx to run TypeScript directly
-# 2. Distroless doesn't include tsx or TypeScript runtime
-# 3. Would require a separate compilation step for worker code
-#
-# If you need a distroless worker, pre-compile worker.ts to JavaScript:
-#   tsc apps/webapp/src/worker.ts --outDir apps/webapp/dist
-#   Then use: CMD ["dist/worker.js"]
-#
-# For now, use the Alpine worker target which has full debugging capabilities.
-# The Alpine image is still very small (~280MB) and runs as non-root user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,14 +90,12 @@ COPY --from=workspace --chown=app:nodejs /app/pnpm-workspace.yaml ./
 
 WORKDIR /app/apps/webapp
 
+FROM app-runtime AS webapp
 USER app
-
 EXPOSE 3000
-
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["pnpm", "start"]
 
-FROM app-runtime AS webapp
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3000/api/health || exit 1
 
@@ -105,9 +103,12 @@ FROM app-runtime AS migration
 CMD ["node", "./scripts/migrate-with-lock.js"]
 
 FROM app-runtime AS worker
+USER app
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["tsx", "src/worker.ts"]
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.VALKEY_HOST||'localhost',port:process.env.VALKEY_PORT||6379,password:process.env.VALKEY_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
-CMD ["tsx", "src/worker.ts"]
 
 # Marketing build graph.
 FROM turbo-source AS marketing-pruner


### PR DESCRIPTION
## Summary
- reorganize the Dockerfile around shared build stages while keeping target-specific runtime behavior intact
- pin the marketing runtime to Bun 1.3.11 and preserve separate runtime config for webapp, worker, and migration images
- simplify the publish workflow and keep per-target digests so each GHCR image retains its own command and metadata

## Verification
- docker run --rm -v \"/home/kai/projekte/z8:/work\" -w /work rhysd/actionlint:latest .github/workflows/publish-images.yml
- docker build --target app-runtime --build-arg NEXT_PUBLIC_BUILD_HASH=local-verify -f Dockerfile .
- docker build --target webapp -f Dockerfile .
- docker build --target worker -f Dockerfile .
- docker build --target migration -f Dockerfile .
- docker build --target marketing -f Dockerfile .
- docker inspect checks for webapp, worker, and migration image config