### PR TITLE
docs: refresh README product messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Across Web, Mobile, and Desktop, Z8 gives teams a dependable operational system 
 Z8 is designed to help organizations operate with confidence in compliance-sensitive environments.
 
 - **Audit-Ready Records**: Time, absence, and related workforce records are captured in a consistent structure that supports dependable reporting, review, and oversight.
+- **Immutable Ledger**: Time records keep an append-only, tamper-evident history for clear traceability and audit readiness.
 - **Traceable Corrections & Approvals**: Changes to recorded time move through clear approval flows with visible history for employees, managers, and compliance stakeholders.
 - **Digital Integrity**: Automated background checks verify the integrity of the data chain to protect against database manipulation.
 - **Audit Logs**: Comprehensive event logging for all administrative actions, from user permission changes to organization settings.
@@ -34,8 +35,17 @@ Z8 is designed to help organizations operate with confidence in compliance-sensi
 ## 📊 Insights & Reporting
 
 - **Advanced Analytics**: Interactive dashboards for team performance, location trends, and workforce distribution.
-- **Export Ready**: Generate payroll and audit-ready exports with advanced filtering, including support for workflows that integrate with systems such as Workday.
+- **Export Ready**: Generate payroll and audit-ready exports with advanced filtering for dependable downstream processing.
 - **Organization Management**: Manage multi-location organizations, team structures, member directories, invitation flows, and department hierarchies from one place.
+
+## 🔄 Integrations & Data Exchange
+
+- **DATEV**: Export payroll-ready time data for accounting and payroll workflows.
+- **Personio**: Export time and payroll data for HR workflows.
+- **SAP SuccessFactors**: Export time and payroll records for enterprise HR workflows.
+- **Workday**: Export payroll and workforce records for enterprise HR operations.
+- **Clockodo**: Import time records into Z8 for a smoother transition.
+- **Clockin**: Import clock-in records into Z8.
 
 ## 🔔 Modern Experience
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# Z8 - Professional Workforce Management & GoBD Compliance
+# Z8 - Workforce Management for Audit-Ready Operations
 
-Z8 is a modern, high-security workforce management platform designed specifically for the rigorous requirements of German labor laws and GoBD compliance (*Grundsätze zur ordnungsmäßigen Führung und Aufbewahrung von Büchern*). 
+Z8 is a workforce management platform built for organizations that need reliable time tracking, audit-ready records, and clear operational control under German labor law and GoBD compliance (*Grundsätze zur ordnungsmäßigen Führung und Aufbewahrung von Büchern*).
 
-Featuring a seamless experience across Web, Mobile, and Desktop, Z8 provides organizations with a tamper-proof source of truth for time tracking, absence management, and holiday planning.
+Across Web, Mobile, and Desktop, Z8 gives teams a dependable operational system for time tracking, absences, travel expenses, and day-to-day workforce management.
 
 ---
 
 ## 🛡️ GoBD & Legal Compliance
 
-Z8 is engineered from the ground up to be audit-ready and legally compliant.
+Z8 is designed to help organizations operate with confidence in compliance-sensitive environments.
 
-- **Immutable Ledger**: Time entries are cryptographically linked in a blockchain-style chain. Existing records cannot be deleted or stealthily modified.
-- **Traceable Corrections**: Any changes to time records require a replacement entry with a full audit trail and manager approval.
+- **Audit-Ready Records**: Time, absence, and related workforce records are captured in a consistent structure that supports dependable reporting, review, and oversight.
+- **Traceable Corrections & Approvals**: Changes to recorded time move through clear approval flows with visible history for employees, managers, and compliance stakeholders.
 - **Digital Integrity**: Automated background checks verify the integrity of the data chain to protect against database manipulation.
 - **Audit Logs**: Comprehensive event logging for all administrative actions, from user permission changes to organization settings.
 
 ## ⏱️ Advanced Time Tracking
 
 - **Multi-Platform Access**: Clock in via the full-featured **Web Dashboard**, the **Mobile App** (iOS/Android), or the low-profile **Tauri Desktop widget**.
-- **Correction Workflows**: Streamlined process for employees to request time corrections, with instantaneous manager notifications.
+- **Correction Workflows**: Streamlined process for employees to request time corrections, with approval-aware reviews and fast manager follow-up.
+- **Clock-In Import Hub**: Bring historical or external clock-in data into Z8 with a guided import flow instead of manual re-entry.
 - **Quick Actions**: Global "Time Clock" popover in the web header for friction-less clock-in/out even when navigating other modules.
 - **Live Status**: Real-time visibility into who is currently clocked in within your team.
 
@@ -28,12 +29,13 @@ Z8 is engineered from the ground up to be audit-ready and legally compliant.
 - **Vacation Balance Tracking**: Sophisticated calculation of remaining leave days based on flexible assignment policies.
 - **Flexible Categories**: Pre-configured status types including Home Office, Sick Leave, Vacation, and custom absence types.
 - **Approval Engine**: Visual timeline for managers to review and approve absence requests while checking for team coverage conflicts.
+- **Travel Expense Workflows**: Handle travel expense claims and approvals in the same operational workflow as the rest of your workforce processes.
 
 ## 📊 Insights & Reporting
 
 - **Advanced Analytics**: Interactive dashboards for team performance, location trends, and workforce distribution.
-- **Export Ready**: Generate reports for payroll or regulatory audits with advanced filtering capabilities.
-- **Organization Management**: Manage multi-location setups, team structures, and distinct department hierarchies.
+- **Export Ready**: Generate payroll and audit-ready exports with advanced filtering, including support for workflows that integrate with systems such as Workday.
+- **Organization Management**: Manage multi-location organizations, team structures, member directories, invitation flows, and department hierarchies from one place.
 
 ## 🔔 Modern Experience
 


### PR DESCRIPTION
## Summary
- polish the README's product positioning and reporting language
- restore immutable-ledger messaging as a primary compliance feature
- add a short integrations section covering DATEV, Personio, SAP SuccessFactors, Workday, Clockodo, and Clockin

## Test Plan
- [x] Run `pnpm test`
- [x] Inspect `git diff origin/main...dev`