### PR TITLE
fix(settings): keep billing and avv routes request-bound

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/settings/__tests__/settings-route-access.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/__tests__/settings-route-access.test.ts
@@ -528,6 +528,16 @@ describe("org-admin settings route access", () => {
 
 		expect(offenders).toEqual([]);
 	});
+
+	it("marks billing and avv settings pages as fully dynamic before auth checks", () => {
+		const billingSource = stripComments(
+			readFileSync(join(SETTINGS_ROOT, "billing/page.tsx"), "utf8"),
+		);
+		const avvSource = stripComments(readFileSync(join(SETTINGS_ROOT, "avv/page.tsx"), "utf8"));
+
+		expect(billingSource.includes("await connection(")).toBe(true);
+		expect(avvSource.includes("await connection(")).toBe(true);
+	});
 });
 
 function resolveSettingsTierFromContext(input: {

--- a/apps/webapp/src/app/[locale]/(app)/settings/__tests__/settings-route-access.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/__tests__/settings-route-access.test.ts
@@ -535,8 +535,25 @@ describe("org-admin settings route access", () => {
 		);
 		const avvSource = stripComments(readFileSync(join(SETTINGS_ROOT, "avv/page.tsx"), "utf8"));
 
-		expect(billingSource.includes("await connection(")).toBe(true);
-		expect(avvSource.includes("await connection(")).toBe(true);
+		expect(billingSource.indexOf("await connection(")).toBeGreaterThan(-1);
+		expect(
+			billingSource.indexOf("await connection(") <
+				billingSource.indexOf('if (process.env.BILLING_ENABLED !== "true")'),
+		).toBe(true);
+		expect(
+			billingSource.indexOf("await connection(") <
+				billingSource.indexOf("await requireOrgAdminSettingsAccess()"),
+		).toBe(true);
+
+		expect(avvSource.indexOf("await connection(")).toBeGreaterThan(-1);
+		expect(
+			avvSource.indexOf("await connection(") <
+				avvSource.indexOf('if (process.env.BILLING_ENABLED !== "true")'),
+		).toBe(true);
+		expect(
+			avvSource.indexOf("await connection(") <
+				avvSource.indexOf("await requireOrgAdminSettingsAccess()"),
+		).toBe(true);
 	});
 });
 

--- a/apps/webapp/src/app/[locale]/(app)/settings/avv/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/settings/avv/page.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { redirect } from "next/navigation";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
@@ -7,6 +8,8 @@ import { AvvDownloadButton } from "@/components/settings/avv/avv-download-button
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default async function AvvPage() {
+	await connection();
+
 	if (process.env.BILLING_ENABLED !== "true") {
 		redirect("/settings");
 	}

--- a/apps/webapp/src/app/[locale]/(app)/settings/billing/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/settings/billing/page.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { redirect } from "next/navigation";
 import { and, eq } from "drizzle-orm";
 import { Effect } from "effect";
@@ -13,6 +14,8 @@ import {
 import { BillingPageClient } from "@/components/billing/billing-page-client";
 
 export default async function BillingSettingsPage() {
+	await connection();
+
 	// Check if billing is enabled
 	if (process.env.BILLING_ENABLED !== "true") {
 		redirect("/settings");


### PR DESCRIPTION
## Summary
- mark the billing and AVV settings pages as fully dynamic before billing and org-admin checks run
- eliminate the intermittent stale-route behavior caused by cacheComponents request caching on those two routes
- add regression coverage that enforces `connection()` stays ahead of billing and auth guards

## Test Plan
- `pnpm test \"src/app/[locale]/(app)/settings/__tests__/settings-route-access.test.ts\"`