### PR TITLE
fix(build): resolve TypeScript blockers

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/settings/profile/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/profile/actions.ts
@@ -195,7 +195,7 @@ export async function updateProfileDetails(data: {
 			syncActiveEmployeeProfile(
 				dbService,
 				session.user.id,
-				session.session.activeOrganizationId,
+				session.session.activeOrganizationId ?? undefined,
 				result.data,
 			).pipe(
 				Effect.catchAll(() =>

--- a/apps/webapp/src/components/tour/use-app-tour.ts
+++ b/apps/webapp/src/components/tour/use-app-tour.ts
@@ -40,9 +40,7 @@ export function useAppTour({ autoStart = false }: UseAppTourOptions = {}) {
 		// Lazy-load driver.js + CSS only when the tour actually starts
 		const [{ driver }] = await Promise.all([
 			import("driver.js"),
-			// @ts-expect-error -- CSS side-effect import has no type declarations
 			import("driver.js/dist/driver.css"),
-			// @ts-expect-error -- CSS side-effect import has no type declarations
 			import("./driver-theme.css"),
 		]);
 


### PR DESCRIPTION
## Summary
- normalize the profile settings org id before syncing the active employee record so Next.js type checking passes
- remove stale CSS import `@ts-expect-error` directives from the app tour hook so TypeScript no longer fails the production build

## Test Plan
- [x] `pnpm build`