### PR TITLE
Add repo-managed Hetzner multi-key SSH support

### DIFF
--- a/docs/superpowers/plans/2026-03-23-hetzner-multi-key-ssh.md
+++ b/docs/superpowers/plans/2026-03-23-hetzner-multi-key-ssh.md
@@ -1,0 +1,292 @@
+# Hetzner Multi-Key SSH Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose repo-managed support for additional SSH public keys in the Hetzner cluster Terraform wrapper while preserving the existing primary key path workflow.
+
+**Architecture:** Add one new wrapper variable in `infra/hetzner-k8s/tofu/variables.tf`, pass it through to the pinned `kube-hetzner` module in `infra/hetzner-k8s/tofu/main.tf`, and document the intended operator usage in `infra/hetzner-k8s/tofu/terraform.tfvars.example`. Keep the wrapper thin and rely on the upstream module's native `ssh_additional_public_keys` behavior.
+
+**Tech Stack:** OpenTofu/Terraform, Hetzner `kube-hetzner` module, HCL
+
+---
+
+## References To Read First
+
+- `AGENTS.md`
+- `docs/superpowers/specs/2026-03-23-hetzner-multi-key-ssh-design.md`
+- `infra/hetzner-k8s/tofu/main.tf`
+- `infra/hetzner-k8s/tofu/variables.tf`
+- `infra/hetzner-k8s/tofu/terraform.tfvars.example`
+
+## File Map
+
+- Modify: `infra/hetzner-k8s/tofu/variables.tf`
+  - Add the new `ssh_additional_public_keys` input with a safe default and precise description.
+- Modify: `infra/hetzner-k8s/tofu/main.tf`
+  - Pass the new wrapper variable through to `module "kube-hetzner"` next to the existing SSH inputs.
+- Modify: `infra/hetzner-k8s/tofu/terraform.tfvars.example`
+  - Document the supported operator pattern: absolute paths for the primary key pair plus inline public strings for collaborator keys.
+
+## Delivery Notes
+
+- Keep this change scoped to `infra/hetzner-k8s/tofu`; do not touch `infra/hetzner-k8s/k8s`.
+- Do not change the semantics of `ssh_public_key_path` or `ssh_private_key_path` beyond clarifying docs.
+- Use absolute path examples in `terraform.tfvars.example`; do not rely on `~` expansion with `file(...)`.
+- Do not add private key material, kubeconfig contents, or secret values to docs or examples.
+
+## Task 1: Add the new wrapper input and example usage
+
+**Files:**
+- Modify: `infra/hetzner-k8s/tofu/variables.tf`
+- Modify: `infra/hetzner-k8s/tofu/terraform.tfvars.example`
+
+- [ ] **Step 1: Confirm the wrapper does not already expose extra SSH keys**
+
+Run:
+
+```bash
+rg -n "ssh_additional_public_keys" infra/hetzner-k8s/tofu
+```
+
+Expected: no matches.
+
+- [ ] **Step 2: Add the new Terraform variable in `variables.tf`**
+
+Add this block immediately after `ssh_private_key_path` so all SSH inputs stay grouped:
+
+```hcl
+variable "ssh_additional_public_keys" {
+  type        = list(string)
+  default     = []
+  description = "Additional SSH public keys to install on cluster nodes."
+}
+```
+
+- [ ] **Step 3: Update `terraform.tfvars.example` to show the supported operator pattern**
+
+Change the SSH example block to this shape:
+
+```hcl
+ssh_public_key_path  = "/home/operator/.ssh/id_ed25519.pub"
+ssh_private_key_path = "/home/operator/.ssh/id_ed25519"
+
+ssh_additional_public_keys = [
+  "ssh-ed25519 AAAA... teammate-1",
+  "ssh-ed25519 AAAA... teammate-2",
+]
+```
+
+Keep the rest of the example file unchanged.
+
+- [ ] **Step 4: Re-run the search to verify the new input is declared and documented**
+
+Run:
+
+```bash
+rg -n "ssh_additional_public_keys|ssh_public_key_path|ssh_private_key_path" infra/hetzner-k8s/tofu/variables.tf infra/hetzner-k8s/tofu/terraform.tfvars.example
+```
+
+Expected: matches in both files, including the new list example.
+
+- [ ] **Step 5: Commit the input contract change**
+
+```bash
+git add infra/hetzner-k8s/tofu/variables.tf infra/hetzner-k8s/tofu/terraform.tfvars.example
+git commit -m "feat(infra): support additional SSH public keys"
+```
+
+## Task 2: Wire the new input into the `kube-hetzner` module and validate
+
+**Files:**
+- Modify: `infra/hetzner-k8s/tofu/main.tf`
+- Modify: `infra/hetzner-k8s/tofu/variables.tf`
+- Modify: `infra/hetzner-k8s/tofu/terraform.tfvars.example`
+
+- [ ] **Step 1: Confirm the module block does not yet pass the new input**
+
+Run:
+
+```bash
+rg -n "ssh_public_key|ssh_private_key|ssh_additional_public_keys" infra/hetzner-k8s/tofu/main.tf
+```
+
+Expected: only `ssh_public_key` and `ssh_private_key` are present.
+
+- [ ] **Step 2: Add the module pass-through in `main.tf`**
+
+Update the SSH block to this shape:
+
+```hcl
+  ssh_public_key            = file(var.ssh_public_key_path)
+  ssh_private_key           = var.ssh_private_key_path == "" ? null : file(var.ssh_private_key_path)
+  ssh_additional_public_keys = var.ssh_additional_public_keys
+```
+
+Keep the ordering grouped with the existing SSH settings.
+
+- [ ] **Step 3: Format the Terraform files**
+
+Run one of these, depending on which binary is installed locally:
+
+```bash
+tofu -chdir=infra/hetzner-k8s/tofu fmt
+```
+
+or
+
+```bash
+terraform -chdir=infra/hetzner-k8s/tofu fmt
+```
+
+Expected: files are formatted with aligned assignments where appropriate.
+
+- [ ] **Step 4: Initialize the working directory before validation**
+
+Run one of these, depending on which binary is installed locally:
+
+```bash
+tofu -chdir=infra/hetzner-k8s/tofu init
+```
+
+or
+
+```bash
+terraform -chdir=infra/hetzner-k8s/tofu init
+```
+
+Expected: provider and module dependencies are installed successfully.
+
+- [ ] **Step 5: Validate the wrapper configuration**
+
+Run one of these, depending on which binary is installed locally:
+
+```bash
+tofu -chdir=infra/hetzner-k8s/tofu validate
+```
+
+or
+
+```bash
+terraform -chdir=infra/hetzner-k8s/tofu validate
+```
+
+Expected: validation succeeds with no HCL errors.
+
+- [ ] **Step 6: Run the repo-level formatting verification check**
+
+Run one of these, depending on which binary is installed locally:
+
+```bash
+tofu -chdir=infra/hetzner-k8s/tofu fmt -check
+```
+
+or
+
+```bash
+terraform -chdir=infra/hetzner-k8s/tofu fmt -check
+```
+
+Expected: no formatting changes are required.
+
+- [ ] **Step 7: Verify the final diff is scoped correctly**
+
+Run:
+
+```bash
+git diff -- infra/hetzner-k8s/tofu/main.tf infra/hetzner-k8s/tofu/variables.tf infra/hetzner-k8s/tofu/terraform.tfvars.example
+```
+
+Expected: only the new variable, module wiring, and example usage/path clarification appear.
+
+- [ ] **Step 8: Commit the module wiring**
+
+```bash
+git add infra/hetzner-k8s/tofu/main.tf infra/hetzner-k8s/tofu/variables.tf infra/hetzner-k8s/tofu/terraform.tfvars.example
+git commit -m "feat(infra): wire additional cluster SSH keys"
+```
+
+## Task 3: Capture manual post-merge verification guidance without applying infra changes here
+
+**Files:**
+- No repo file changes required.
+
+- [ ] **Step 1: Check infra prerequisites before planning**
+
+Run:
+
+```bash
+test -n "$HCLOUD_TOKEN" && echo "HCLOUD_TOKEN set" || echo "HCLOUD_TOKEN missing"
+command -v tofu || command -v terraform
+```
+
+Expected: `HCLOUD_TOKEN` is set and either `tofu` or `terraform` is installed.
+
+- [ ] **Step 2: Prepare the operator guidance for a manual infra plan**
+
+Use the same real input source the operator normally uses for this cluster, for example a populated `terraform.tfvars`, `*.auto.tfvars`, or explicit `-var-file` arguments that include `ssh_additional_public_keys`.
+
+The manual command the operator should run later is one of these, depending on which binary is installed locally:
+
+```bash
+tofu -chdir=infra/hetzner-k8s/tofu plan
+```
+
+or
+
+```bash
+terraform -chdir=infra/hetzner-k8s/tofu plan
+```
+
+Expected: when the operator runs it with real inputs, the plan uses the cluster's real tfvars and shows only the intended SSH key input-related change.
+
+- [ ] **Step 3: Decide whether the plan includes node replacement or reprovisioning**
+
+Review the manual plan output before any future operator-driven apply.
+
+Expected:
+
+- If the plan includes node replacement or reprovisioning, continue with the end-to-end key verification steps below.
+- If the plan does not touch any nodes, do not claim node-bootstrap verification yet; record that repo wiring is complete and end-to-end verification remains pending until the next intentional node replacement or reprovision.
+
+- [ ] **Step 4: Prepare the operator guidance for post-apply cluster health verification**
+
+Use the operator's normal kubeconfig path or exported `KUBECONFIG` for this cluster. If the repo-local kubeconfig is the standard path in the current environment, use it without printing its contents.
+
+The manual command the operator should run after their own apply path is:
+
+```bash
+kubectl get nodes -o wide
+```
+
+Expected: nodes remain `Ready` after the infra change.
+
+- [ ] **Step 5: Prepare the operator guidance for direct key verification on a replaced node**
+
+Run this against the replaced node name, substituting the exact public key string being added:
+
+```bash
+kubectl debug node/<replaced-node-name> --image=busybox:1.36 --profile=sysadmin --attach=false -- sleep 300
+kubectl exec -n default <debug-pod-name> -- chroot /host sh -lc "grep -qxF 'ssh-ed25519 AAAA... teammate-1' /root/.ssh/authorized_keys"
+kubectl delete pod -n default <debug-pod-name>
+```
+
+Expected: the `grep` exits successfully, proving the replaced node received the additional authorized key from infra-managed bootstrap.
+
+- [ ] **Step 6: Prepare the operator guidance for validating the access path invariant**
+
+The manual checks after any future apply/reprovision must confirm node reachability still uses the cluster's existing private-network or bastion/NAT-router path, not a new public access path.
+
+Expected: verification notes explicitly confirm the SSH path is unchanged except for the additional authorized public key.
+
+- [ ] **Step 7: If no node was replaced, record the verification boundary explicitly**
+
+Expected: the implementation notes state that config wiring is applied, but end-to-end node bootstrap verification is deferred until a future node replacement or reprovision event.
+
+## Final Verification Checklist
+
+- `infra/hetzner-k8s/tofu/variables.tf` defines `ssh_additional_public_keys` with `default = []`
+- `infra/hetzner-k8s/tofu/main.tf` passes `ssh_additional_public_keys = var.ssh_additional_public_keys`
+- `infra/hetzner-k8s/tofu/terraform.tfvars.example` shows absolute primary key paths and inline extra public keys
+- `tofu fmt -check` or `terraform fmt -check` passes
+- `tofu validate` or `terraform validate` passes
+- No secrets, private keys, or kubeconfig contents were added to repo files

--- a/docs/superpowers/specs/2026-03-23-hetzner-multi-key-ssh-design.md
+++ b/docs/superpowers/specs/2026-03-23-hetzner-multi-key-ssh-design.md
@@ -1,0 +1,160 @@
+# Hetzner Multi-Key SSH Design
+
+## Summary
+
+Add repo-managed support for extra SSH public keys in the Hetzner cluster Terraform so the existing primary key workflow remains unchanged while additional operators can retain root access across reprovisioning and node replacement.
+
+## Context
+
+- `infra/hetzner-k8s/tofu/main.tf` currently passes a single primary public key and optional private key into the `kube-hetzner` module.
+- The live cluster needed an emergency one-off key append on all nodes so an additional operator key could access the private cluster nodes.
+- The upstream `kube-hetzner` module version already supports `ssh_additional_public_keys`, but the repo wrapper does not currently expose it.
+- The desired operator model is: keep the primary key path-based for provisioning, and configure collaborator keys as inline public-key strings in tfvars.
+
+## Goals
+
+- Preserve the current primary key provisioning workflow.
+- Add declarative support for one or more additional SSH public keys.
+- Keep reprovisioning and node replacement able to restore all intended operator access automatically.
+- Avoid storing private key material in repo-managed inputs or examples.
+
+## Non-Goals
+
+- No change to Kubernetes manifests under `infra/hetzner-k8s/k8s`.
+- No change to cluster topology, workload configuration, or kubeconfig handling.
+- No custom SSH key sync scripts or node bootstrap hacks.
+- No automatic Hetzner apply in this design; live apply still depends on local tool and credential availability.
+
+## Approved Direction
+
+Use the upstream module's native `ssh_additional_public_keys` support.
+
+Keep:
+
+- `ssh_public_key_path` for the primary public key
+- `ssh_private_key_path` for the matching primary private key, preserving the current wrapper behavior when the path is set or left empty
+
+Add:
+
+- `ssh_additional_public_keys` as a repo variable of type `list(string)` with default `[]`
+
+This gives the repo a minimal, upstream-aligned way to persist collaborator SSH access without disturbing the existing provisioning contract.
+
+## Options Considered
+
+### 1. Recommended: expose upstream `ssh_additional_public_keys`
+
+- Smallest and cleanest change.
+- Uses functionality already provided by the pinned `kube-hetzner` module.
+- Keeps the repo as the source of truth for extra operator access.
+- Preserves the current private-key-based provisioning flow.
+
+### 2. Use Hetzner label-based key selection
+
+- Could reduce key strings stored in tfvars.
+- Makes access dependent on live Hetzner account label state rather than fully repo-declared inputs.
+- Less predictable for disaster recovery or handoff.
+
+### 3. Build a custom key distribution mechanism
+
+- Could support arbitrary future sync logic.
+- Adds complexity, drift risk, and security surface.
+- Unnecessary because the upstream module already covers the needed use case.
+
+## Architecture
+
+### 1. Terraform input shape
+
+Extend `infra/hetzner-k8s/tofu/variables.tf` with:
+
+```hcl
+variable "ssh_additional_public_keys" {
+  type        = list(string)
+  default     = []
+  description = "Additional SSH public keys to install on cluster nodes."
+}
+```
+
+Keep these existing inputs unchanged:
+
+- `hcloud_token`
+- `ssh_public_key_path`
+- `ssh_private_key_path`
+
+### 2. Module wiring
+
+Update `infra/hetzner-k8s/tofu/main.tf` so the local wrapper passes the new list directly into the upstream module:
+
+```hcl
+ssh_public_key           = file(var.ssh_public_key_path)
+ssh_private_key          = var.ssh_private_key_path == "" ? null : file(var.ssh_private_key_path)
+ssh_additional_public_keys = var.ssh_additional_public_keys
+```
+
+The wrapper remains intentionally thin and delegates SSH key installation behavior to the upstream module.
+
+### 3. Example operator configuration
+
+Update `infra/hetzner-k8s/tofu/terraform.tfvars.example` to document the intended usage pattern:
+
+```hcl
+ssh_public_key_path  = "/home/operator/.ssh/id_ed25519.pub"
+ssh_private_key_path = "/home/operator/.ssh/id_ed25519"
+
+ssh_additional_public_keys = [
+  "ssh-ed25519 AAAA... teammate-1",
+  "ssh-ed25519 AAAA... teammate-2",
+]
+```
+
+Use explicit absolute paths in tfvars examples because `file(...)` should not rely on `~` expansion.
+
+This keeps the primary key path-based while making collaborator access self-contained and machine-independent.
+
+## Data Flow
+
+1. The operator sets the primary key paths locally as before.
+2. The operator adds one or more collaborator public keys inline in tfvars.
+3. Terraform passes the primary key plus extra public keys into the `kube-hetzner` module.
+4. The module installs the resulting authorized key set onto provisioned or replaced nodes.
+5. Future node recreation restores both the primary and additional public keys without manual intervention.
+
+## Rollout And Safety
+
+- This is a repo-only Terraform/OpenTofu change under `infra/hetzner-k8s/tofu`.
+- It does not modify Kubernetes workload manifests or running application resources by itself.
+- It preserves the existing primary key behavior to minimize operational disruption.
+- Only public keys are added to the new configuration surface; no private keys or tokens are introduced.
+- Live application of the change should still follow the normal infra workflow: inspect first, then `tofu plan`, then `tofu apply` once prerequisites are present.
+
+## Error Handling
+
+- Default the additional key list to `[]` so existing operators are not forced to change their tfvars immediately.
+- Keep the variable type as `list(string)` so malformed non-list values fail validation early.
+- Avoid custom parsing, file loading, or templating for extra keys to reduce operator mistakes.
+- If a live apply is attempted without `HCLOUD_TOKEN` or `tofu`/`terraform`, stop after safe repo changes and report the missing prerequisite explicitly.
+
+## Testing And Verification
+
+Repo-level verification:
+
+- `terraform fmt -check` or `tofu fmt -check` in `infra/hetzner-k8s/tofu`
+- `terraform validate` or `tofu validate` in `infra/hetzner-k8s/tofu`
+
+Live infra verification after apply:
+
+- Confirm `tofu plan` shows only the intended SSH key related change.
+- Apply with valid `HCLOUD_TOKEN`.
+- Verify replacement or reprovisioned nodes receive the extra authorized keys.
+- Confirm node reachability still depends on the private-network access path or bastion/NAT-router path already used by the cluster.
+
+## Expected Outcome
+
+- The repo supports multiple operator SSH public keys declaratively.
+- Existing provisioning behavior stays familiar for the primary operator key.
+- Future node replacement no longer requires manual emergency key insertion for collaborator access.
+
+## Notes
+
+- The current live cluster was updated manually before this design so access is already restored, but that live state is not yet represented in repo-managed infra inputs.
+- I did not create a git commit for this spec because no commit was requested.

--- a/infra/hetzner-k8s/tofu/main.tf
+++ b/infra/hetzner-k8s/tofu/main.tf
@@ -23,8 +23,9 @@ module "kube-hetzner" {
 
   hcloud_token = var.hcloud_token
 
-  ssh_public_key  = file(var.ssh_public_key_path)
-  ssh_private_key = var.ssh_private_key_path == "" ? null : file(var.ssh_private_key_path)
+  ssh_public_key             = file(var.ssh_public_key_path)
+  ssh_private_key            = var.ssh_private_key_path == "" ? null : file(var.ssh_private_key_path)
+  ssh_additional_public_keys = var.ssh_additional_public_keys
 
   network_region = var.network_region
 

--- a/infra/hetzner-k8s/tofu/terraform.tfvars.example
+++ b/infra/hetzner-k8s/tofu/terraform.tfvars.example
@@ -1,6 +1,11 @@
 hcloud_token         = "CHANGEME"
-ssh_public_key_path  = "~/.ssh/id_ed25519.pub"
-ssh_private_key_path = "~/.ssh/id_ed25519"
+ssh_public_key_path  = "/home/operator/.ssh/id_ed25519.pub"
+ssh_private_key_path = "/home/operator/.ssh/id_ed25519"
+
+ssh_additional_public_keys = [
+  "ssh-ed25519 AAAA... teammate-1",
+  "ssh-ed25519 AAAA... teammate-2",
+]
 
 cluster_name = "z8"
 

--- a/infra/hetzner-k8s/tofu/variables.tf
+++ b/infra/hetzner-k8s/tofu/variables.tf
@@ -15,6 +15,12 @@ variable "ssh_private_key_path" {
   description = "Optional path to the SSH private key (leave empty to use ssh-agent)."
 }
 
+variable "ssh_additional_public_keys" {
+  type        = list(string)
+  default     = []
+  description = "Additional SSH public keys to install on cluster nodes."
+}
+
 variable "cluster_name" {
   type        = string
   default     = "z8"


### PR DESCRIPTION
## Summary
- add `ssh_additional_public_keys` to the Hetzner Terraform wrapper and pass it through to the pinned `kube-hetzner` module
- update the example tfvars to use absolute primary key paths and inline collaborator public keys for reproducible node access
- add the matching design spec and implementation plan for the multi-key SSH workflow

## Test Plan
- [x] `pnpm test`
- [ ] `tofu -chdir=infra/hetzner-k8s/tofu init`
- [ ] `tofu -chdir=infra/hetzner-k8s/tofu validate`
- [ ] `tofu -chdir=infra/hetzner-k8s/tofu fmt -check`

## Notes
- `tofu` and `terraform` are not installed in this environment, so the Terraform-specific validation steps remain pending.