### PR TITLE
fix: stop 0004 from recreating app auth schema

### DIFF
--- a/apps/webapp/drizzle/0004_hard_bill_hollister.sql
+++ b/apps/webapp/drizzle/0004_hard_bill_hollister.sql
@@ -1,20 +1,2 @@
-CREATE TYPE "public"."app_auth_code_status" AS ENUM('pending', 'used', 'expired');--> statement-breakpoint
-CREATE TYPE "public"."app_auth_type" AS ENUM('mobile', 'desktop');--> statement-breakpoint
-CREATE TABLE "app_auth_code" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"user_id" text NOT NULL,
-	"app" "app_auth_type" NOT NULL,
-	"code" text NOT NULL,
-	"session_token" text NOT NULL,
-	"status" "app_auth_code_status" DEFAULT 'pending' NOT NULL,
-	"expires_at" timestamp NOT NULL,
-	"used_at" timestamp,
-	"created_at" timestamp DEFAULT now() NOT NULL
-);
---> statement-breakpoint
 ALTER TABLE "sso_provider" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "two_factor" ADD COLUMN "verified" boolean DEFAULT true;--> statement-breakpoint
-ALTER TABLE "app_auth_code" ADD CONSTRAINT "app_auth_code_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "appAuthCode_userId_idx" ON "app_auth_code" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "appAuthCode_app_status_idx" ON "app_auth_code" USING btree ("app","status");--> statement-breakpoint
-CREATE INDEX "appAuthCode_code_idx" ON "app_auth_code" USING btree ("code");

--- a/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
+++ b/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration0004 = readFileSync(
+	new URL("../../../drizzle/0004_hard_bill_hollister.sql", import.meta.url),
+	"utf8"
+);
+
+const migration0004Statements = migration0004
+	.split("--> statement-breakpoint")
+	.map((statement) => statement.trim())
+	.filter(Boolean);
+
+describe("drizzle follow-up migrations", () => {
+	it("keeps 0004 limited to the follow-up auth alters", () => {
+		expect(migration0004Statements).toEqual([
+			'ALTER TABLE "sso_provider" ALTER COLUMN "user_id" SET NOT NULL;',
+			'ALTER TABLE "two_factor" ADD COLUMN "verified" boolean DEFAULT true;',
+		]);
+	});
+});


### PR DESCRIPTION
## Summary
- remove the duplicate app auth table, enum, foreign key, and index creation from `apps/webapp/drizzle/0004_hard_bill_hollister.sql`
- keep `0004` limited to the intended follow-up auth alters so production migration runs after `0003`
- add a regression test that asserts `0004` only contains those two follow-up statements

## Test Plan
- `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
- `pnpm test` on `main` still fails in `apps/mobile/src/features/absences/absences-screen.test.tsx` with a pre-existing `AssertionError: Target cannot be null or undefined`