### PR TITLE
Harden app auth and webhook integrations

### DIFF
--- a/.agents/skills/z8-k8s-deployment/SKILL.md
+++ b/.agents/skills/z8-k8s-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: z8-k8s-deployment
-description: Manage the Z8 Kubernetes deployment, manifests, and Hetzner infrastructure for this repo. Use this whenever the user asks to refresh GHCR images, rollout restart workloads, scale deployments, rerun `drizzle-migrate`, update ingress or Traefik middleware, manage RustFS routes, inspect cert-manager or rollout state, or make Hetzner/OpenTofu changes for the existing cluster. Prefer this skill even if the user only mentions `kubectl`, `app-prod`, `drizzle-migrate`, `kubeconfig.recovered.yaml`, Traefik, ingress, middleware, RustFS, `rustfs.z8-time.app`, `s3.z8-time.app`, telemetry, marketing, cert-manager, GHCR, Hetzner, `hcloud`, `tofu`, or deployment refreshes without explicitly asking for a “skill.”
+description: Manage the Z8 Kubernetes deployment, manifests, and Hetzner infrastructure for this repo. Use this whenever the user asks to refresh GHCR images, rollout restart workloads like `web`, `worker`, or `docs`, scale deployments, rerun `drizzle-migrate`, update ingress or Traefik middleware, manage RustFS routes, inspect cert-manager or rollout state, or make Hetzner/OpenTofu changes for the existing cluster. Prefer this skill even if the user only mentions `kubectl`, `app-prod`, `drizzle-migrate`, `kubeconfig.recovered.yaml`, Traefik, ingress, middleware, RustFS, `rustfs.z8-time.app`, `s3.z8-time.app`, telemetry, docs, marketing, cert-manager, GHCR, Hetzner, `hcloud`, `tofu`, or deployment refreshes without explicitly asking for a “skill.”
 ---
 
 # Z8 K8s Deployment
@@ -11,7 +11,7 @@ This skill is repo-specific. It is not a generic Kubernetes tutorial. Use the re
 
 ## What this skill covers
 
-- Refresh `web`, `worker`, and `drizzle-migrate` images from GHCR
+- Refresh `web`, `worker`, `docs`, and `drizzle-migrate` images from GHCR
 - Restart, scale, and inspect workloads in `app-prod`
 - Recreate and verify migration jobs
 - Add or modify Kubernetes manifests under `infra/hetzner-k8s/k8s`
@@ -62,6 +62,7 @@ Use these paths as your first stop:
 - `infra/hetzner-k8s/k8s/kustomization.yaml` - top-level app manifest set
 - `infra/hetzner-k8s/k8s/app/web-deployment.yaml` - web deployment
 - `infra/hetzner-k8s/k8s/app/worker-deployment.yaml` - worker deployment
+- `infra/hetzner-k8s/k8s/app/docs-deployment.yaml` - docs deployment
 - `infra/hetzner-k8s/k8s/app/migration-job.yaml` - migration job
 - `infra/hetzner-k8s/k8s/app/web-ingress.yaml` - UI ingress
 - `infra/hetzner-k8s/k8s/app/marketing-ingress.yaml` - marketing ingress
@@ -94,7 +95,7 @@ Use for day-2 cluster operations.
 
 Examples:
 - refresh latest GHCR images
-- rollout restart `web` and `worker`
+- rollout restart `web`, `worker`, or `docs`
 - rerun `drizzle-migrate`
 - scale a deployment
 - apply manifest changes under `infra/hetzner-k8s/k8s`
@@ -122,15 +123,15 @@ Workflow:
 
 ## Core playbooks
 
-### Refresh web, worker, and migration images
+### Refresh web, worker, docs, and migration images
 
 Use this when the user says a new image was published to GHCR.
 
-1. Restart `deployment/web` and `deployment/worker` in `app-prod`.
-2. Wait for both rollouts to complete.
+1. Restart `deployment/web`, `deployment/worker`, and `deployment/docs` in `app-prod`.
+2. Wait for all three rollouts to complete.
 3. Delete and recreate `job/drizzle-migrate` from `infra/hetzner-k8s/k8s/app/migration-job.yaml`.
 4. Wait for the job to complete.
-5. Report the live image digests for `web`, `worker`, and the migration pod.
+5. Report the live image digests for `web`, `worker`, `docs`, and the migration pod.
 
 Why: `:latest` tags only become real after new pods are created, and the migration job must be recreated to pull the new image.
 
@@ -196,7 +197,7 @@ Always verify based on the task type.
 
 - rollout completed
 - new pods running
-- image digests reported
+- image digests reported for `web`, `worker`, and `docs`
 
 ### After migration rerun
 
@@ -241,9 +242,10 @@ Examples:
 
 ## Example prompts this skill should handle
 
-- "refresh webapp, worker and migration from the latest GH image"
+- "refresh webapp, worker, docs and migration from the latest GH image"
 - "scale marketing to 0 and verify it stayed down"
 - "add an IP allowlist to the rustfs webui ingress"
 - "route telemetry through Traefik to an external VM and verify TLS"
 - "check which Hetzner ssh keys can access the control planes"
-- "update the k8s deployment and pull the newest webapp images"
+- "update the k8s deployment and pull the newest webapp, worker, and docs images"
+- "restart the docs pod and verify the new image digest"

--- a/apps/webapp/drizzle/0004_hard_bill_hollister.sql
+++ b/apps/webapp/drizzle/0004_hard_bill_hollister.sql
@@ -1,20 +1,2 @@
-CREATE TYPE "public"."app_auth_code_status" AS ENUM('pending', 'used', 'expired');--> statement-breakpoint
-CREATE TYPE "public"."app_auth_type" AS ENUM('mobile', 'desktop');--> statement-breakpoint
-CREATE TABLE "app_auth_code" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"user_id" text NOT NULL,
-	"app" "app_auth_type" NOT NULL,
-	"code" text NOT NULL,
-	"session_token" text NOT NULL,
-	"status" "app_auth_code_status" DEFAULT 'pending' NOT NULL,
-	"expires_at" timestamp NOT NULL,
-	"used_at" timestamp,
-	"created_at" timestamp DEFAULT now() NOT NULL
-);
---> statement-breakpoint
 ALTER TABLE "sso_provider" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "two_factor" ADD COLUMN "verified" boolean DEFAULT true;--> statement-breakpoint
-ALTER TABLE "app_auth_code" ADD CONSTRAINT "app_auth_code_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "appAuthCode_userId_idx" ON "app_auth_code" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "appAuthCode_app_status_idx" ON "app_auth_code" USING btree ("app","status");--> statement-breakpoint
-CREATE INDEX "appAuthCode_code_idx" ON "app_auth_code" USING btree ("code");

--- a/apps/webapp/src/app/[locale]/(app)/settings/webhooks/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/webhooks/actions.ts
@@ -25,7 +25,12 @@ import {
 	updateWebhookEndpoint,
 } from "@/lib/webhooks";
 import { addWebhookJob } from "@/lib/webhooks/webhook-queue";
-import type { WebhookDelivery, WebhookEndpoint, WebhookPayloadData } from "@/lib/webhooks/types";
+import type {
+	PublicWebhookEndpoint,
+	WebhookDelivery,
+	WebhookEndpoint,
+	WebhookPayloadData,
+} from "@/lib/webhooks/types";
 
 const logger = createLogger("WebhookActions");
 
@@ -580,7 +585,7 @@ export async function testWebhook(
  */
 export async function getWebhooks(
 	organizationId: string,
-): Promise<ServerActionResult<{ webhooks: WebhookEndpoint[] }>> {
+): Promise<ServerActionResult<{ webhooks: PublicWebhookEndpoint[] }>> {
 	return runServerActionSafe(
 		Effect.gen(function* (_) {
 			const authService = yield* _(AuthService);

--- a/apps/webapp/src/app/api/auth/app-exchange/route.test.ts
+++ b/apps/webapp/src/app/api/auth/app-exchange/route.test.ts
@@ -29,7 +29,7 @@ describe("POST /api/auth/app-exchange", () => {
 
 		expect(response.status).toBe(400);
 		expect(mockState.consumeAppAuthCode).not.toHaveBeenCalled();
-		expect(await response.json()).toEqual({ error: "Code is required" });
+		expect(await response.json()).toEqual({ error: "Code and verifier are required" });
 	});
 
 	it("returns the session token when a valid mobile code is exchanged", async () => {
@@ -40,7 +40,7 @@ describe("POST /api/auth/app-exchange", () => {
 
 		const response = await POST(
 			new Request("https://app.example.com/api/auth/app-exchange", {
-				body: JSON.stringify({ code: "ONE-TIME-CODE" }),
+				body: JSON.stringify({ code: "ONE-TIME-CODE", verifier: "VERIFIER" }),
 				headers: {
 					"Content-Type": "application/json",
 					"X-Z8-App-Type": "mobile",
@@ -53,7 +53,25 @@ describe("POST /api/auth/app-exchange", () => {
 		expect(mockState.consumeAppAuthCode).toHaveBeenCalledWith({
 			app: "mobile",
 			code: "ONE-TIME-CODE",
+			verifier: "VERIFIER",
 		});
 		expect(await response.json()).toEqual({ token: "session-token" });
+	});
+
+	it("requires a verifier to exchange app auth codes", async () => {
+		const response = await POST(
+			new Request("https://app.example.com/api/auth/app-exchange", {
+				body: JSON.stringify({ code: "ONE-TIME-CODE" }),
+				headers: {
+					"Content-Type": "application/json",
+					"X-Z8-App-Type": "mobile",
+				},
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.consumeAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({ error: "Code and verifier are required" });
 	});
 });

--- a/apps/webapp/src/app/api/auth/app-exchange/route.ts
+++ b/apps/webapp/src/app/api/auth/app-exchange/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { consumeAppAuthCode, type SupportedApp } from "@/lib/auth/app-auth-code";
 
-const bodySchema = z.object({ code: z.string().trim().min(1) });
+const bodySchema = z.object({
+	code: z.string().trim().min(1),
+	verifier: z.string().trim().min(1),
+});
 
 function resolveAppType(request: Request): SupportedApp | null {
 	const appType = request.headers.get("x-z8-app-type")?.toLowerCase();
@@ -19,10 +22,14 @@ export async function POST(request: Request) {
 	const body = await request.json().catch(() => null);
 	const parsed = bodySchema.safeParse(body);
 	if (!parsed.success) {
-		return NextResponse.json({ error: "Code is required" }, { status: 400 });
+		return NextResponse.json({ error: "Code and verifier are required" }, { status: 400 });
 	}
 
-	const result = await consumeAppAuthCode({ app, code: parsed.data.code });
+	const result = await consumeAppAuthCode({
+		app,
+		code: parsed.data.code,
+		verifier: parsed.data.verifier,
+	});
 	if (result.status !== "success") {
 		return NextResponse.json({ error: "Invalid or expired code" }, { status: 401 });
 	}

--- a/apps/webapp/src/app/api/auth/app-login/route.test.ts
+++ b/apps/webapp/src/app/api/auth/app-login/route.test.ts
@@ -46,7 +46,9 @@ describe("GET /api/auth/app-login", () => {
 		mockState.createAppAuthCode.mockResolvedValue({ code: "ONE-TIME-CODE" });
 
 		const response = await GET(
-			createRequest("https://app.example.com/api/auth/app-login?redirect=z8mobile://auth/callback"),
+			createRequest(
+				"https://app.example.com/api/auth/app-login?redirect=z8mobile://auth/callback&challenge=CODE-CHALLENGE",
+			),
 		);
 
 		expect(response.status).toBe(307);
@@ -54,15 +56,50 @@ describe("GET /api/auth/app-login", () => {
 			app: "mobile",
 			sessionToken: "session-token",
 			userId: "user-1",
+			codeChallenge: "CODE-CHALLENGE",
 		});
 		expect(response.headers.get("location")).toBe("z8mobile://auth/callback?code=ONE-TIME-CODE");
+	});
+
+	it("requires a code challenge before minting a mobile auth code", async () => {
+		const response = await GET(
+			createRequest("https://app.example.com/api/auth/app-login?redirect=z8mobile://auth/callback"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.createAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({ error: "Missing challenge parameter" });
+	});
+
+	it("rejects mobile deep links outside the expected auth callback", async () => {
+		const response = await GET(
+			createRequest("https://app.example.com/api/auth/app-login?redirect=z8mobile://evil/callback"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.createAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			error: "Invalid redirect URL. Must be z8mobile://auth/callback",
+		});
+	});
+
+	it("rejects desktop deep links outside the expected auth callback", async () => {
+		const response = await GET(
+			createRequest("https://app.example.com/api/auth/app-login?app=desktop&redirect=z8://evil/callback"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.createAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			error: "Invalid redirect URL. Must be z8://auth/callback",
+		});
 	});
 
 	it("redirects unauthenticated mobile requests through sign-in with a callbackUrl", async () => {
 		mockState.getSession.mockResolvedValue(null);
 
 		const requestUrl =
-			"https://app.example.com/api/auth/app-login?redirect=z8mobile://auth/callback%3Fsource%3Dmobile";
+			"https://app.example.com/api/auth/app-login?redirect=z8mobile://auth/callback%3Fsource%3Dmobile&challenge=CODE-CHALLENGE";
 
 		const response = await GET(createRequest(requestUrl));
 

--- a/apps/webapp/src/app/api/auth/app-login/route.ts
+++ b/apps/webapp/src/app/api/auth/app-login/route.ts
@@ -10,6 +10,24 @@ function getAllowedScheme(app: SupportedApp): string {
 	return app === "desktop" ? "z8://" : "z8mobile://";
 }
 
+function getAllowedRedirect(app: SupportedApp): string {
+	return app === "desktop" ? "z8://auth/callback" : "z8mobile://auth/callback";
+}
+
+function isAllowedRedirect(redirectUrl: string, app: SupportedApp): boolean {
+	try {
+		const requested = new URL(redirectUrl);
+		const allowed = new URL(getAllowedRedirect(app));
+		return (
+			requested.protocol === allowed.protocol &&
+			requested.hostname === allowed.hostname &&
+			requested.pathname === allowed.pathname
+		);
+	} catch {
+		return false;
+	}
+}
+
 function canUseRequestedApp(
 	user: { canUseDesktop?: boolean | null; canUseMobile?: boolean | null },
 	app: SupportedApp,
@@ -20,17 +38,21 @@ function canUseRequestedApp(
 export async function GET(request: NextRequest) {
 	const app = resolveApp(request.nextUrl.searchParams);
 	const redirectUrl = request.nextUrl.searchParams.get("redirect");
+	const codeChallenge = request.nextUrl.searchParams.get("challenge");
 
 	if (!redirectUrl) {
 		return NextResponse.json({ error: "Missing redirect parameter" }, { status: 400 });
 	}
 
-	const allowedScheme = getAllowedScheme(app);
-	if (!redirectUrl.startsWith(allowedScheme)) {
+	if (!isAllowedRedirect(redirectUrl, app)) {
 		return NextResponse.json(
-			{ error: `Invalid redirect URL. Must use ${allowedScheme} protocol` },
+			{ error: `Invalid redirect URL. Must be ${getAllowedRedirect(app)}` },
 			{ status: 400 },
 		);
+	}
+
+	if (!codeChallenge) {
+		return NextResponse.json({ error: "Missing challenge parameter" }, { status: 400 });
 	}
 
 	const session = await auth.api.getSession({ headers: request.headers });
@@ -49,6 +71,7 @@ export async function GET(request: NextRequest) {
 
 	const authCode = await createAppAuthCode({
 		app,
+		codeChallenge,
 		sessionToken: session.session.token,
 		userId: session.user.id,
 	});

--- a/apps/webapp/src/app/api/auth/desktop-login/route.test.ts
+++ b/apps/webapp/src/app/api/auth/desktop-login/route.test.ts
@@ -51,7 +51,9 @@ describe("GET /api/auth/desktop-login", () => {
 		mockState.createAppAuthCode.mockResolvedValue({ code: "DESKTOP-CODE" });
 
 		const response = await GET(
-			createRequest("https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback"),
+			createRequest(
+				"https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback&challenge=CODE-CHALLENGE",
+			),
 		);
 
 		expect(response.status).toBe(307);
@@ -59,8 +61,19 @@ describe("GET /api/auth/desktop-login", () => {
 			app: "desktop",
 			sessionToken: "session-token",
 			userId: "user-1",
+			codeChallenge: "CODE-CHALLENGE",
 		});
 		expect(response.headers.get("location")).toBe("z8://auth/callback?code=DESKTOP-CODE");
+	});
+
+	it("requires a code challenge before minting a desktop auth code", async () => {
+		const response = await GET(
+			createRequest("https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.createAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({ error: "Missing challenge parameter" });
 	});
 
 	it("preserves access-denied redirects for authenticated users without desktop access", async () => {
@@ -75,7 +88,9 @@ describe("GET /api/auth/desktop-login", () => {
 		});
 
 		const response = await GET(
-			createRequest("https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback"),
+			createRequest(
+				"https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback&challenge=CODE-CHALLENGE",
+			),
 		);
 
 		expect(response.status).toBe(307);
@@ -96,11 +111,23 @@ describe("GET /api/auth/desktop-login", () => {
 		});
 	});
 
+	it("rejects desktop deep links outside the expected auth callback", async () => {
+		const response = await GET(
+			createRequest("https://app.example.com/api/auth/desktop-login?redirect=z8://evil/callback"),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.createAppAuthCode).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({
+			error: "Invalid redirect URL. Must be z8://auth/callback",
+		});
+	});
+
 	it("redirects unauthenticated desktop requests through sign-in with a callbackUrl", async () => {
 		mockState.getSession.mockResolvedValue(null);
 
 		const requestUrl =
-			"https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback%3Fsource%3Ddesktop";
+			"https://app.example.com/api/auth/desktop-login?redirect=z8://auth/callback%3Fsource%3Ddesktop&challenge=CODE-CHALLENGE";
 
 		const response = await GET(createRequest(requestUrl));
 

--- a/apps/webapp/src/app/api/auth/desktop-login/route.ts
+++ b/apps/webapp/src/app/api/auth/desktop-login/route.ts
@@ -3,6 +3,22 @@ import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { createAppAuthCode } from "@/lib/auth/app-auth-code";
 
+const DESKTOP_CALLBACK_URL = "z8://auth/callback";
+
+function isAllowedDesktopRedirect(redirectUrl: string): boolean {
+	try {
+		const requested = new URL(redirectUrl);
+		const allowed = new URL(DESKTOP_CALLBACK_URL);
+		return (
+			requested.protocol === allowed.protocol &&
+			requested.hostname === allowed.hostname &&
+			requested.pathname === allowed.pathname
+		);
+	} catch {
+		return false;
+	}
+}
+
 /**
  * GET /api/auth/desktop-login
  * Initiates OAuth login for desktop app, redirects to callback with token
@@ -13,17 +29,29 @@ import { createAppAuthCode } from "@/lib/auth/app-auth-code";
 export async function GET(request: NextRequest) {
 	const searchParams = request.nextUrl.searchParams;
 	const redirectUrl = searchParams.get("redirect");
+	const codeChallenge = searchParams.get("challenge");
 
 	if (!redirectUrl) {
 		return NextResponse.json({ error: "Missing redirect parameter" }, { status: 400 });
 	}
 
-	// Validate the redirect URL is a valid z8:// protocol
+	// Validate the redirect URL is the expected desktop callback.
 	if (!redirectUrl.startsWith("z8://")) {
 		return NextResponse.json(
 			{ error: "Invalid redirect URL. Must be z8:// protocol" },
 			{ status: 400 },
 		);
+	}
+
+	if (!isAllowedDesktopRedirect(redirectUrl)) {
+		return NextResponse.json(
+			{ error: `Invalid redirect URL. Must be ${DESKTOP_CALLBACK_URL}` },
+			{ status: 400 },
+		);
+	}
+
+	if (!codeChallenge) {
+		return NextResponse.json({ error: "Missing challenge parameter" }, { status: 400 });
 	}
 
 	// Check if user is already authenticated
@@ -45,6 +73,7 @@ export async function GET(request: NextRequest) {
 
 		const authCode = await createAppAuthCode({
 			app: "desktop",
+			codeChallenge,
 			sessionToken: session.session.token,
 			userId: session.user.id,
 		});

--- a/apps/webapp/src/app/api/teams/setup/route.test.ts
+++ b/apps/webapp/src/app/api/teams/setup/route.test.ts
@@ -1,0 +1,116 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+	getSession: vi.fn(),
+	headers: vi.fn(),
+	getAbility: vi.fn(),
+	employeeFindFirst: vi.fn(),
+	organizationFindFirst: vi.fn(),
+	teamsTenantFindFirst: vi.fn(),
+	insertValues: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+	headers: mockState.headers,
+}));
+
+vi.mock("next/server", async () => {
+	const actual = await vi.importActual<typeof import("next/server")>("next/server");
+	return {
+		...actual,
+		connection: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+vi.mock("@/lib/auth", () => ({
+	auth: {
+		api: {
+			getSession: mockState.getSession,
+		},
+	},
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+	getAbility: mockState.getAbility,
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+vi.mock("@/db", () => ({
+	db: {
+		query: {
+			employee: { findFirst: mockState.employeeFindFirst },
+			organization: { findFirst: mockState.organizationFindFirst },
+			teamsTenantConfig: { findFirst: mockState.teamsTenantFindFirst },
+		},
+		insert: () => ({ values: mockState.insertValues }),
+	},
+}));
+
+vi.mock("@/db/schema", () => ({
+	employee: { userId: "employee.userId", organizationId: "employee.organizationId" },
+	teamsTenantConfig: {
+		id: "teamsTenantConfig.id",
+		tenantId: "teamsTenantConfig.tenantId",
+		organizationId: "teamsTenantConfig.organizationId",
+	},
+}));
+
+vi.mock("@/db/auth-schema", () => ({
+	organization: { id: "organization.id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: (...args: unknown[]) => args,
+	eq: (...args: unknown[]) => args,
+}));
+
+const { POST } = await import("./route");
+
+function createRequest(body: unknown): NextRequest {
+	return new Request("https://app.example.com/api/teams/setup", {
+		method: "POST",
+		body: JSON.stringify(body),
+		headers: { "Content-Type": "application/json" },
+	}) as NextRequest;
+}
+
+describe("POST /api/teams/setup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.headers.mockResolvedValue(new Headers());
+		mockState.getSession.mockResolvedValue({
+			user: { id: "user-1" },
+			session: { activeOrganizationId: "org-active" },
+		});
+		mockState.getAbility.mockResolvedValue({
+			cannot: vi.fn().mockReturnValue(false),
+		});
+		mockState.employeeFindFirst.mockResolvedValue({ id: "emp-target" });
+		mockState.organizationFindFirst.mockResolvedValue({ id: "org-target" });
+		mockState.teamsTenantFindFirst.mockResolvedValue(null);
+		mockState.insertValues.mockResolvedValue(undefined);
+	});
+
+	it("rejects setup for a non-active target organization", async () => {
+		const response = await POST(
+			createRequest({
+				tenantId: "tenant-1",
+				tenantName: "Tenant 1",
+				organizationId: "org-target",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		expect(mockState.getAbility).not.toHaveBeenCalled();
+		expect(mockState.insertValues).not.toHaveBeenCalled();
+		expect(await response.json()).toEqual({ error: "Access denied" });
+	});
+});

--- a/apps/webapp/src/app/api/teams/setup/route.ts
+++ b/apps/webapp/src/app/api/teams/setup/route.ts
@@ -85,6 +85,10 @@ export async function POST(request: NextRequest) {
 			);
 		}
 
+		if (session.session.activeOrganizationId !== organizationId) {
+			return NextResponse.json({ error: "Access denied" }, { status: 403 });
+		}
+
 		// Verify user has admin access using CASL
 		// First check they're a member of the organization
 		const emp = await db.query.employee.findFirst({
@@ -218,6 +222,10 @@ export async function DELETE(request: NextRequest) {
 				{ error: "Missing organizationId" },
 				{ status: 400 },
 			);
+		}
+
+		if (session.session.activeOrganizationId !== organizationId) {
+			return NextResponse.json({ error: "Access denied" }, { status: 403 });
 		}
 
 		// Verify user has admin access using CASL

--- a/apps/webapp/src/components/webhooks/webhook-endpoint-card.tsx
+++ b/apps/webapp/src/components/webhooks/webhook-endpoint-card.tsx
@@ -42,14 +42,14 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
-import type { WebhookEndpoint } from "@/lib/webhooks/types";
+import type { PublicWebhookEndpoint, WebhookEndpoint } from "@/lib/webhooks/types";
 import { useRouter } from "@/navigation";
 import { WebhookDeliveryLogsDialog } from "./webhook-delivery-logs-dialog";
 import { WebhookFormDialog } from "./webhook-form-dialog";
 import { WebhookSecretDialog } from "./webhook-secret-dialog";
 
 interface WebhookEndpointCardProps {
-	webhook: WebhookEndpoint;
+	webhook: PublicWebhookEndpoint;
 	onUpdated: (webhook: WebhookEndpoint) => void;
 	onDeleted: (webhookId: string) => void;
 }
@@ -65,7 +65,7 @@ export function WebhookEndpointCard({ webhook, onUpdated, onDeleted }: WebhookEn
 	const [newSecret, setNewSecret] = useState<string | null>(null);
 
 	// Mask URL for display
-	const maskedUrl = webhook.url.length > 50 ? `${webhook.url.slice(0, 50)}...` : webhook.url;
+	const maskedUrl = webhook.url.length > 50 ? `${webhook.url.slice(0, 50)}…` : webhook.url;
 
 	// Format last delivery time
 	const lastDeliveryTime = webhook.lastDeliveredAt

--- a/apps/webapp/src/components/webhooks/webhook-form-dialog.tsx
+++ b/apps/webapp/src/components/webhooks/webhook-form-dialog.tsx
@@ -24,13 +24,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { NotificationType } from "@/lib/notifications/types";
-import type { WebhookEndpoint } from "@/lib/webhooks/types";
+import type { PublicWebhookEndpoint, WebhookEndpoint } from "@/lib/webhooks/types";
 import { useRouter } from "@/navigation";
 import { WebhookSecretDialog } from "./webhook-secret-dialog";
 
 interface WebhookFormDialogProps {
 	organizationId: string;
-	webhook?: WebhookEndpoint;
+	webhook?: PublicWebhookEndpoint;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onSuccess: (webhook: WebhookEndpoint) => void;

--- a/apps/webapp/src/components/webhooks/webhooks-page-client.tsx
+++ b/apps/webapp/src/components/webhooks/webhooks-page-client.tsx
@@ -5,13 +5,13 @@ import { useTranslate } from "@tolgee/react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import type { WebhookEndpoint } from "@/lib/webhooks/types";
+import type { PublicWebhookEndpoint, WebhookEndpoint } from "@/lib/webhooks/types";
 import { WebhookEndpointCard } from "./webhook-endpoint-card";
 import { WebhookFormDialog } from "./webhook-form-dialog";
 
 interface WebhooksPageClientProps {
 	organizationId: string;
-	webhooks: WebhookEndpoint[];
+	webhooks: PublicWebhookEndpoint[];
 }
 
 export function WebhooksPageClient({
@@ -19,15 +19,17 @@ export function WebhooksPageClient({
 	webhooks: initialWebhooks,
 }: WebhooksPageClientProps) {
 	const { t } = useTranslate();
-	const [webhooks, setWebhooks] = useState(initialWebhooks);
+	const [webhooks, setWebhooks] = useState<PublicWebhookEndpoint[]>(initialWebhooks);
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 
 	const handleWebhookCreated = (webhook: WebhookEndpoint) => {
-		setWebhooks((prev) => [webhook, ...prev]);
+		const { secret: _secret, ...publicWebhook } = webhook;
+		setWebhooks((prev) => [publicWebhook, ...prev]);
 	};
 
 	const handleWebhookUpdated = (webhook: WebhookEndpoint) => {
-		setWebhooks((prev) => prev.map((w) => (w.id === webhook.id ? webhook : w)));
+		const { secret: _secret, ...publicWebhook } = webhook;
+		setWebhooks((prev) => prev.map((w) => (w.id === webhook.id ? publicWebhook : w)));
 	};
 
 	const handleWebhookDeleted = (webhookId: string) => {
@@ -50,43 +52,43 @@ export function WebhooksPageClient({
 						</p>
 					</div>
 					<Button onClick={() => setIsCreateDialogOpen(true)}>
-						<IconPlus className="mr-2 h-4 w-4" />
+						<IconPlus className="mr-2 h-4 w-4" aria-hidden="true" />
 						{t("webhooks.create", "Add Webhook")}
 					</Button>
 				</div>
 				<Card>
 					<CardContent className="pt-6">
-					{webhooks.length === 0 ? (
-						<div className="flex flex-col items-center justify-center py-12 text-center">
-							<IconWebhook className="h-12 w-12 text-muted-foreground/50" />
-							<h3 className="mt-4 text-lg font-semibold">
-								{t("webhooks.empty.title", "No webhooks configured")}
-							</h3>
-							<p className="mt-2 text-sm text-muted-foreground">
-								{t(
-									"webhooks.empty.description",
-									"Create your first webhook to start receiving event notifications.",
-								)}
-							</p>
-							<Button className="mt-4" onClick={() => setIsCreateDialogOpen(true)}>
-								<IconPlus className="mr-2 h-4 w-4" />
-								{t("webhooks.create", "Add Webhook")}
-							</Button>
-						</div>
-					) : (
-						<div className="space-y-4">
-							{webhooks.map((webhook) => (
-								<WebhookEndpointCard
-									key={webhook.id}
-									webhook={webhook}
-									onUpdated={handleWebhookUpdated}
-									onDeleted={handleWebhookDeleted}
-								/>
-							))}
-						</div>
-					)}
-				</CardContent>
-			</Card>
+						{webhooks.length === 0 ? (
+							<div className="flex flex-col items-center justify-center py-12 text-center">
+								<IconWebhook className="h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
+								<h3 className="mt-4 text-lg font-semibold">
+									{t("webhooks.empty.title", "No webhooks configured")}
+								</h3>
+								<p className="mt-2 text-sm text-muted-foreground">
+									{t(
+										"webhooks.empty.description",
+										"Create your first webhook to start receiving event notifications.",
+									)}
+								</p>
+								<Button className="mt-4" onClick={() => setIsCreateDialogOpen(true)}>
+									<IconPlus className="mr-2 h-4 w-4" aria-hidden="true" />
+									{t("webhooks.create", "Add Webhook")}
+								</Button>
+							</div>
+						) : (
+							<div className="space-y-4">
+								{webhooks.map((webhook) => (
+									<WebhookEndpointCard
+										key={webhook.id}
+										webhook={webhook}
+										onUpdated={handleWebhookUpdated}
+										onDeleted={handleWebhookDeleted}
+									/>
+								))}
+							</div>
+						)}
+					</CardContent>
+				</Card>
 			</div>
 
 			<WebhookFormDialog

--- a/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
+++ b/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration0004 = readFileSync(
+	new URL("../../../drizzle/0004_hard_bill_hollister.sql", import.meta.url),
+	"utf8"
+);
+
+const migration0004Statements = migration0004
+	.split("--> statement-breakpoint")
+	.map((statement) => statement.trim())
+	.filter(Boolean);
+
+describe("drizzle follow-up migrations", () => {
+	it("keeps 0004 limited to the follow-up auth alters", () => {
+		expect(migration0004Statements).toEqual([
+			'ALTER TABLE "sso_provider" ALTER COLUMN "user_id" SET NOT NULL;',
+			'ALTER TABLE "two_factor" ADD COLUMN "verified" boolean DEFAULT true;',
+		]);
+	});
+});

--- a/apps/webapp/src/db/schema/app-auth.ts
+++ b/apps/webapp/src/db/schema/app-auth.ts
@@ -17,6 +17,7 @@ export const appAuthCode = pgTable(
 			.references(() => user.id, { onDelete: "cascade" }),
 		app: appAuthTypeEnum("app").notNull(),
 		code: text("code").notNull(),
+		codeChallenge: text("code_challenge"),
 		sessionToken: text("session_token").notNull(),
 		status: appAuthCodeStatusEnum("status").default("pending").notNull(),
 		expiresAt: timestamp("expires_at").notNull(),

--- a/apps/webapp/src/lib/auth/app-auth-code.test.ts
+++ b/apps/webapp/src/lib/auth/app-auth-code.test.ts
@@ -1,4 +1,8 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const TEST_VERIFIER = "test-verifier";
+const TEST_CHALLENGE = createHash("sha256").update(TEST_VERIFIER).digest("base64url");
 
 const mockState = vi.hoisted(() => ({
 	insertValues: vi.fn(),
@@ -41,6 +45,7 @@ describe("app auth code service", () => {
 
 		const result = await createAppAuthCode({
 			app: "mobile",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			userId: "user-1",
 		});
@@ -50,6 +55,7 @@ describe("app auth code service", () => {
 		expect(mockState.insertValues).toHaveBeenCalledWith(
 			expect.objectContaining({
 				app: "mobile",
+				codeChallenge: TEST_CHALLENGE,
 				sessionToken: "session-token",
 				userId: "user-1",
 				status: "pending",
@@ -61,13 +67,16 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-1",
 			app: "mobile",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "pending",
 			expiresAt: new Date(Date.now() + 60_000),
 		});
 		mockState.updateReturning.mockResolvedValue([{ id: "code-1" }]);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "ABCD" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "ABCD", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			sessionToken: "session-token",
 			status: "success",
 		});
@@ -80,7 +89,9 @@ describe("app auth code service", () => {
 	it("rejects missing codes", async () => {
 		mockState.findFirst.mockResolvedValue(undefined);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "MISSING" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "MISSING", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 	});
@@ -89,20 +100,43 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-used",
 			app: "mobile",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "used",
 			expiresAt: new Date(Date.now() + 60_000),
 		});
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "USED" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "USED", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
+	});
+
+	it("rejects legacy codes without a stored challenge", async () => {
+		mockState.findFirst.mockResolvedValue({
+			id: "code-legacy",
+			app: "mobile",
+			codeChallenge: null,
+			sessionToken: "session-token",
+			status: "pending",
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "LEGACY", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
+			status: "invalid_code",
+		});
+		expect(mockState.updateSet).not.toHaveBeenCalled();
 	});
 
 	it("rejects codes when the requested app does not match the stored app lookup", async () => {
 		mockState.findFirst.mockResolvedValue(undefined);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "DESKTOP-CODE" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "DESKTOP-CODE", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 	});
@@ -111,13 +145,16 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-desktop",
 			app: "desktop",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "pending",
 			expiresAt: new Date(Date.now() + 60_000),
 		});
 		mockState.updateReturning.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "DESKTOP-STORED" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "DESKTOP-STORED", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 
@@ -130,13 +167,16 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-3",
 			app: "mobile",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "pending",
 			expiresAt: new Date(Date.now() + 60_000),
 		});
 		mockState.updateReturning.mockResolvedValue([]);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "RACE" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "RACE", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 	});
@@ -145,13 +185,16 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-4",
 			app: "mobile",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "pending",
 			expiresAt: new Date(Date.now() + 60_000),
 		});
 		mockState.updateReturning.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "code-4" }]);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "EDGE" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "EDGE", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 
@@ -169,13 +212,16 @@ describe("app auth code service", () => {
 		mockState.findFirst.mockResolvedValue({
 			id: "code-2",
 			app: "desktop",
+			codeChallenge: TEST_CHALLENGE,
 			sessionToken: "session-token",
 			status: "pending",
 			expiresAt: new Date(Date.now() - 60_000),
 		});
 		mockState.updateReturning.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "code-2" }]);
 
-		await expect(consumeAppAuthCode({ app: "mobile", code: "EXPIRED" })).resolves.toEqual({
+		await expect(
+			consumeAppAuthCode({ app: "mobile", code: "EXPIRED", verifier: TEST_VERIFIER }),
+		).resolves.toEqual({
 			status: "invalid_code",
 		});
 
@@ -192,6 +238,7 @@ describe("app auth code service", () => {
 			mockState.findFirst.mockResolvedValue({
 				id: "code-boundary",
 				app: "mobile",
+				codeChallenge: TEST_CHALLENGE,
 				sessionToken: "session-token",
 				status: "pending",
 				expiresAt,
@@ -200,7 +247,9 @@ describe("app auth code service", () => {
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([{ id: "code-boundary" }]);
 
-			await expect(consumeAppAuthCode({ app: "mobile", code: "BOUNDARY" })).resolves.toEqual({
+			await expect(
+				consumeAppAuthCode({ app: "mobile", code: "BOUNDARY", verifier: TEST_VERIFIER }),
+			).resolves.toEqual({
 				status: "invalid_code",
 			});
 

--- a/apps/webapp/src/lib/auth/app-auth-code.ts
+++ b/apps/webapp/src/lib/auth/app-auth-code.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { and, eq, gt, lte } from "drizzle-orm";
 import { appAuthCode, db } from "@/db";
 
@@ -10,6 +10,7 @@ export async function createAppAuthCode(input: {
 	userId: string;
 	sessionToken: string;
 	app: SupportedApp;
+	codeChallenge: string;
 }) {
 	const code = randomBytes(16).toString("hex").toUpperCase();
 	const expiresAt = new Date(Date.now() + APP_AUTH_CODE_TTL_MS);
@@ -18,6 +19,7 @@ export async function createAppAuthCode(input: {
 		userId: input.userId,
 		app: input.app,
 		code,
+		codeChallenge: input.codeChallenge,
 		sessionToken: input.sessionToken,
 		status: "pending",
 		expiresAt,
@@ -26,12 +28,31 @@ export async function createAppAuthCode(input: {
 	return { code, expiresAt };
 }
 
-export async function consumeAppAuthCode(input: { code: string; app: SupportedApp }) {
+function challengeForVerifier(verifier: string): string {
+	return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function isMatchingChallenge(verifier: string, challenge: string): boolean {
+	const actual = Buffer.from(challengeForVerifier(verifier));
+	const expected = Buffer.from(challenge);
+	return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+export async function consumeAppAuthCode(input: {
+	code: string;
+	app: SupportedApp;
+	verifier: string;
+}) {
 	const record = await db.query.appAuthCode.findFirst({
 		where: and(eq(appAuthCode.code, input.code), eq(appAuthCode.app, input.app)),
 	});
 
-	if (!record || record.status !== "pending") {
+	if (
+		!record ||
+		record.status !== "pending" ||
+		!record.codeChallenge ||
+		!isMatchingChallenge(input.verifier, record.codeChallenge)
+	) {
 		return { status: "invalid_code" } as const;
 	}
 

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.test.ts
@@ -34,6 +34,7 @@ describe("WorkdayApiClient", () => {
 			"https://example.workday.com/ccx/oauth2/acme/token",
 			expect.objectContaining({
 				method: "POST",
+				redirect: "manual",
 				headers: expect.objectContaining({
 					"Content-Type": "application/x-www-form-urlencoded",
 				}),

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/api-client.ts
@@ -62,6 +62,7 @@ export class WorkdayApiClient {
 				Accept: "application/json",
 			},
 			body,
+			redirect: "manual",
 			signal: AbortSignal.timeout(this.timeoutMs),
 		});
 
@@ -94,6 +95,7 @@ export class WorkdayApiClient {
 						}
 						: {}),
 				},
+				redirect: "manual",
 				signal: AbortSignal.timeout(this.timeoutMs),
 			});
 
@@ -170,6 +172,7 @@ export class WorkdayApiClient {
 				Accept: "application/json",
 				Authorization: `Bearer ${accessToken}`,
 			},
+			redirect: "manual",
 			signal: AbortSignal.timeout(this.timeoutMs),
 		});
 
@@ -203,6 +206,7 @@ export class WorkdayApiClient {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify(payload),
+			redirect: "manual",
 			signal: AbortSignal.timeout(this.timeoutMs),
 		});
 

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.test.ts
@@ -28,6 +28,21 @@ describe("WorkdayConnector", () => {
 		});
 	});
 
+	it("rejects Workday instance URLs that can target internal services", async () => {
+		const connector = new WorkdayConnector();
+
+		await expect(
+			connector.validateConfig({
+				...DEFAULT_WORKDAY_CONFIG,
+				instanceUrl: "http://169.254.169.254",
+				tenantId: "acme",
+			}),
+		).resolves.toEqual({
+			valid: false,
+			errors: ["instanceUrl must use HTTPS", "instanceUrl cannot target private or internal addresses"],
+		});
+	});
+
 	it("returns validation errors for malformed config types", async () => {
 		const connector = new WorkdayConnector();
 
@@ -63,9 +78,20 @@ describe("WorkdayConnector", () => {
 			expiresAt: Date.now() + 3600_000,
 		});
 		const testConnection = vi.fn().mockResolvedValue({ success: true });
+		const findWorkerByEmployeeNumber = vi.fn();
+		const findWorkerByEmail = vi.fn();
+		const createAttendance = vi.fn();
+		const createAbsence = vi.fn();
 		const connector = new WorkdayConnector({
 			getCredentials,
-			createApiClient: () => ({ getOAuthToken, testConnection }),
+			createApiClient: () => ({
+				getOAuthToken,
+				testConnection,
+				findWorkerByEmployeeNumber,
+				findWorkerByEmail,
+				createAttendance,
+				createAbsence,
+			}),
 		});
 
 		const response = await connector.testConnection("org_123", {

--- a/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
+++ b/apps/webapp/src/lib/payroll-export/exporters/workday/workday-connector.ts
@@ -6,6 +6,7 @@ import type {
 	WageTypeMapping,
 	WorkPeriodData,
 } from "../../types";
+import { isPrivateIP } from "@/lib/webhooks/url-validation";
 import { WorkdayApiClient } from "./api-client";
 import {
 	DEFAULT_WORKDAY_CONFIG,
@@ -20,6 +21,25 @@ const SYNC_THRESHOLD = 500;
 const WORKDAY_VAULT_KEY_CLIENT_ID = "payroll/workday/client_id";
 const WORKDAY_VAULT_KEY_CLIENT_SECRET = "payroll/workday/client_secret";
 const WORKDAY_VAULT_KEY_SCOPE = "payroll/workday/scope";
+
+function validateInstanceUrl(instanceUrl: string): string[] {
+	const errors: string[] = [];
+
+	try {
+		const parsed = new URL(instanceUrl);
+		if (parsed.protocol !== "https:") {
+			errors.push("instanceUrl must use HTTPS");
+		}
+
+		if (isPrivateIP(parsed.hostname)) {
+			errors.push("instanceUrl cannot target private or internal addresses");
+		}
+	} catch {
+		errors.push("instanceUrl must be a valid URL");
+	}
+
+	return errors;
+}
 
 interface WorkdayConnectorDeps {
 	getCredentials?: (organizationId: string) => Promise<WorkdayOAuthCredentials | null>;
@@ -279,6 +299,7 @@ export class WorkdayConnector implements IPayrollExporter {
 		} else if (!instanceUrl.trim()) {
 			errors.push("instanceUrl is required");
 		} else {
+			errors.push(...validateInstanceUrl(instanceUrl));
 			config.instanceUrl = instanceUrl;
 		}
 

--- a/apps/webapp/src/lib/webhooks/types.ts
+++ b/apps/webapp/src/lib/webhooks/types.ts
@@ -9,6 +9,7 @@ import type { WebhookDelivery, WebhookEndpoint } from "@/db/schema";
 
 // Re-export database types
 export type { WebhookDelivery, WebhookEndpoint };
+export type PublicWebhookEndpoint = Omit<WebhookEndpoint, "secret">;
 
 /**
  * Parameters for creating a webhook endpoint

--- a/apps/webapp/src/lib/webhooks/webhook-delivery.test.ts
+++ b/apps/webapp/src/lib/webhooks/webhook-delivery.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+	resolveAndValidateUrl: vi.fn(),
+}));
+
+vi.mock("./url-validation", () => ({
+	resolveAndValidateUrl: mockState.resolveAndValidateUrl,
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+const { executeWebhookRequest } = await import("./webhook-delivery");
+
+describe("executeWebhookRequest", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.clearAllMocks();
+	});
+
+	it("does not automatically follow redirects after validating the original webhook URL", async () => {
+		mockState.resolveAndValidateUrl.mockResolvedValue({ valid: true });
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, {
+				status: 302,
+				headers: { Location: "http://169.254.169.254/latest/meta-data/" },
+			}),
+		);
+
+		await executeWebhookRequest({
+			url: "https://webhook.example.com/events",
+			payload: {
+				id: "event-1",
+				type: "password_changed",
+				createdAt: "2026-01-01",
+				data: {},
+			},
+			secret: "secret",
+			eventType: "password_changed",
+			deliveryId: "delivery-1",
+		});
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			"https://webhook.example.com/events",
+			expect.objectContaining({ redirect: "manual" }),
+		);
+	});
+});

--- a/apps/webapp/src/lib/webhooks/webhook-delivery.ts
+++ b/apps/webapp/src/lib/webhooks/webhook-delivery.ts
@@ -77,6 +77,7 @@ export async function executeWebhookRequest(params: {
 				method: "POST",
 				headers,
 				body: payloadString,
+				redirect: "manual",
 				signal: controller.signal,
 			});
 		} finally {

--- a/apps/webapp/src/lib/webhooks/webhook-service.test.ts
+++ b/apps/webapp/src/lib/webhooks/webhook-service.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+	findMany: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+	db: {
+		query: {
+			webhookEndpoint: {
+				findMany: mockState.findMany,
+			},
+		},
+	},
+}));
+
+vi.mock("@/db/schema", () => ({
+	webhookDelivery: {},
+	webhookEndpoint: {
+		organizationId: "webhookEndpoint.organizationId",
+		createdAt: "webhookEndpoint.createdAt",
+	},
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: (...args: unknown[]) => args,
+	eq: (...args: unknown[]) => args,
+	sql: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+const { getWebhookEndpointsByOrganization } = await import("./webhook-service");
+
+describe("getWebhookEndpointsByOrganization", () => {
+	it("does not return webhook signing secrets for client-facing lists", async () => {
+		mockState.findMany.mockResolvedValue([
+			{
+				id: "webhook-1",
+				organizationId: "org-1",
+				name: "Payroll",
+				url: "https://example.com/webhook",
+				secret: "whsec_secret",
+				subscribedEvents: ["time_entry.created"],
+				isActive: true,
+				createdAt: new Date("2026-01-01T00:00:00Z"),
+				updatedAt: new Date("2026-01-01T00:00:00Z"),
+			},
+		]);
+
+		const endpoints = await getWebhookEndpointsByOrganization("org-1");
+
+		expect(endpoints).toHaveLength(1);
+		expect(endpoints[0]).not.toHaveProperty("secret");
+	});
+});

--- a/apps/webapp/src/lib/webhooks/webhook-service.ts
+++ b/apps/webapp/src/lib/webhooks/webhook-service.ts
@@ -16,6 +16,7 @@ import type {
 	WebhookDeliveryResult,
 	WebhookEndpoint,
 	WebhookPayloadData,
+	PublicWebhookEndpoint,
 } from "./types";
 import { MAX_ATTEMPTS, RETRY_DELAYS_MS } from "./types";
 
@@ -110,11 +111,13 @@ export async function getWebhookEndpoint(webhookId: string): Promise<WebhookEndp
  */
 export async function getWebhookEndpointsByOrganization(
 	organizationId: string,
-): Promise<WebhookEndpoint[]> {
-	return db.query.webhookEndpoint.findMany({
+): Promise<PublicWebhookEndpoint[]> {
+	const endpoints = await db.query.webhookEndpoint.findMany({
 		where: eq(webhookEndpoint.organizationId, organizationId),
 		orderBy: (endpoint, { desc }) => [desc(endpoint.createdAt)],
 	});
+
+	return endpoints.map(({ secret: _secret, ...endpoint }) => endpoint);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Harden native app auth with strict callback allowlists and PKCE-style verifier binding.
- Prevent cross-org Teams setup and redirect-based SSRF in webhook and Workday integrations.
- Redact webhook secrets from client-facing webhook lists and add regression coverage.

## Test Plan
- pnpm --dir apps/webapp test src/app/api/auth/app-login/route.test.ts src/app/api/auth/desktop-login/route.test.ts src/app/api/auth/app-exchange/route.test.ts src/lib/auth/app-auth-code.test.ts src/app/api/teams/setup/route.test.ts src/lib/webhooks/webhook-delivery.test.ts src/lib/webhooks/webhook-service.test.ts src/lib/payroll-export/exporters/workday/api-client.test.ts src/lib/payroll-export/exporters/workday/workday-connector.test.ts