### PR TITLE
Add approval performance analytics

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
@@ -110,6 +110,7 @@ function createAbsenceData(totalDays = 2) {
 
 function createManagerData({
 	approvalRate = 87.5,
+	managerName = "Avery Manager",
 	teamLabel = "Operations approvals",
 	withBottlenecks = true,
 } = {}) {
@@ -122,7 +123,22 @@ function createManagerData({
 			approvalRate,
 			pendingSlaWarnings: 3,
 		},
-		byManager: [],
+		byManager: withBottlenecks
+			? [
+					{
+						managerId: "manager-1",
+						managerName,
+						avgResponseTime: 8,
+						avgDecisionTimeHours: 14,
+						totalApprovals: 4,
+						totalRejections: 1,
+						approvalRate: 80,
+						teamSize: 6,
+						pendingCount: 3,
+						pendingSlaWarnings: 1,
+					},
+				]
+			: [],
 		byTeam: withBottlenecks
 			? [
 					{
@@ -190,10 +206,29 @@ describe("AnalyticsOverviewPage", () => {
 		expect(screen.getByText("87.5%")).toBeTruthy();
 		expect(screen.getByText("Of decided requests approved")).toBeTruthy();
 		expect(screen.getByText("Approval Bottlenecks")).toBeTruthy();
+		expect(screen.getByText("Avery Manager")).toBeTruthy();
 		expect(screen.getByText("Operations approvals")).toBeTruthy();
+		expect(
+			within(screen.getByRole("list", { name: "By Manager" })).getAllByRole("listitem"),
+		).toHaveLength(1);
 		expect(
 			within(screen.getByRole("list", { name: "By Team" })).getAllByRole("listitem"),
 		).toHaveLength(1);
+	});
+
+	it("keeps team and absence analytics visible when manager analytics rejects", async () => {
+		getManagerEffectivenessDataMock.mockRejectedValueOnce(new Error("Manager analytics failed"));
+
+		render(<AnalyticsOverviewPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText("160.0h")).toBeTruthy();
+			expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(2);
+			expect(screen.getByText("0.0%")).toBeTruthy();
+			expect(screen.getByText("No approval bottlenecks found")).toBeTruthy();
+		});
+		expect(screen.queryByText("Avery Manager")).toBeNull();
+		expect(screen.queryByText("No data available")).toBeNull();
 	});
 
 	it("clears failed datasets and shows empty bottlenecks when analytics fail", async () => {

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
@@ -1,0 +1,156 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getAbsencePatternsDataMock, getManagerEffectivenessDataMock, getTeamPerformanceDataMock } =
+	vi.hoisted(() => ({
+		getAbsencePatternsDataMock: vi.fn(),
+		getManagerEffectivenessDataMock: vi.fn(),
+		getTeamPerformanceDataMock: vi.fn(),
+	}));
+
+vi.mock("next/dynamic", () => ({
+	default: () =>
+		function DynamicChartMock({ children }: { children?: React.ReactNode }) {
+			return <div data-testid="dynamic-chart">{children}</div>;
+		},
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		error: vi.fn(),
+	},
+}));
+
+vi.mock("@tabler/icons-react", () => ({
+	IconCalendarOff: () => <span aria-hidden="true" />,
+	IconCheck: () => <span aria-hidden="true" />,
+	IconClock: () => <span aria-hidden="true" />,
+	IconLoader2: () => <span aria-hidden="true" />,
+	IconUsers: () => <span aria-hidden="true" />,
+}));
+
+vi.mock("@/components/analytics/export-button", () => ({
+	ExportButton: () => <button type="button">Export</button>,
+}));
+
+vi.mock("@/components/reports/date-range-picker", () => ({
+	DateRangePicker: () => <button type="button">Current month</button>,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+	Card: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+	CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+	CardHeader: ({ children }: { children: React.ReactNode }) => <header>{children}</header>,
+	CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+	ChartContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	ChartTooltip: () => null,
+	ChartTooltipContent: () => null,
+}));
+
+vi.mock("./actions", () => ({
+	getAbsencePatternsData: getAbsencePatternsDataMock,
+	getManagerEffectivenessData: getManagerEffectivenessDataMock,
+	getTeamPerformanceData: getTeamPerformanceDataMock,
+}));
+
+import AnalyticsOverviewPage from "./page";
+
+describe("AnalyticsOverviewPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getTeamPerformanceDataMock.mockResolvedValue({
+			success: true,
+			data: {
+				teams: [
+					{
+						teamId: "team-1",
+						teamName: "Operations",
+						totalHours: 320,
+						avgHoursPerEmployee: 160,
+						employeeCount: 2,
+						employees: [],
+					},
+				],
+				organizationTotal: 320,
+				dateRange: { start: new Date("2026-04-01"), end: new Date("2026-04-30") },
+			},
+		});
+		getAbsencePatternsDataMock.mockResolvedValue({
+			success: true,
+			data: {
+				summary: {
+					totalAbsences: 1,
+					totalDays: 2,
+					avgDaysPerAbsence: 2,
+					absenceRate: 1,
+				},
+				byType: [{ categoryName: "Vacation", count: 1, totalDays: 2, percentage: 100 }],
+				byTeam: [],
+				patterns: {
+					sickLeavePatterns: { avgDuration: 0, peakMonths: [], frequentEmployees: [] },
+					vacationClustering: { score: 0, hotspots: [] },
+				},
+				timeline: [],
+			},
+		});
+		getManagerEffectivenessDataMock.mockResolvedValue({
+			success: true,
+			data: {
+				approvalMetrics: {
+					avgResponseTime: 12,
+					avgDecisionTimeHours: 18,
+					totalApprovals: 7,
+					totalRejections: 1,
+					approvalRate: 87.5,
+					pendingSlaWarnings: 3,
+				},
+				byManager: [],
+				byTeam: [
+					{
+						id: "team-ops",
+						label: "Operations approvals",
+						approvedCount: 5,
+						rejectedCount: 1,
+						pendingCount: 4,
+						pendingSlaWarnings: 2,
+						avgDecisionTimeHours: 22,
+						approvalRate: 83.3,
+					},
+				],
+				byType: [
+					{
+						id: "vacation",
+						label: "Vacation",
+						approvedCount: 2,
+						rejectedCount: 0,
+						pendingCount: 1,
+						pendingSlaWarnings: 1,
+						avgDecisionTimeHours: 10,
+						approvalRate: 100,
+					},
+				],
+				responseTimeDistribution: [],
+				trends: [],
+			},
+		});
+	});
+
+	it("renders real approval analytics and bottlenecks", async () => {
+		render(<AnalyticsOverviewPage />);
+
+		await waitFor(() => {
+			expect(getManagerEffectivenessDataMock).toHaveBeenCalledTimes(1);
+		});
+		expect(screen.getByText("87.5%")).toBeTruthy();
+		expect(screen.getByText("Of decided requests approved")).toBeTruthy();
+		expect(screen.getByText("Approval Bottlenecks")).toBeTruthy();
+		expect(screen.getByText("Operations approvals")).toBeTruthy();
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
@@ -229,11 +229,28 @@ describe("AnalyticsOverviewPage", () => {
 		await waitFor(() => {
 			expect(screen.getByText("160.0h")).toBeTruthy();
 			expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(2);
+			expect(screen.getByText("Unavailable")).toBeTruthy();
+			expect(screen.getByText("Approval analytics could not be loaded")).toBeTruthy();
+		});
+		expect(screen.queryByText("0.0%")).toBeNull();
+		expect(screen.queryByText("No approval bottlenecks found")).toBeNull();
+		expect(screen.queryByText("Avery Manager")).toBeNull();
+		expect(screen.queryByText("No data available")).toBeNull();
+	});
+
+	it("shows normal empty bottlenecks when manager analytics succeeds with no bottlenecks", async () => {
+		getManagerEffectivenessDataMock.mockResolvedValueOnce({
+			success: true,
+			data: createManagerData({ approvalRate: 0, withBottlenecks: false }),
+		});
+
+		render(<AnalyticsOverviewPage />);
+
+		await waitFor(() => {
 			expect(screen.getByText("0.0%")).toBeTruthy();
 			expect(screen.getByText("No approval bottlenecks found")).toBeTruthy();
 		});
-		expect(screen.queryByText("Avery Manager")).toBeNull();
-		expect(screen.queryByText("No data available")).toBeNull();
+		expect(screen.queryByText("Approval analytics could not be loaded")).toBeNull();
 	});
 
 	it("clears failed datasets and shows empty bottlenecks when analytics fail", async () => {

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -37,7 +37,18 @@ vi.mock("@/components/analytics/export-button", () => ({
 }));
 
 vi.mock("@/components/reports/date-range-picker", () => ({
-	DateRangePicker: () => <button type="button">Current month</button>,
+	DateRangePicker: ({
+		onChange,
+	}: {
+		onChange: (dateRange: { start: Date; end: Date }) => void;
+	}) => (
+		<button
+			type="button"
+			onClick={() => onChange({ start: new Date("2026-05-01"), end: new Date("2026-05-31") })}
+		>
+			Change range
+		</button>
+	),
 }));
 
 vi.mock("@/components/ui/card", () => ({
@@ -62,60 +73,61 @@ vi.mock("./actions", () => ({
 
 import AnalyticsOverviewPage from "./page";
 
-describe("AnalyticsOverviewPage", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		getTeamPerformanceDataMock.mockResolvedValue({
-			success: true,
-			data: {
-				teams: [
-					{
-						teamId: "team-1",
-						teamName: "Operations",
-						totalHours: 320,
-						avgHoursPerEmployee: 160,
-						employeeCount: 2,
-						employees: [],
-					},
-				],
-				organizationTotal: 320,
-				dateRange: { start: new Date("2026-04-01"), end: new Date("2026-04-30") },
+function createTeamData(teamName = "Operations", totalHours = 320) {
+	return {
+		teams: [
+			{
+				teamId: `team-${teamName}`,
+				teamName,
+				totalHours,
+				avgHoursPerEmployee: totalHours / 2,
+				employeeCount: 2,
+				employees: [],
 			},
-		});
-		getAbsencePatternsDataMock.mockResolvedValue({
-			success: true,
-			data: {
-				summary: {
-					totalAbsences: 1,
-					totalDays: 2,
-					avgDaysPerAbsence: 2,
-					absenceRate: 1,
-				},
-				byType: [{ categoryName: "Vacation", count: 1, totalDays: 2, percentage: 100 }],
-				byTeam: [],
-				patterns: {
-					sickLeavePatterns: { avgDuration: 0, peakMonths: [], frequentEmployees: [] },
-					vacationClustering: { score: 0, hotspots: [] },
-				},
-				timeline: [],
-			},
-		});
-		getManagerEffectivenessDataMock.mockResolvedValue({
-			success: true,
-			data: {
-				approvalMetrics: {
-					avgResponseTime: 12,
-					avgDecisionTimeHours: 18,
-					totalApprovals: 7,
-					totalRejections: 1,
-					approvalRate: 87.5,
-					pendingSlaWarnings: 3,
-				},
-				byManager: [],
-				byTeam: [
+		],
+		organizationTotal: totalHours,
+		dateRange: { start: new Date("2026-04-01"), end: new Date("2026-04-30") },
+	};
+}
+
+function createAbsenceData(totalDays = 2) {
+	return {
+		summary: {
+			totalAbsences: 1,
+			totalDays,
+			avgDaysPerAbsence: totalDays,
+			absenceRate: 1,
+		},
+		byType: [{ categoryName: "Vacation", count: 1, totalDays, percentage: 100 }],
+		byTeam: [],
+		patterns: {
+			sickLeavePatterns: { avgDuration: 0, peakMonths: [], frequentEmployees: [] },
+			vacationClustering: { score: 0, hotspots: [] },
+		},
+		timeline: [],
+	};
+}
+
+function createManagerData({
+	approvalRate = 87.5,
+	teamLabel = "Operations approvals",
+	withBottlenecks = true,
+} = {}) {
+	return {
+		approvalMetrics: {
+			avgResponseTime: 12,
+			avgDecisionTimeHours: 18,
+			totalApprovals: 7,
+			totalRejections: 1,
+			approvalRate,
+			pendingSlaWarnings: 3,
+		},
+		byManager: [],
+		byTeam: withBottlenecks
+			? [
 					{
 						id: "team-ops",
-						label: "Operations approvals",
+						label: teamLabel,
 						approvedCount: 5,
 						rejectedCount: 1,
 						pendingCount: 4,
@@ -123,8 +135,10 @@ describe("AnalyticsOverviewPage", () => {
 						avgDecisionTimeHours: 22,
 						approvalRate: 83.3,
 					},
-				],
-				byType: [
+				]
+			: [],
+		byType: withBottlenecks
+			? [
 					{
 						id: "vacation",
 						label: "Vacation",
@@ -135,10 +149,35 @@ describe("AnalyticsOverviewPage", () => {
 						avgDecisionTimeHours: 10,
 						approvalRate: 100,
 					},
-				],
-				responseTimeDistribution: [],
-				trends: [],
-			},
+				]
+			: [],
+		responseTimeDistribution: [],
+		trends: [],
+	};
+}
+
+function deferred<T>() {
+	let resolve: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve: resolve! };
+}
+
+describe("AnalyticsOverviewPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getTeamPerformanceDataMock.mockResolvedValue({
+			success: true,
+			data: createTeamData(),
+		});
+		getAbsencePatternsDataMock.mockResolvedValue({
+			success: true,
+			data: createAbsenceData(),
+		});
+		getManagerEffectivenessDataMock.mockResolvedValue({
+			success: true,
+			data: createManagerData(),
 		});
 	});
 
@@ -152,5 +191,69 @@ describe("AnalyticsOverviewPage", () => {
 		expect(screen.getByText("Of decided requests approved")).toBeTruthy();
 		expect(screen.getByText("Approval Bottlenecks")).toBeTruthy();
 		expect(screen.getByText("Operations approvals")).toBeTruthy();
+		expect(
+			within(screen.getByRole("list", { name: "By Team" })).getAllByRole("listitem"),
+		).toHaveLength(1);
+	});
+
+	it("clears failed datasets and shows empty bottlenecks when analytics fail", async () => {
+		render(<AnalyticsOverviewPage />);
+
+		await screen.findByText("Operations approvals");
+		expect(screen.getByText("87.5%")).toBeTruthy();
+
+		getTeamPerformanceDataMock.mockResolvedValueOnce({ success: false, error: "Team failed" });
+		getAbsencePatternsDataMock.mockResolvedValueOnce({ success: false, error: "Absence failed" });
+		getManagerEffectivenessDataMock.mockResolvedValueOnce({
+			success: true,
+			data: createManagerData({ approvalRate: 0, withBottlenecks: false }),
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Change range" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("0.0h")).toBeTruthy();
+			expect(screen.getByText("No approval bottlenecks found")).toBeTruthy();
+		});
+		expect(screen.queryByText("Operations approvals")).toBeNull();
+		expect(screen.getAllByText("No data available")).toHaveLength(2);
+	});
+
+	it("ignores stale responses when the date range changes before older requests finish", async () => {
+		const firstTeam = deferred<{ success: true; data: ReturnType<typeof createTeamData> }>();
+		const firstAbsence = deferred<{ success: true; data: ReturnType<typeof createAbsenceData> }>();
+		const firstManager = deferred<{ success: true; data: ReturnType<typeof createManagerData> }>();
+
+		getTeamPerformanceDataMock
+			.mockReturnValueOnce(firstTeam.promise)
+			.mockResolvedValueOnce({ success: true, data: createTeamData("Current Team", 500) });
+		getAbsencePatternsDataMock
+			.mockReturnValueOnce(firstAbsence.promise)
+			.mockResolvedValueOnce({ success: true, data: createAbsenceData(4) });
+		getManagerEffectivenessDataMock
+			.mockReturnValueOnce(firstManager.promise)
+			.mockResolvedValueOnce({
+				success: true,
+				data: createManagerData({ approvalRate: 91.2, teamLabel: "Current approvals" }),
+			});
+
+		render(<AnalyticsOverviewPage />);
+		fireEvent.click(screen.getByRole("button", { name: "Change range" }));
+
+		await screen.findByText("Current approvals");
+		expect(screen.getByText("91.2%")).toBeTruthy();
+
+		firstTeam.resolve({ success: true, data: createTeamData("Stale Team", 100) });
+		firstAbsence.resolve({ success: true, data: createAbsenceData(8) });
+		firstManager.resolve({
+			success: true,
+			data: createManagerData({ approvalRate: 55.5, teamLabel: "Stale approvals" }),
+		});
+
+		await waitFor(() => {
+			expect(screen.queryByText("Stale approvals")).toBeNull();
+		});
+		expect(screen.getByText("Current approvals")).toBeTruthy();
+		expect(screen.getByText("91.2%")).toBeTruthy();
 	});
 });

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx
@@ -4,12 +4,17 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getAbsencePatternsDataMock, getManagerEffectivenessDataMock, getTeamPerformanceDataMock } =
-	vi.hoisted(() => ({
-		getAbsencePatternsDataMock: vi.fn(),
-		getManagerEffectivenessDataMock: vi.fn(),
-		getTeamPerformanceDataMock: vi.fn(),
-	}));
+const {
+	getAbsencePatternsDataMock,
+	getManagerEffectivenessDataMock,
+	getTeamPerformanceDataMock,
+	toastErrorMock,
+} = vi.hoisted(() => ({
+	getAbsencePatternsDataMock: vi.fn(),
+	getManagerEffectivenessDataMock: vi.fn(),
+	getTeamPerformanceDataMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+}));
 
 vi.mock("next/dynamic", () => ({
 	default: () =>
@@ -20,7 +25,7 @@ vi.mock("next/dynamic", () => ({
 
 vi.mock("sonner", () => ({
 	toast: {
-		error: vi.fn(),
+		error: toastErrorMock,
 	},
 }));
 
@@ -252,6 +257,7 @@ describe("AnalyticsOverviewPage", () => {
 		});
 		expect(screen.queryByText("Operations approvals")).toBeNull();
 		expect(screen.getAllByText("No data available")).toHaveLength(2);
+		expect(toastErrorMock).toHaveBeenCalledWith("Failed to load analytics data");
 	});
 
 	it("ignores stale responses when the date range changes before older requests finish", async () => {

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
@@ -39,6 +39,11 @@ type AnalyticsPageData = {
 	managerData: ManagerEffectivenessData | null;
 };
 
+type BottleneckListRow = Pick<
+	ApprovalBottleneckRow,
+	"id" | "label" | "pendingCount" | "pendingSlaWarnings" | "avgDecisionTimeHours" | "approvalRate"
+>;
+
 export default function AnalyticsOverviewPage() {
 	const [dateRange, setDateRange] = useState<DateRange>(() =>
 		getDateRangeForPreset("current_month"),
@@ -56,7 +61,7 @@ export default function AnalyticsOverviewPage() {
 
 		setAnalyticsData((current) => ({ ...current, loading: true }));
 		// Organization ID is now derived server-side from authenticated session
-		Promise.all([
+		Promise.allSettled([
 			getTeamPerformanceData(dateRange),
 			getAbsencePatternsData(dateRange),
 			getManagerEffectivenessData(dateRange),
@@ -66,11 +71,32 @@ export default function AnalyticsOverviewPage() {
 					return;
 				}
 
+				const rejectedResults = [teamResult, absenceResult, managerResult].filter(
+					(result) => result.status === "rejected",
+				);
+				if (rejectedResults.length > 0) {
+					console.error("Failed to load analytics data:", rejectedResults);
+					toast.error("Failed to load analytics data");
+				}
+
 				setAnalyticsData({
 					loading: false,
-					teamData: teamResult.success && teamResult.data ? teamResult.data : null,
-					absenceData: absenceResult.success && absenceResult.data ? absenceResult.data : null,
-					managerData: managerResult.success && managerResult.data ? managerResult.data : null,
+					teamData:
+						teamResult.status === "fulfilled" && teamResult.value.success && teamResult.value.data
+							? teamResult.value.data
+							: null,
+					absenceData:
+						absenceResult.status === "fulfilled" &&
+						absenceResult.value.success &&
+						absenceResult.value.data
+							? absenceResult.value.data
+							: null,
+					managerData:
+						managerResult.status === "fulfilled" &&
+						managerResult.value.success &&
+						managerResult.value.data
+							? managerResult.value.data
+							: null,
 				});
 			})
 			.catch((error) => {
@@ -111,9 +137,21 @@ export default function AnalyticsOverviewPage() {
 			category: cat.categoryName,
 			days: cat.totalDays,
 		})) || [];
+	const managerBottleneckRows =
+		managerData?.byManager.map((manager) => ({
+			id: manager.managerId,
+			label: manager.managerName,
+			pendingCount: manager.pendingCount,
+			pendingSlaWarnings: manager.pendingSlaWarnings,
+			avgDecisionTimeHours: manager.avgDecisionTimeHours,
+			approvalRate: manager.approvalRate,
+		})) ?? [];
 
 	const hasApprovalBottlenecks = Boolean(
-		managerData && (managerData.byTeam.length > 0 || managerData.byType.length > 0),
+		managerData &&
+			(managerBottleneckRows.length > 0 ||
+				managerData.byTeam.length > 0 ||
+				managerData.byType.length > 0),
 	);
 
 	return (
@@ -271,7 +309,10 @@ export default function AnalyticsOverviewPage() {
 						</CardHeader>
 						<CardContent>
 							{hasApprovalBottlenecks ? (
-								<div className="grid gap-6 md:grid-cols-2">
+								<div className="grid gap-6 md:grid-cols-3">
+									{managerBottleneckRows.length ? (
+										<BottleneckList title="By Manager" rows={managerBottleneckRows} />
+									) : null}
 									{managerData?.byTeam.length ? (
 										<BottleneckList title="By Team" rows={managerData.byTeam} />
 									) : null}
@@ -290,7 +331,7 @@ export default function AnalyticsOverviewPage() {
 	);
 }
 
-function BottleneckList({ title, rows }: { title: string; rows: ApprovalBottleneckRow[] }) {
+function BottleneckList({ title, rows }: { title: string; rows: BottleneckListRow[] }) {
 	const listId = `approval-bottlenecks-${title.toLowerCase().replaceAll(" ", "-")}`;
 
 	return (

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
@@ -52,31 +52,40 @@ export default function AnalyticsOverviewPage() {
 	const { loading, teamData, absenceData, managerData } = analyticsData;
 
 	useEffect(() => {
-		async function loadData() {
-			setAnalyticsData((current) => ({ ...current, loading: true }));
-			try {
-				// Organization ID is now derived server-side from authenticated session
-				const [teamResult, absenceResult, managerResult] = await Promise.all([
-					getTeamPerformanceData(dateRange),
-					getAbsencePatternsData(dateRange),
-					getManagerEffectivenessData(dateRange),
-				]);
+		let canceled = false;
 
-				setAnalyticsData((current) => ({
+		setAnalyticsData((current) => ({ ...current, loading: true }));
+		// Organization ID is now derived server-side from authenticated session
+		Promise.all([
+			getTeamPerformanceData(dateRange),
+			getAbsencePatternsData(dateRange),
+			getManagerEffectivenessData(dateRange),
+		])
+			.then(([teamResult, absenceResult, managerResult]) => {
+				if (canceled) {
+					return;
+				}
+
+				setAnalyticsData({
 					loading: false,
-					teamData: teamResult.success && teamResult.data ? teamResult.data : current.teamData,
-					absenceData:
-						absenceResult.success && absenceResult.data ? absenceResult.data : current.absenceData,
+					teamData: teamResult.success && teamResult.data ? teamResult.data : null,
+					absenceData: absenceResult.success && absenceResult.data ? absenceResult.data : null,
 					managerData: managerResult.success && managerResult.data ? managerResult.data : null,
-				}));
-			} catch (error) {
-				console.error("Failed to load analytics data:", error);
-				setAnalyticsData((current) => ({ ...current, loading: false, managerData: null }));
-				toast.error("Failed to load analytics data");
-			}
-		}
+				});
+			})
+			.catch((error) => {
+				if (canceled) {
+					return;
+				}
 
-		loadData();
+				console.error("Failed to load analytics data:", error);
+				setAnalyticsData({ loading: false, teamData: null, absenceData: null, managerData: null });
+				toast.error("Failed to load analytics data");
+			});
+
+		return () => {
+			canceled = true;
+		};
 	}, [dateRange]);
 
 	// Calculate KPIs from loaded data
@@ -282,12 +291,16 @@ export default function AnalyticsOverviewPage() {
 }
 
 function BottleneckList({ title, rows }: { title: string; rows: ApprovalBottleneckRow[] }) {
+	const listId = `approval-bottlenecks-${title.toLowerCase().replaceAll(" ", "-")}`;
+
 	return (
 		<div className="space-y-3">
-			<h3 className="text-sm font-medium">{title}</h3>
-			<div className="divide-y rounded-md border">
+			<h3 id={listId} className="text-sm font-medium">
+				{title}
+			</h3>
+			<ul aria-labelledby={listId} className="divide-y rounded-md border">
 				{rows.slice(0, 3).map((row) => (
-					<div key={row.id} className="flex items-center justify-between gap-4 p-3 text-sm">
+					<li key={row.id} className="flex items-center justify-between gap-4 p-3 text-sm">
 						<div className="min-w-0">
 							<p className="truncate font-medium">{row.label}</p>
 							<p className="text-xs text-muted-foreground">
@@ -298,9 +311,9 @@ function BottleneckList({ title, rows }: { title: string; rows: ApprovalBottlene
 							<p>{row.approvalRate.toFixed(1)}% approved</p>
 							<p>{row.avgDecisionTimeHours.toFixed(1)}h avg decision</p>
 						</div>
-					</div>
+					</li>
 				))}
-			</div>
+			</ul>
 		</div>
 	);
 }

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
@@ -13,42 +13,66 @@ const CartesianGrid = dynamic(() => import("recharts").then((mod) => mod.Cartesi
 });
 const XAxis = dynamic(() => import("recharts").then((mod) => mod.XAxis), { ssr: false });
 const YAxis = dynamic(() => import("recharts").then((mod) => mod.YAxis), { ssr: false });
+
 import { ExportButton } from "@/components/analytics/export-button";
 import { DateRangePicker } from "@/components/reports/date-range-picker";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
-import type { AbsencePatternsData, TeamPerformanceData } from "@/lib/analytics/types";
+import type {
+	AbsencePatternsData,
+	ApprovalBottleneckRow,
+	ManagerEffectivenessData,
+	TeamPerformanceData,
+} from "@/lib/analytics/types";
 import { getDateRangeForPreset } from "@/lib/reports/date-ranges";
 import type { DateRange } from "@/lib/reports/types";
-import { getAbsencePatternsData, getTeamPerformanceData } from "./actions";
+import {
+	getAbsencePatternsData,
+	getManagerEffectivenessData,
+	getTeamPerformanceData,
+} from "./actions";
+
+type AnalyticsPageData = {
+	loading: boolean;
+	teamData: TeamPerformanceData | null;
+	absenceData: AbsencePatternsData | null;
+	managerData: ManagerEffectivenessData | null;
+};
 
 export default function AnalyticsOverviewPage() {
-	const [dateRange, setDateRange] = useState<DateRange>(getDateRangeForPreset("current_month"));
-	const [loading, setLoading] = useState(true);
-	const [teamData, setTeamData] = useState<TeamPerformanceData | null>(null);
-	const [absenceData, setAbsenceData] = useState<AbsencePatternsData | null>(null);
+	const [dateRange, setDateRange] = useState<DateRange>(() =>
+		getDateRangeForPreset("current_month"),
+	);
+	const [analyticsData, setAnalyticsData] = useState<AnalyticsPageData>({
+		loading: true,
+		teamData: null,
+		absenceData: null,
+		managerData: null,
+	});
+	const { loading, teamData, absenceData, managerData } = analyticsData;
 
 	useEffect(() => {
 		async function loadData() {
-			setLoading(true);
+			setAnalyticsData((current) => ({ ...current, loading: true }));
 			try {
 				// Organization ID is now derived server-side from authenticated session
-				const [teamResult, absenceResult] = await Promise.all([
+				const [teamResult, absenceResult, managerResult] = await Promise.all([
 					getTeamPerformanceData(dateRange),
 					getAbsencePatternsData(dateRange),
+					getManagerEffectivenessData(dateRange),
 				]);
 
-				if (teamResult.success && teamResult.data) {
-					setTeamData(teamResult.data);
-				}
-				if (absenceResult.success && absenceResult.data) {
-					setAbsenceData(absenceResult.data);
-				}
+				setAnalyticsData((current) => ({
+					loading: false,
+					teamData: teamResult.success && teamResult.data ? teamResult.data : current.teamData,
+					absenceData:
+						absenceResult.success && absenceResult.data ? absenceResult.data : current.absenceData,
+					managerData: managerResult.success && managerResult.data ? managerResult.data : null,
+				}));
 			} catch (error) {
 				console.error("Failed to load analytics data:", error);
+				setAnalyticsData((current) => ({ ...current, loading: false, managerData: null }));
 				toast.error("Failed to load analytics data");
-			} finally {
-				setLoading(false);
 			}
 		}
 
@@ -63,7 +87,7 @@ export default function AnalyticsOverviewPage() {
 				(teamData.teams.reduce((sum, team) => sum + team.employeeCount, 0) || 1)
 			: 0,
 		absenceRate: absenceData?.summary.totalDays || 0,
-		approvalRate: 95.0, // TODO: Calculate from manager effectiveness data
+		approvalRate: managerData?.approvalMetrics.approvalRate ?? 0,
 	};
 
 	// Prepare chart data
@@ -78,6 +102,10 @@ export default function AnalyticsOverviewPage() {
 			category: cat.categoryName,
 			days: cat.totalDays,
 		})) || [];
+
+	const hasApprovalBottlenecks = Boolean(
+		managerData && (managerData.byTeam.length > 0 || managerData.byType.length > 0),
+	);
 
 	return (
 		<div className="space-y-6 px-4 lg:px-6">
@@ -100,8 +128,12 @@ export default function AnalyticsOverviewPage() {
 
 			{/* Loading State */}
 			{loading && (
-				<div className="flex items-center justify-center py-12">
-					<IconLoader2 className="size-8 animate-spin text-muted-foreground" />
+				<div
+					className="flex items-center justify-center py-12"
+					role="status"
+					aria-label="Loading analytics data"
+				>
+					<IconLoader2 className="size-8 animate-spin text-muted-foreground" aria-hidden="true" />
 				</div>
 			)}
 
@@ -112,7 +144,7 @@ export default function AnalyticsOverviewPage() {
 						<Card>
 							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 								<CardTitle className="text-sm font-medium">Total Employees</CardTitle>
-								<IconUsers className="size-4 text-muted-foreground" />
+								<IconUsers className="size-4 text-muted-foreground" aria-hidden="true" />
 							</CardHeader>
 							<CardContent>
 								<div className="text-2xl font-bold">{kpiData.totalEmployees}</div>
@@ -123,7 +155,7 @@ export default function AnalyticsOverviewPage() {
 						<Card>
 							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 								<CardTitle className="text-sm font-medium">Avg Work Hours</CardTitle>
-								<IconClock className="size-4 text-muted-foreground" />
+								<IconClock className="size-4 text-muted-foreground" aria-hidden="true" />
 							</CardHeader>
 							<CardContent>
 								<div className="text-2xl font-bold">{kpiData.avgWorkHours.toFixed(1)}h</div>
@@ -134,7 +166,7 @@ export default function AnalyticsOverviewPage() {
 						<Card>
 							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 								<CardTitle className="text-sm font-medium">Total Absence Days</CardTitle>
-								<IconCalendarOff className="size-4 text-muted-foreground" />
+								<IconCalendarOff className="size-4 text-muted-foreground" aria-hidden="true" />
 							</CardHeader>
 							<CardContent>
 								<div className="text-2xl font-bold">{kpiData.absenceRate.toFixed(0)}</div>
@@ -145,11 +177,11 @@ export default function AnalyticsOverviewPage() {
 						<Card>
 							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 								<CardTitle className="text-sm font-medium">Approval Rate</CardTitle>
-								<IconCheck className="size-4 text-muted-foreground" />
+								<IconCheck className="size-4 text-muted-foreground" aria-hidden="true" />
 							</CardHeader>
 							<CardContent>
 								<div className="text-2xl font-bold">{kpiData.approvalRate.toFixed(1)}%</div>
-								<p className="text-xs text-muted-foreground">Of submitted requests approved</p>
+								<p className="text-xs text-muted-foreground">Of decided requests approved</p>
 							</CardContent>
 						</Card>
 					</div>
@@ -220,8 +252,55 @@ export default function AnalyticsOverviewPage() {
 							</CardContent>
 						</Card>
 					</div>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Approval Bottlenecks</CardTitle>
+							<CardDescription>
+								Teams and request types with pending work or SLA warnings
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{hasApprovalBottlenecks ? (
+								<div className="grid gap-6 md:grid-cols-2">
+									{managerData?.byTeam.length ? (
+										<BottleneckList title="By Team" rows={managerData.byTeam} />
+									) : null}
+									{managerData?.byType.length ? (
+										<BottleneckList title="By Type" rows={managerData.byType} />
+									) : null}
+								</div>
+							) : (
+								<p className="text-sm text-muted-foreground">No approval bottlenecks found</p>
+							)}
+						</CardContent>
+					</Card>
 				</>
 			)}
+		</div>
+	);
+}
+
+function BottleneckList({ title, rows }: { title: string; rows: ApprovalBottleneckRow[] }) {
+	return (
+		<div className="space-y-3">
+			<h3 className="text-sm font-medium">{title}</h3>
+			<div className="divide-y rounded-md border">
+				{rows.slice(0, 3).map((row) => (
+					<div key={row.id} className="flex items-center justify-between gap-4 p-3 text-sm">
+						<div className="min-w-0">
+							<p className="truncate font-medium">{row.label}</p>
+							<p className="text-xs text-muted-foreground">
+								{row.pendingCount} pending - {row.pendingSlaWarnings} SLA warnings
+							</p>
+						</div>
+						<div className="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+							<p>{row.approvalRate.toFixed(1)}% approved</p>
+							<p>{row.avgDecisionTimeHours.toFixed(1)}h avg decision</p>
+						</div>
+					</div>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
@@ -71,11 +71,11 @@ export default function AnalyticsOverviewPage() {
 					return;
 				}
 
-				const rejectedResults = [teamResult, absenceResult, managerResult].filter(
-					(result) => result.status === "rejected",
+				const failedResults = [teamResult, absenceResult, managerResult].filter(
+					(result) => result.status === "rejected" || !result.value.success,
 				);
-				if (rejectedResults.length > 0) {
-					console.error("Failed to load analytics data:", rejectedResults);
+				if (failedResults.length > 0) {
+					console.error("Failed to load analytics data:", failedResults);
 					toast.error("Failed to load analytics data");
 				}
 

--- a/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/analytics/page.tsx
@@ -37,6 +37,7 @@ type AnalyticsPageData = {
 	teamData: TeamPerformanceData | null;
 	absenceData: AbsencePatternsData | null;
 	managerData: ManagerEffectivenessData | null;
+	managerDataUnavailable: boolean;
 };
 
 type BottleneckListRow = Pick<
@@ -53,8 +54,9 @@ export default function AnalyticsOverviewPage() {
 		teamData: null,
 		absenceData: null,
 		managerData: null,
+		managerDataUnavailable: false,
 	});
-	const { loading, teamData, absenceData, managerData } = analyticsData;
+	const { loading, teamData, absenceData, managerData, managerDataUnavailable } = analyticsData;
 
 	useEffect(() => {
 		let canceled = false;
@@ -97,6 +99,11 @@ export default function AnalyticsOverviewPage() {
 						managerResult.value.data
 							? managerResult.value.data
 							: null,
+					managerDataUnavailable: !(
+						managerResult.status === "fulfilled" &&
+						managerResult.value.success &&
+						managerResult.value.data
+					),
 				});
 			})
 			.catch((error) => {
@@ -105,7 +112,13 @@ export default function AnalyticsOverviewPage() {
 				}
 
 				console.error("Failed to load analytics data:", error);
-				setAnalyticsData({ loading: false, teamData: null, absenceData: null, managerData: null });
+				setAnalyticsData({
+					loading: false,
+					teamData: null,
+					absenceData: null,
+					managerData: null,
+					managerDataUnavailable: true,
+				});
 				toast.error("Failed to load analytics data");
 			});
 
@@ -122,7 +135,7 @@ export default function AnalyticsOverviewPage() {
 				(teamData.teams.reduce((sum, team) => sum + team.employeeCount, 0) || 1)
 			: 0,
 		absenceRate: absenceData?.summary.totalDays || 0,
-		approvalRate: managerData?.approvalMetrics.approvalRate ?? 0,
+		approvalRate: managerDataUnavailable ? null : (managerData?.approvalMetrics.approvalRate ?? 0),
 	};
 
 	// Prepare chart data
@@ -227,8 +240,16 @@ export default function AnalyticsOverviewPage() {
 								<IconCheck className="size-4 text-muted-foreground" aria-hidden="true" />
 							</CardHeader>
 							<CardContent>
-								<div className="text-2xl font-bold">{kpiData.approvalRate.toFixed(1)}%</div>
-								<p className="text-xs text-muted-foreground">Of decided requests approved</p>
+								<div className="text-2xl font-bold">
+									{kpiData.approvalRate === null
+										? "Unavailable"
+										: `${kpiData.approvalRate.toFixed(1)}%`}
+								</div>
+								<p className="text-xs text-muted-foreground">
+									{managerDataUnavailable
+										? "Approval analytics could not be loaded"
+										: "Of decided requests approved"}
+								</p>
 							</CardContent>
 						</Card>
 					</div>
@@ -308,7 +329,11 @@ export default function AnalyticsOverviewPage() {
 							</CardDescription>
 						</CardHeader>
 						<CardContent>
-							{hasApprovalBottlenecks ? (
+							{managerDataUnavailable ? (
+								<p className="text-sm text-muted-foreground">
+									Approval bottlenecks could not be loaded
+								</p>
+							) : hasApprovalBottlenecks ? (
 								<div className="grid gap-6 md:grid-cols-3">
 									{managerBottleneckRows.length ? (
 										<BottleneckList title="By Manager" rows={managerBottleneckRows} />

--- a/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
+++ b/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { buildApprovalPerformanceData } from "../approval-performance";
+
+const baseSubmittedAt = new Date("2026-04-01T08:00:00.000Z");
+
+describe("buildApprovalPerformanceData", () => {
+	const baseRow = {
+		source: "approval_request" as const,
+		type: "absence_entry",
+		organizationId: "org-1",
+		requesterEmployeeId: "employee-1",
+		requesterTeamId: "team-1",
+		requesterTeamName: "Operations",
+		approverEmployeeId: "manager-1",
+		approverName: "Mina Manager",
+		status: "approved" as const,
+		submittedAt: baseSubmittedAt,
+		decidedAt: new Date("2026-04-01T12:00:00.000Z"),
+		slaStatus: "on_time" as const,
+	};
+
+	it("calculates approval rate from decided rows and excludes pending rows", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				status: "rejected",
+				decidedAt: new Date("2026-04-01T10:00:00.000Z"),
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.totalApprovals).toBe(1);
+		expect(result.approvalMetrics.totalRejections).toBe(1);
+		expect(result.approvalMetrics.approvalRate).toBe(50);
+	});
+
+	it("calculates average decision time in hours from decidedAt and submittedAt", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				decidedAt: new Date("2026-04-01T16:00:00.000Z"),
+			},
+		]);
+
+		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(6);
+		expect(result.approvalMetrics.avgResponseTime).toBe(0.25);
+	});
+
+	it("counts pending SLA warnings for approaching and overdue rows", () => {
+		const result = buildApprovalPerformanceData([
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "approaching",
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "overdue",
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.pendingSlaWarnings).toBe(2);
+		expect(result.byManager[0]?.pendingSlaWarnings).toBe(2);
+	});
+
+	it("groups bottlenecks by manager, requester team, and approval type", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				source: "travel_expense_claim",
+				type: "travel_expense_claim",
+				requesterTeamId: "team-2",
+				requesterTeamName: "Field Sales",
+				approverEmployeeId: "manager-2",
+				approverName: "Tara Travel",
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "overdue",
+			},
+		]);
+
+		expect(result.byManager.map((row) => row.managerName)).toEqual(["Tara Travel", "Mina Manager"]);
+		expect(result.byTeam.map((row) => row.label)).toContain("Field Sales");
+		expect(result.byType.map((row) => row.label)).toContain("Travel Expense Claim");
+	});
+
+	it("excludes draft-like rows before calculation", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				source: "travel_expense_claim",
+				type: "travel_expense_claim",
+				status: "draft",
+				decidedAt: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.totalApprovals).toBe(1);
+		expect(result.byType).toHaveLength(1);
+	});
+});

--- a/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
+++ b/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
@@ -53,6 +53,26 @@ describe("buildApprovalPerformanceData", () => {
 		expect(result.approvalMetrics.avgResponseTime).toBe(0.25);
 	});
 
+	it("excludes pending rows with accidental decision timestamps from decision time", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: new Date("2026-04-03T08:00:00.000Z"),
+			},
+		]);
+
+		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(4);
+		expect(result.byManager[0]?.avgDecisionTimeHours).toBe(4);
+		expect(result.responseTimeDistribution).toContainEqual({
+			bucket: "< 1 day",
+			count: 1,
+			percentage: 100,
+		});
+		expect(result.trends[0]?.avgDecisionTimeHours).toBe(4);
+	});
+
 	it("counts pending SLA warnings for approaching and overdue rows", () => {
 		const result = buildApprovalPerformanceData([
 			{

--- a/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
+++ b/apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
@@ -98,7 +98,35 @@ describe("buildApprovalPerformanceData", () => {
 
 		expect(result.byManager.map((row) => row.managerName)).toEqual(["Tara Travel", "Mina Manager"]);
 		expect(result.byTeam.map((row) => row.label)).toContain("Field Sales");
+		expect(result.byTeam[0]).toMatchObject({
+			approvedCount: 0,
+			rejectedCount: 0,
+			pendingCount: 1,
+			pendingSlaWarnings: 1,
+			avgDecisionTimeHours: 0,
+			approvalRate: 0,
+		});
 		expect(result.byType.map((row) => row.label)).toContain("Travel Expense Claim");
+	});
+
+	it("includes average decision time hours in monthly trends", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				decidedAt: new Date("2026-04-01T16:00:00.000Z"),
+			},
+		]);
+
+		expect(result.trends).toEqual([
+			{
+				month: "2026-04",
+				approvals: 2,
+				rejections: 0,
+				avgResponseTime: 0.25,
+				avgDecisionTimeHours: 6,
+			},
+		]);
 	});
 
 	it("excludes draft-like rows before calculation", () => {

--- a/apps/webapp/src/lib/analytics/__tests__/types.approval-performance.test.ts
+++ b/apps/webapp/src/lib/analytics/__tests__/types.approval-performance.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { ManagerEffectivenessData } from "../types";
+
+describe("ManagerEffectivenessData approval performance shape", () => {
+	it("supports decision-time and bottleneck metrics", () => {
+		const data = {
+			approvalMetrics: {
+				avgResponseTime: 0.25,
+				avgDecisionTimeHours: 6,
+				totalApprovals: 2,
+				totalRejections: 1,
+				approvalRate: 66.67,
+				pendingSlaWarnings: 3,
+			},
+			byManager: [
+				{
+					managerId: "manager-1",
+					managerName: "Mina Manager",
+					avgResponseTime: 0.25,
+					avgDecisionTimeHours: 6,
+					totalApprovals: 2,
+					totalRejections: 1,
+					approvalRate: 66.67,
+					teamSize: 4,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+				},
+			],
+			byTeam: [
+				{
+					id: "team-1",
+					label: "Operations",
+					approvedCount: 2,
+					rejectedCount: 1,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+					avgDecisionTimeHours: 6,
+					approvalRate: 66.67,
+				},
+			],
+			byType: [
+				{
+					id: "absence_entry",
+					label: "Absence Entry",
+					approvedCount: 2,
+					rejectedCount: 1,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+					avgDecisionTimeHours: 6,
+					approvalRate: 66.67,
+				},
+			],
+			responseTimeDistribution: [{ bucket: "< 1 day", count: 3, percentage: 100 }],
+			trends: [
+				{
+					month: "2026-04",
+					approvals: 2,
+					rejections: 1,
+					avgResponseTime: 0.25,
+					avgDecisionTimeHours: 6,
+				},
+			],
+		} satisfies ManagerEffectivenessData;
+
+		expect(data.approvalMetrics.pendingSlaWarnings).toBe(3);
+	});
+});

--- a/apps/webapp/src/lib/analytics/approval-performance.ts
+++ b/apps/webapp/src/lib/analytics/approval-performance.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 
-import type { ManagerEffectivenessData } from "./types";
+import type { ApprovalBottleneckRow, ManagerEffectivenessData } from "./types";
 
 export type ApprovalAnalyticsStatus = "approved" | "rejected" | "pending" | "draft";
 
@@ -23,28 +23,9 @@ export type ApprovalAnalyticsRow = {
 	slaStatus: ApprovalAnalyticsSlaStatus;
 };
 
-type ApprovalMetricSummary = ManagerEffectivenessData["approvalMetrics"] & {
-	avgDecisionTimeHours: number;
-	pendingSlaWarnings: number;
-};
+type ApprovalMetricSummary = ManagerEffectivenessData["approvalMetrics"];
 
-type ApprovalBottleneckRow = {
-	id: string;
-	label: string;
-	avgDecisionTimeHours: number;
-	avgResponseTime: number;
-	totalApprovals: number;
-	totalRejections: number;
-	approvalRate: number;
-	pendingCount: number;
-	pendingSlaWarnings: number;
-};
-
-type ApprovalManagerRow = ManagerEffectivenessData["byManager"][number] &
-	ApprovalBottleneckRow & {
-		managerId: string;
-		managerName: string;
-	};
+type ApprovalManagerRow = ManagerEffectivenessData["byManager"][number];
 
 export type ApprovalPerformanceData = Omit<
 	ManagerEffectivenessData,
@@ -91,10 +72,16 @@ export function buildApprovalPerformanceData(
 			id: row.approverEmployeeId ?? "unassigned",
 			label: row.approverName ?? "Unassigned",
 		})).map((row) => ({
-			...row,
 			managerId: row.id,
 			managerName: row.label,
+			avgResponseTime: round(row.avgDecisionTimeHours / 24),
+			avgDecisionTimeHours: row.avgDecisionTimeHours,
+			totalApprovals: row.approvedCount,
+			totalRejections: row.rejectedCount,
+			approvalRate: row.approvalRate,
 			teamSize: 0,
+			pendingCount: row.pendingCount,
+			pendingSlaWarnings: row.pendingSlaWarnings,
 		})),
 		byTeam: buildGroupedRows(rows, (row) => ({
 			id: row.requesterTeamId ?? "unassigned",
@@ -143,13 +130,12 @@ function buildGroupedRows(
 			return {
 				id,
 				label: group.label,
-				avgDecisionTimeHours: round(avgDecisionTimeHours),
-				avgResponseTime: round(avgDecisionTimeHours / 24),
-				totalApprovals: group.approvals,
-				totalRejections: group.rejections,
-				approvalRate: decidedCount > 0 ? round((group.approvals / decidedCount) * 100) : 0,
+				approvedCount: group.approvals,
+				rejectedCount: group.rejections,
 				pendingCount: group.pending,
 				pendingSlaWarnings: group.pendingSlaWarnings,
+				avgDecisionTimeHours: round(avgDecisionTimeHours),
+				approvalRate: decidedCount > 0 ? round((group.approvals / decidedCount) * 100) : 0,
 			};
 		})
 		.sort((a, b) => {
@@ -229,6 +215,8 @@ function buildMonthlyTrends(rows: ApprovalAnalyticsRow[]): ApprovalPerformanceDa
 			rejections: data.rejections,
 			avgResponseTime:
 				data.decidedCount > 0 ? round(data.totalDecisionTimeHours / data.decidedCount / 24) : 0,
+			avgDecisionTimeHours:
+				data.decidedCount > 0 ? round(data.totalDecisionTimeHours / data.decidedCount) : 0,
 		}));
 }
 

--- a/apps/webapp/src/lib/analytics/approval-performance.ts
+++ b/apps/webapp/src/lib/analytics/approval-performance.ts
@@ -46,7 +46,10 @@ type ApprovalManagerRow = ManagerEffectivenessData["byManager"][number] &
 		managerName: string;
 	};
 
-export type ApprovalPerformanceData = Omit<ManagerEffectivenessData, "approvalMetrics" | "byManager"> & {
+export type ApprovalPerformanceData = Omit<
+	ManagerEffectivenessData,
+	"approvalMetrics" | "byManager"
+> & {
 	approvalMetrics: ApprovalMetricSummary;
 	byManager: ApprovalManagerRow[];
 	byTeam: ApprovalBottleneckRow[];
@@ -64,7 +67,9 @@ type GroupAccumulator = {
 
 const RESPONSE_TIME_BUCKETS = ["< 1 day", "1-3 days", "3-7 days", "> 7 days"] as const;
 
-export function buildApprovalPerformanceData(inputRows: ApprovalAnalyticsRow[]): ApprovalPerformanceData {
+export function buildApprovalPerformanceData(
+	inputRows: ApprovalAnalyticsRow[],
+): ApprovalPerformanceData {
 	const rows = inputRows.filter((row) => row.status !== "draft");
 	const approvedRows = rows.filter((row) => row.status === "approved");
 	const rejectedRows = rows.filter((row) => row.status === "rejected");
@@ -158,7 +163,9 @@ function buildGroupedRows(
 		});
 }
 
-function buildResponseTimeDistribution(decisionTimeHours: number[]): ApprovalPerformanceData["responseTimeDistribution"] {
+function buildResponseTimeDistribution(
+	decisionTimeHours: number[],
+): ApprovalPerformanceData["responseTimeDistribution"] {
 	const bucketCounts = new Map<(typeof RESPONSE_TIME_BUCKETS)[number], number>(
 		RESPONSE_TIME_BUCKETS.map((bucket) => [bucket, 0]),
 	);
@@ -182,7 +189,8 @@ function buildResponseTimeDistribution(decisionTimeHours: number[]): ApprovalPer
 		return {
 			bucket,
 			count,
-			percentage: decisionTimeHours.length > 0 ? Math.round((count / decisionTimeHours.length) * 100) : 0,
+			percentage:
+				decisionTimeHours.length > 0 ? Math.round((count / decisionTimeHours.length) * 100) : 0,
 		};
 	});
 }
@@ -229,11 +237,15 @@ function decisionTimeHoursFor(row: ApprovalAnalyticsRow): number[] {
 		return [];
 	}
 
-	return [row.decidedAt.getTime() - row.submittedAt.getTime()].map((milliseconds) => milliseconds / 3_600_000);
+	return [row.decidedAt.getTime() - row.submittedAt.getTime()].map(
+		(milliseconds) => milliseconds / 3_600_000,
+	);
 }
 
 function isPendingSlaWarning(row: ApprovalAnalyticsRow): boolean {
-	return row.status === "pending" && (row.slaStatus === "approaching" || row.slaStatus === "overdue");
+	return (
+		row.status === "pending" && (row.slaStatus === "approaching" || row.slaStatus === "overdue")
+	);
 }
 
 function average(values: number[]): number {

--- a/apps/webapp/src/lib/analytics/approval-performance.ts
+++ b/apps/webapp/src/lib/analytics/approval-performance.ts
@@ -1,0 +1,252 @@
+import { DateTime } from "luxon";
+
+import type { ManagerEffectivenessData } from "./types";
+
+export type ApprovalAnalyticsStatus = "approved" | "rejected" | "pending" | "draft";
+
+export type ApprovalAnalyticsSource = "approval_request" | "travel_expense_claim";
+
+export type ApprovalAnalyticsSlaStatus = "on_time" | "approaching" | "overdue" | null;
+
+export type ApprovalAnalyticsRow = {
+	source: ApprovalAnalyticsSource;
+	type: string;
+	organizationId: string;
+	requesterEmployeeId: string;
+	requesterTeamId: string | null;
+	requesterTeamName: string | null;
+	approverEmployeeId: string | null;
+	approverName: string | null;
+	status: ApprovalAnalyticsStatus;
+	submittedAt: Date;
+	decidedAt: Date | null;
+	slaStatus: ApprovalAnalyticsSlaStatus;
+};
+
+type ApprovalMetricSummary = ManagerEffectivenessData["approvalMetrics"] & {
+	avgDecisionTimeHours: number;
+	pendingSlaWarnings: number;
+};
+
+type ApprovalBottleneckRow = {
+	id: string;
+	label: string;
+	avgDecisionTimeHours: number;
+	avgResponseTime: number;
+	totalApprovals: number;
+	totalRejections: number;
+	approvalRate: number;
+	pendingCount: number;
+	pendingSlaWarnings: number;
+};
+
+type ApprovalManagerRow = ManagerEffectivenessData["byManager"][number] &
+	ApprovalBottleneckRow & {
+		managerId: string;
+		managerName: string;
+	};
+
+export type ApprovalPerformanceData = Omit<ManagerEffectivenessData, "approvalMetrics" | "byManager"> & {
+	approvalMetrics: ApprovalMetricSummary;
+	byManager: ApprovalManagerRow[];
+	byTeam: ApprovalBottleneckRow[];
+	byType: ApprovalBottleneckRow[];
+};
+
+type GroupAccumulator = {
+	label: string;
+	approvals: number;
+	rejections: number;
+	pending: number;
+	pendingSlaWarnings: number;
+	decisionTimeHours: number[];
+};
+
+const RESPONSE_TIME_BUCKETS = ["< 1 day", "1-3 days", "3-7 days", "> 7 days"] as const;
+
+export function buildApprovalPerformanceData(inputRows: ApprovalAnalyticsRow[]): ApprovalPerformanceData {
+	const rows = inputRows.filter((row) => row.status !== "draft");
+	const approvedRows = rows.filter((row) => row.status === "approved");
+	const rejectedRows = rows.filter((row) => row.status === "rejected");
+	const decisionTimeHours = rows.flatMap((row) => decisionTimeHoursFor(row));
+	const pendingSlaWarnings = rows.filter(isPendingSlaWarning).length;
+	const decidedCount = approvedRows.length + rejectedRows.length;
+	const avgDecisionTimeHours = average(decisionTimeHours);
+
+	return {
+		approvalMetrics: {
+			avgResponseTime: round(avgDecisionTimeHours / 24),
+			avgDecisionTimeHours: round(avgDecisionTimeHours),
+			totalApprovals: approvedRows.length,
+			totalRejections: rejectedRows.length,
+			approvalRate: decidedCount > 0 ? round((approvedRows.length / decidedCount) * 100) : 0,
+			pendingSlaWarnings,
+		},
+		byManager: buildGroupedRows(rows, (row) => ({
+			id: row.approverEmployeeId ?? "unassigned",
+			label: row.approverName ?? "Unassigned",
+		})).map((row) => ({
+			...row,
+			managerId: row.id,
+			managerName: row.label,
+			teamSize: 0,
+		})),
+		byTeam: buildGroupedRows(rows, (row) => ({
+			id: row.requesterTeamId ?? "unassigned",
+			label: row.requesterTeamName ?? "Unassigned",
+		})),
+		byType: buildGroupedRows(rows, (row) => ({
+			id: row.type,
+			label: labelForType(row.type),
+		})),
+		responseTimeDistribution: buildResponseTimeDistribution(decisionTimeHours),
+		trends: buildMonthlyTrends(rows),
+	};
+}
+
+function buildGroupedRows(
+	rows: ApprovalAnalyticsRow[],
+	selectGroup: (row: ApprovalAnalyticsRow) => { id: string; label: string },
+): ApprovalBottleneckRow[] {
+	const groups = new Map<string, GroupAccumulator>();
+
+	for (const row of rows) {
+		const group = selectGroup(row);
+		const current = groups.get(group.id) ?? {
+			label: group.label,
+			approvals: 0,
+			rejections: 0,
+			pending: 0,
+			pendingSlaWarnings: 0,
+			decisionTimeHours: [] as number[],
+		};
+
+		if (row.status === "approved") current.approvals++;
+		if (row.status === "rejected") current.rejections++;
+		if (row.status === "pending") current.pending++;
+		if (isPendingSlaWarning(row)) current.pendingSlaWarnings++;
+
+		current.decisionTimeHours.push(...decisionTimeHoursFor(row));
+		groups.set(group.id, current);
+	}
+
+	return Array.from(groups.entries())
+		.map(([id, group]) => {
+			const decidedCount = group.approvals + group.rejections;
+			const avgDecisionTimeHours = average(group.decisionTimeHours);
+
+			return {
+				id,
+				label: group.label,
+				avgDecisionTimeHours: round(avgDecisionTimeHours),
+				avgResponseTime: round(avgDecisionTimeHours / 24),
+				totalApprovals: group.approvals,
+				totalRejections: group.rejections,
+				approvalRate: decidedCount > 0 ? round((group.approvals / decidedCount) * 100) : 0,
+				pendingCount: group.pending,
+				pendingSlaWarnings: group.pendingSlaWarnings,
+			};
+		})
+		.sort((a, b) => {
+			const slaDelta = b.pendingSlaWarnings - a.pendingSlaWarnings;
+			if (slaDelta !== 0) return slaDelta;
+
+			const pendingDelta = b.pendingCount - a.pendingCount;
+			if (pendingDelta !== 0) return pendingDelta;
+
+			return b.avgDecisionTimeHours - a.avgDecisionTimeHours;
+		});
+}
+
+function buildResponseTimeDistribution(decisionTimeHours: number[]): ApprovalPerformanceData["responseTimeDistribution"] {
+	const bucketCounts = new Map<(typeof RESPONSE_TIME_BUCKETS)[number], number>(
+		RESPONSE_TIME_BUCKETS.map((bucket) => [bucket, 0]),
+	);
+
+	for (const hours of decisionTimeHours) {
+		const days = hours / 24;
+		if (days < 1) {
+			bucketCounts.set("< 1 day", (bucketCounts.get("< 1 day") ?? 0) + 1);
+		} else if (days <= 3) {
+			bucketCounts.set("1-3 days", (bucketCounts.get("1-3 days") ?? 0) + 1);
+		} else if (days <= 7) {
+			bucketCounts.set("3-7 days", (bucketCounts.get("3-7 days") ?? 0) + 1);
+		} else {
+			bucketCounts.set("> 7 days", (bucketCounts.get("> 7 days") ?? 0) + 1);
+		}
+	}
+
+	return RESPONSE_TIME_BUCKETS.map((bucket) => {
+		const count = bucketCounts.get(bucket) ?? 0;
+
+		return {
+			bucket,
+			count,
+			percentage: decisionTimeHours.length > 0 ? Math.round((count / decisionTimeHours.length) * 100) : 0,
+		};
+	});
+}
+
+function buildMonthlyTrends(rows: ApprovalAnalyticsRow[]): ApprovalPerformanceData["trends"] {
+	const monthly = new Map<
+		string,
+		{ approvals: number; rejections: number; totalDecisionTimeHours: number; decidedCount: number }
+	>();
+
+	for (const row of rows) {
+		const month = DateTime.fromJSDate(row.submittedAt).toFormat("yyyy-MM");
+		const current = monthly.get(month) ?? {
+			approvals: 0,
+			rejections: 0,
+			totalDecisionTimeHours: 0,
+			decidedCount: 0,
+		};
+
+		if (row.status === "approved") current.approvals++;
+		if (row.status === "rejected") current.rejections++;
+
+		for (const hours of decisionTimeHoursFor(row)) {
+			current.totalDecisionTimeHours += hours;
+			current.decidedCount++;
+		}
+
+		monthly.set(month, current);
+	}
+
+	return Array.from(monthly.entries())
+		.sort((a, b) => a[0].localeCompare(b[0]))
+		.map(([month, data]) => ({
+			month,
+			approvals: data.approvals,
+			rejections: data.rejections,
+			avgResponseTime:
+				data.decidedCount > 0 ? round(data.totalDecisionTimeHours / data.decidedCount / 24) : 0,
+		}));
+}
+
+function decisionTimeHoursFor(row: ApprovalAnalyticsRow): number[] {
+	if (!row.decidedAt) {
+		return [];
+	}
+
+	return [row.decidedAt.getTime() - row.submittedAt.getTime()].map((milliseconds) => milliseconds / 3_600_000);
+}
+
+function isPendingSlaWarning(row: ApprovalAnalyticsRow): boolean {
+	return row.status === "pending" && (row.slaStatus === "approaching" || row.slaStatus === "overdue");
+}
+
+function average(values: number[]): number {
+	return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+function labelForType(type: string): string {
+	return type
+		.split("_")
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function round(value: number): number {
+	return Math.round(value * 100) / 100;
+}

--- a/apps/webapp/src/lib/analytics/approval-performance.ts
+++ b/apps/webapp/src/lib/analytics/approval-performance.ts
@@ -221,7 +221,7 @@ function buildMonthlyTrends(rows: ApprovalAnalyticsRow[]): ApprovalPerformanceDa
 }
 
 function decisionTimeHoursFor(row: ApprovalAnalyticsRow): number[] {
-	if (!row.decidedAt) {
+	if ((row.status !== "approved" && row.status !== "rejected") || !row.decidedAt) {
 		return [];
 	}
 

--- a/apps/webapp/src/lib/analytics/types.ts
+++ b/apps/webapp/src/lib/analytics/types.ts
@@ -140,22 +140,40 @@ export type AbsencePatternsData = {
 /**
  * Manager Effectiveness Analytics
  */
+export type ApprovalBottleneckRow = {
+	id: string;
+	label: string;
+	approvedCount: number;
+	rejectedCount: number;
+	pendingCount: number;
+	pendingSlaWarnings: number;
+	avgDecisionTimeHours: number;
+	approvalRate: number;
+};
+
 export type ManagerEffectivenessData = {
 	approvalMetrics: {
 		avgResponseTime: number;
+		avgDecisionTimeHours: number;
 		totalApprovals: number;
 		totalRejections: number;
 		approvalRate: number;
+		pendingSlaWarnings: number;
 	};
 	byManager: Array<{
 		managerId: string;
 		managerName: string;
 		avgResponseTime: number;
+		avgDecisionTimeHours: number;
 		totalApprovals: number;
 		totalRejections: number;
 		approvalRate: number;
 		teamSize: number;
+		pendingCount: number;
+		pendingSlaWarnings: number;
 	}>;
+	byTeam: ApprovalBottleneckRow[];
+	byType: ApprovalBottleneckRow[];
 	responseTimeDistribution: Array<{
 		bucket: string;
 		count: number;
@@ -166,6 +184,7 @@ export type ManagerEffectivenessData = {
 		approvals: number;
 		rejections: number;
 		avgResponseTime: number;
+		avgDecisionTimeHours: number;
 	}>;
 };
 

--- a/apps/webapp/src/lib/approvals/domain/sla-calculator.ts
+++ b/apps/webapp/src/lib/approvals/domain/sla-calculator.ts
@@ -54,6 +54,32 @@ const DEFAULT_SLA_RULES: SLARule[] = [
 		escalationEnabled: false,
 	},
 
+	// Travel expenses
+	{
+		approvalType: "travel_expense_claim",
+		priority: "urgent",
+		deadlineHours: 8,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "high",
+		deadlineHours: 24,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "normal",
+		deadlineHours: 48,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "low",
+		deadlineHours: 72,
+		escalationEnabled: false,
+	},
+
 	// Shift requests
 	{
 		approvalType: "shift_request",

--- a/apps/webapp/src/lib/approvals/handlers/travel-expense-claim.handler.test.ts
+++ b/apps/webapp/src/lib/approvals/handlers/travel-expense-claim.handler.test.ts
@@ -297,9 +297,9 @@ describe("TravelExpenseClaimHandler", () => {
 				resolvedAt: null,
 				priority: "high",
 				sla: {
-					deadline: null,
-					status: "on_time",
-					hoursRemaining: null,
+					deadline: new Date("2026-04-10T10:00:00.000Z"),
+					status: "overdue",
+					hoursRemaining: -23,
 				},
 				display: {
 					title: "Travel Expense",

--- a/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
+++ b/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
@@ -11,7 +11,7 @@ import { DatabaseService } from "../database.service";
 import { AnalyticsService } from "../analytics.service";
 
 describe("AnalyticsService.getManagerEffectiveness", () => {
-	it("combines approval requests and submitted travel expense claims with manager team sizes", async () => {
+	it("combines approval sources and scopes manager team sizes through managed employees", async () => {
 		const approvalRequestFindMany = vi.fn().mockResolvedValue([
 			{
 				id: "approval-1",
@@ -51,7 +51,8 @@ describe("AnalyticsService.getManagerEffectiveness", () => {
 		]);
 		const groupBy = vi.fn().mockResolvedValue([{ managerId: "manager-1", count: 7 }]);
 		const where = vi.fn().mockReturnValue({ groupBy });
-		const from = vi.fn().mockReturnValue({ where });
+		const innerJoin = vi.fn().mockReturnValue({ where });
+		const from = vi.fn().mockReturnValue({ innerJoin });
 		const select = vi.fn().mockReturnValue({ from });
 
 		const dbLayer = Layer.succeed(
@@ -84,6 +85,8 @@ describe("AnalyticsService.getManagerEffectiveness", () => {
 		);
 
 		expect(travelExpenseClaimFindMany).toHaveBeenCalledTimes(1);
+		expect(innerJoin).toHaveBeenCalledTimes(1);
+		expect(where).toHaveBeenCalledTimes(1);
 		expect(result.approvalMetrics.totalApprovals).toBe(1);
 		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(4);
 		expect(result.approvalMetrics.pendingSlaWarnings).toBe(1);

--- a/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
+++ b/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
@@ -1,0 +1,99 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/time-tracking/calculations", () => ({
+	calculateExpectedWorkHours: vi.fn(),
+	calculateExpectedWorkHoursForEmployee: vi.fn(),
+	calculateWorkHours: vi.fn(),
+}));
+
+import { DatabaseService } from "../database.service";
+import { AnalyticsService } from "../analytics.service";
+
+describe("AnalyticsService.getManagerEffectiveness", () => {
+	it("combines approval requests and submitted travel expense claims with manager team sizes", async () => {
+		const approvalRequestFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "approval-1",
+				organizationId: "org-1",
+				entityType: "absence_entry",
+				requestedBy: "employee-1",
+				approverId: "manager-1",
+				status: "approved",
+				createdAt: new Date("2026-04-01T08:00:00.000Z"),
+				approvedAt: new Date("2026-04-01T12:00:00.000Z"),
+				updatedAt: new Date("2026-04-03T12:00:00.000Z"),
+				approver: { user: { name: "Mina Manager" } },
+				requester: {
+					teamId: "team-1",
+					user: { name: "Riley Requester" },
+					team: { name: "Operations" },
+				},
+			},
+		]);
+		const travelExpenseClaimFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "claim-1",
+				organizationId: "org-1",
+				employeeId: "employee-2",
+				approverId: "manager-1",
+				type: "travel_expense_claim",
+				status: "submitted",
+				submittedAt: new Date("2026-04-02T08:00:00.000Z"),
+				decidedAt: null,
+				employee: {
+					teamId: "team-2",
+					user: { name: "Tara Traveler" },
+					team: { name: "Field Sales" },
+				},
+				approver: { user: { name: "Mina Manager" } },
+			},
+		]);
+		const groupBy = vi.fn().mockResolvedValue([{ managerId: "manager-1", count: 7 }]);
+		const where = vi.fn().mockReturnValue({ groupBy });
+		const from = vi.fn().mockReturnValue({ where });
+		const select = vi.fn().mockReturnValue({ from });
+
+		const dbLayer = Layer.succeed(
+			DatabaseService,
+			DatabaseService.of({
+				db: {
+					query: {
+						approvalRequest: { findMany: approvalRequestFindMany },
+						travelExpenseClaim: { findMany: travelExpenseClaimFindMany },
+					},
+					select,
+				} as never,
+				query: (_name, query) => Effect.promise(query) as never,
+			}),
+		);
+
+		const result = await Effect.runPromise(
+			Effect.gen(function* (_) {
+				const service = yield* _(AnalyticsService);
+				return yield* _(
+					service.getManagerEffectiveness({
+						organizationId: "org-1",
+						dateRange: {
+							start: new Date("2026-04-01T00:00:00.000Z"),
+							end: new Date("2026-04-30T23:59:59.999Z"),
+						},
+					}),
+				);
+			}).pipe(Effect.provide(AnalyticsService.Live), Effect.provide(dbLayer)),
+		);
+
+		expect(travelExpenseClaimFindMany).toHaveBeenCalledTimes(1);
+		expect(result.approvalMetrics.totalApprovals).toBe(1);
+		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(4);
+		expect(result.approvalMetrics.pendingSlaWarnings).toBe(1);
+		expect(result.byManager[0]).toMatchObject({
+			managerId: "manager-1",
+			managerName: "Mina Manager",
+			teamSize: 7,
+			pendingCount: 1,
+		});
+		expect(result.byTeam.map((row) => row.label)).toContain("Field Sales");
+		expect(result.byType.map((row) => row.id)).toContain("travel_expense_claim");
+	});
+});

--- a/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
+++ b/apps/webapp/src/lib/effect/services/__tests__/analytics-manager-effectiveness.service.test.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect";
 import { describe, expect, it, vi } from "vitest";
+import { employee } from "@/db/schema";
 
 vi.mock("@/lib/time-tracking/calculations", () => ({
 	calculateExpectedWorkHours: vi.fn(),
@@ -9,6 +10,21 @@ vi.mock("@/lib/time-tracking/calculations", () => ({
 
 import { DatabaseService } from "../database.service";
 import { AnalyticsService } from "../analytics.service";
+
+function conditionIncludes(value: unknown, expected: unknown): boolean {
+	const seen = new WeakSet<object>();
+
+	function visit(current: unknown): boolean {
+		if (current === expected) return true;
+		if (!current || typeof current !== "object") return false;
+		if (seen.has(current)) return false;
+
+		seen.add(current);
+		return Object.values(current).some(visit);
+	}
+
+	return visit(value);
+}
 
 describe("AnalyticsService.getManagerEffectiveness", () => {
 	it("combines approval sources and scopes manager team sizes through managed employees", async () => {
@@ -87,6 +103,9 @@ describe("AnalyticsService.getManagerEffectiveness", () => {
 		expect(travelExpenseClaimFindMany).toHaveBeenCalledTimes(1);
 		expect(innerJoin).toHaveBeenCalledTimes(1);
 		expect(where).toHaveBeenCalledTimes(1);
+		const teamSizeWhereCondition = where.mock.calls[0]?.[0];
+		expect(conditionIncludes(teamSizeWhereCondition, employee.organizationId)).toBe(true);
+		expect(conditionIncludes(teamSizeWhereCondition, "org-1")).toBe(true);
 		expect(result.approvalMetrics.totalApprovals).toBe(1);
 		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(4);
 		expect(result.approvalMetrics.pendingSlaWarnings).toBe(1);

--- a/apps/webapp/src/lib/effect/services/analytics.service.ts
+++ b/apps/webapp/src/lib/effect/services/analytics.service.ts
@@ -918,6 +918,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							dbService.query("getApprovalsForEffectiveness", async () => {
 								return await dbService.db.query.approvalRequest.findMany({
 									where: and(
+										eq(approvalRequest.organizationId, organizationId),
 										gte(approvalRequest.createdAt, dateRange.start),
 										lte(approvalRequest.createdAt, dateRange.end),
 										managerId ? eq(approvalRequest.approverId, managerId) : undefined,
@@ -945,17 +946,17 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							approvals.length > 0 ? (totalApprovals / approvals.length) * 100 : 0;
 
 						// Calculate average response time
-						const responseTimes = approvals
+						const responseTimeHours = approvals
 							.filter((a) => a.updatedAt && a.createdAt)
 							.map((a) => {
 								const created = new Date(a.createdAt);
 								const updated = new Date(a.updatedAt!);
-								return differenceInDays(updated, created);
+								return (updated.getTime() - created.getTime()) / (1000 * 60 * 60);
 							});
 
-						const avgResponseTime =
-							responseTimes.length > 0
-								? responseTimes.reduce((sum, t) => sum + t, 0) / responseTimes.length
+						const avgResponseTimeHours =
+							responseTimeHours.length > 0
+								? responseTimeHours.reduce((sum, t) => sum + t, 0) / responseTimeHours.length
 								: 0;
 
 						// Group by manager
@@ -965,7 +966,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 								name: string;
 								approvals: number;
 								rejections: number;
-								responseTimes: number[];
+								responseTimeHours: number[];
 							}
 						>();
 
@@ -977,7 +978,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 								name: approval.approver.user.name || "Unknown",
 								approvals: 0,
 								rejections: 0,
-								responseTimes: [] as number[],
+								responseTimeHours: [] as number[],
 							};
 
 							if (approval.status === "approved") existing.approvals++;
@@ -986,7 +987,9 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							if (approval.updatedAt && approval.createdAt) {
 								const created = new Date(approval.createdAt);
 								const updated = new Date(approval.updatedAt);
-								existing.responseTimes.push(differenceInDays(updated, created));
+								existing.responseTimeHours.push(
+									(updated.getTime() - created.getTime()) / (1000 * 60 * 60),
+								);
 							}
 
 							managerMap.set(key, existing);
@@ -1015,17 +1018,18 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 
 						const byManager = Array.from(managerMap.entries()).map(([managerId, data]) => {
 							const total = data.approvals + data.rejections;
-							const avgResponse =
-								data.responseTimes.length > 0
-									? data.responseTimes.reduce((sum, t) => sum + t, 0) / data.responseTimes.length
+							const avgResponseHours =
+								data.responseTimeHours.length > 0
+									? data.responseTimeHours.reduce((sum, t) => sum + t, 0) /
+										data.responseTimeHours.length
 									: 0;
-							const roundedAvgResponse = Math.round(avgResponse * 100) / 100;
+							const roundedAvgResponse = Math.round((avgResponseHours / 24) * 100) / 100;
 
 							return {
 								managerId,
 								managerName: data.name,
 								avgResponseTime: roundedAvgResponse,
-								avgDecisionTimeHours: Math.round(roundedAvgResponse * 24 * 100) / 100,
+								avgDecisionTimeHours: Math.round(avgResponseHours * 100) / 100,
 								totalApprovals: data.approvals,
 								totalRejections: data.rejections,
 								approvalRate: total > 0 ? (data.approvals / total) * 100 : 0,
@@ -1043,12 +1047,13 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							"> 7 days": 0,
 						};
 
-						for (const rt of responseTimes) {
-							if (rt < 1) {
+						for (const rt of responseTimeHours) {
+							const days = rt / 24;
+							if (days < 1) {
 								distributionBuckets["< 1 day"]++;
-							} else if (rt <= 3) {
+							} else if (days <= 3) {
 								distributionBuckets["1-3 days"]++;
-							} else if (rt <= 7) {
+							} else if (days <= 7) {
 								distributionBuckets["3-7 days"]++;
 							} else {
 								distributionBuckets["> 7 days"]++;
@@ -1060,14 +1065,16 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 								bucket,
 								count,
 								percentage:
-									responseTimes.length > 0 ? Math.round((count / responseTimes.length) * 100) : 0,
+									responseTimeHours.length > 0
+										? Math.round((count / responseTimeHours.length) * 100)
+										: 0,
 							}),
 						);
 
 						// Calculate monthly trends
 						const monthlyMap = new Map<
 							string,
-							{ approvals: number; rejections: number; totalResponseTime: number; count: number }
+							{ approvals: number; rejections: number; totalResponseTimeHours: number; count: number }
 						>();
 
 						for (const approval of approvals) {
@@ -1075,7 +1082,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							const existing = monthlyMap.get(month) || {
 								approvals: 0,
 								rejections: 0,
-								totalResponseTime: 0,
+								totalResponseTimeHours: 0,
 								count: 0,
 							};
 
@@ -1085,7 +1092,8 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							if (approval.updatedAt && approval.createdAt) {
 								const created = new Date(approval.createdAt);
 								const updated = new Date(approval.updatedAt);
-								existing.totalResponseTime += differenceInDays(updated, created);
+								existing.totalResponseTimeHours +=
+									(updated.getTime() - created.getTime()) / (1000 * 60 * 60);
 								existing.count++;
 							}
 
@@ -1095,26 +1103,26 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 						const trends = Array.from(monthlyMap.entries())
 							.sort((a, b) => a[0].localeCompare(b[0]))
 							.map(([month, data]) => {
+								const avgResponseTimeHours =
+									data.count > 0 ? data.totalResponseTimeHours / data.count : 0;
 								const avgResponseTime =
-									data.count > 0
-										? Math.round((data.totalResponseTime / data.count) * 100) / 100
-										: 0;
+									data.count > 0 ? Math.round((avgResponseTimeHours / 24) * 100) / 100 : 0;
 
 								return {
 									month,
 									approvals: data.approvals,
 									rejections: data.rejections,
 									avgResponseTime,
-									avgDecisionTimeHours: Math.round(avgResponseTime * 24 * 100) / 100,
+									avgDecisionTimeHours: Math.round(avgResponseTimeHours * 100) / 100,
 								};
 							});
 
-						const roundedAvgResponseTime = Math.round(avgResponseTime * 100) / 100;
+						const roundedAvgResponseTime = Math.round((avgResponseTimeHours / 24) * 100) / 100;
 
 						return {
 							approvalMetrics: {
 								avgResponseTime: roundedAvgResponseTime,
-								avgDecisionTimeHours: Math.round(roundedAvgResponseTime * 24 * 100) / 100,
+								avgDecisionTimeHours: Math.round(avgResponseTimeHours * 100) / 100,
 								totalApprovals,
 								totalRejections,
 								approvalRate: Math.round(approvalRate * 100) / 100,

--- a/apps/webapp/src/lib/effect/services/analytics.service.ts
+++ b/apps/webapp/src/lib/effect/services/analytics.service.ts
@@ -1042,7 +1042,13 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 										count: sql<number>`count(*)::int`,
 									})
 									.from(employeeManagers)
-									.where(inArray(employeeManagers.managerId, managerIds))
+									.innerJoin(employee, eq(employeeManagers.employeeId, employee.id))
+									.where(
+										and(
+											inArray(employeeManagers.managerId, managerIds),
+											eq(employee.organizationId, organizationId),
+										),
+									)
 									.groupBy(employeeManagers.managerId);
 							}),
 						);

--- a/apps/webapp/src/lib/effect/services/analytics.service.ts
+++ b/apps/webapp/src/lib/effect/services/analytics.service.ts
@@ -1019,15 +1019,19 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 								data.responseTimes.length > 0
 									? data.responseTimes.reduce((sum, t) => sum + t, 0) / data.responseTimes.length
 									: 0;
+							const roundedAvgResponse = Math.round(avgResponse * 100) / 100;
 
 							return {
 								managerId,
 								managerName: data.name,
-								avgResponseTime: Math.round(avgResponse * 100) / 100,
+								avgResponseTime: roundedAvgResponse,
+								avgDecisionTimeHours: Math.round(roundedAvgResponse * 24 * 100) / 100,
 								totalApprovals: data.approvals,
 								totalRejections: data.rejections,
 								approvalRate: total > 0 ? (data.approvals / total) * 100 : 0,
 								teamSize: teamSizeMap.get(managerId) || 0,
+								pendingCount: 0,
+								pendingSlaWarnings: 0,
 							};
 						});
 
@@ -1090,24 +1094,35 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 
 						const trends = Array.from(monthlyMap.entries())
 							.sort((a, b) => a[0].localeCompare(b[0]))
-							.map(([month, data]) => ({
-								month,
-								approvals: data.approvals,
-								rejections: data.rejections,
-								avgResponseTime:
+							.map(([month, data]) => {
+								const avgResponseTime =
 									data.count > 0
 										? Math.round((data.totalResponseTime / data.count) * 100) / 100
-										: 0,
-							}));
+										: 0;
+
+								return {
+									month,
+									approvals: data.approvals,
+									rejections: data.rejections,
+									avgResponseTime,
+									avgDecisionTimeHours: Math.round(avgResponseTime * 24 * 100) / 100,
+								};
+							});
+
+						const roundedAvgResponseTime = Math.round(avgResponseTime * 100) / 100;
 
 						return {
 							approvalMetrics: {
-								avgResponseTime: Math.round(avgResponseTime * 100) / 100,
+								avgResponseTime: roundedAvgResponseTime,
+								avgDecisionTimeHours: Math.round(roundedAvgResponseTime * 24 * 100) / 100,
 								totalApprovals,
 								totalRejections,
 								approvalRate: Math.round(approvalRate * 100) / 100,
+								pendingSlaWarnings: 0,
 							},
 							byManager,
+							byTeam: [],
+							byType: [],
 							responseTimeDistribution,
 							trends,
 						};

--- a/apps/webapp/src/lib/effect/services/analytics.service.ts
+++ b/apps/webapp/src/lib/effect/services/analytics.service.ts
@@ -6,7 +6,7 @@
  * absence patterns, and manager effectiveness metrics.
  */
 
-import { and, eq, gte, isNull, lte, or, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { DateTime } from "luxon";
 import {
@@ -15,8 +15,13 @@ import {
 	employee,
 	employeeCostCenterAssignment,
 	employeeManagers,
+	travelExpenseClaim,
 	workPeriod,
 } from "@/db/schema";
+import {
+	buildApprovalPerformanceData,
+	type ApprovalAnalyticsRow,
+} from "@/lib/analytics/approval-performance";
 import type {
 	AbsencePatternsData,
 	AbsencePatternsParams,
@@ -33,6 +38,11 @@ import type {
 	WorkHoursAnalyticsData,
 	WorkHoursParams,
 } from "@/lib/analytics/types";
+import {
+	calculateSLADeadline,
+	calculateSLAStatus,
+} from "@/lib/approvals/domain/sla-calculator";
+import type { ApprovalPriority, ApprovalType } from "@/lib/approvals/domain/types";
 import { clampOvertime } from "@/lib/analytics/overtime-burndown";
 import { differenceInDays, format } from "@/lib/datetime/luxon-utils";
 import {
@@ -120,6 +130,23 @@ function toTrendDirection(delta: number): TrendDirection {
 	if (delta > 0) return "up";
 	if (delta < 0) return "down";
 	return "flat";
+}
+
+function isApprovalType(type: string): type is ApprovalType {
+	return ["absence_entry", "time_entry", "shift_request", "travel_expense_claim"].includes(type);
+}
+
+function getSlaStatusForAnalytics(
+	type: string,
+	priority: ApprovalPriority,
+	submittedAt: Date,
+): ApprovalAnalyticsRow["slaStatus"] {
+	if (!isApprovalType(type)) return null;
+
+	const deadline = calculateSLADeadline(type, priority, submittedAt);
+	if (!deadline) return null;
+
+	return calculateSLAStatus(deadline).status;
 }
 
 function buildGroupedOvertimeRows(
@@ -913,7 +940,6 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 					Effect.gen(function* (_) {
 						const { organizationId, dateRange, managerId } = params;
 
-						// Get all approval requests in date range
 						const approvals = yield* _(
 							dbService.query("getApprovalsForEffectiveness", async () => {
 								return await dbService.db.query.approvalRequest.findMany({
@@ -932,6 +958,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 										requester: {
 											with: {
 												user: true,
+												team: true,
 											},
 										},
 									},
@@ -939,71 +966,73 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							}),
 						);
 
-						// Calculate metrics
-						const totalApprovals = approvals.filter((a) => a.status === "approved").length;
-						const totalRejections = approvals.filter((a) => a.status === "rejected").length;
-						const decidedCount = totalApprovals + totalRejections;
-						const approvalRate = decidedCount > 0 ? (totalApprovals / decidedCount) * 100 : 0;
+						const travelClaims = yield* _(
+							dbService.query("getTravelExpenseClaimsForEffectiveness", async () => {
+								return await dbService.db.query.travelExpenseClaim.findMany({
+									where: and(
+										eq(travelExpenseClaim.organizationId, organizationId),
+										gte(travelExpenseClaim.submittedAt, dateRange.start),
+										lte(travelExpenseClaim.submittedAt, dateRange.end),
+										inArray(travelExpenseClaim.status, ["submitted", "approved", "rejected"]),
+										isNotNull(travelExpenseClaim.submittedAt),
+										managerId ? eq(travelExpenseClaim.approverId, managerId) : undefined,
+									),
+									with: {
+										employee: {
+											with: {
+												user: true,
+												team: true,
+											},
+										},
+										approver: {
+											with: {
+												user: true,
+											},
+										},
+									},
+								});
+							}),
+						);
 
-						// Calculate average response time
-						const responseTimeHours = approvals
-							.filter(
-								(a) =>
-									(a.status === "approved" || a.status === "rejected") && a.updatedAt && a.createdAt,
-							)
-							.map((a) => {
-								const created = new Date(a.createdAt);
-								const updated = new Date(a.updatedAt!);
-								return (updated.getTime() - created.getTime()) / (1000 * 60 * 60);
-							});
+						const approvalRows: ApprovalAnalyticsRow[] = approvals.map((approval) => ({
+							source: "approval_request",
+							type: approval.entityType,
+							organizationId: approval.organizationId,
+							requesterEmployeeId: approval.requestedBy,
+							requesterTeamId: approval.requester?.teamId ?? null,
+							requesterTeamName: approval.requester?.team?.name ?? null,
+							approverEmployeeId: approval.approverId,
+							approverName: approval.approver?.user.name ?? null,
+							status: approval.status,
+							submittedAt: approval.createdAt,
+							decidedAt: approval.approvedAt,
+							slaStatus: getSlaStatusForAnalytics(approval.entityType, "normal", approval.createdAt),
+						}));
 
-						const avgResponseTimeHours =
-							responseTimeHours.length > 0
-								? responseTimeHours.reduce((sum, t) => sum + t, 0) / responseTimeHours.length
-								: 0;
+						const travelRows: ApprovalAnalyticsRow[] = travelClaims
+							.filter((claim) => claim.submittedAt)
+							.map((claim) => ({
+								source: "travel_expense_claim",
+								type: "travel_expense_claim",
+								organizationId: claim.organizationId,
+								requesterEmployeeId: claim.employeeId,
+								requesterTeamId: claim.employee?.teamId ?? null,
+								requesterTeamName: claim.employee?.team?.name ?? null,
+								approverEmployeeId: claim.approverId,
+								approverName: claim.approver?.user.name ?? null,
+								status: claim.status === "submitted" ? "pending" : claim.status,
+								submittedAt: claim.submittedAt!,
+								decidedAt: claim.decidedAt,
+								slaStatus: getSlaStatusForAnalytics("travel_expense_claim", "normal", claim.submittedAt!),
+							}));
 
-						// Group by manager
-						const managerMap = new Map<
-							string,
-							{
-								name: string;
-								approvals: number;
-								rejections: number;
-								responseTimeHours: number[];
-							}
-						>();
-
-						for (const approval of approvals) {
-							if (!approval.approver) continue;
-
-							const key = approval.approverId;
-							const existing = managerMap.get(key) || {
-								name: approval.approver.user.name || "Unknown",
-								approvals: 0,
-								rejections: 0,
-								responseTimeHours: [] as number[],
-							};
-
-							if (approval.status === "approved") existing.approvals++;
-							if (approval.status === "rejected") existing.rejections++;
-
-							if (
-								(approval.status === "approved" || approval.status === "rejected") &&
-								approval.updatedAt &&
-								approval.createdAt
-							) {
-								const created = new Date(approval.createdAt);
-								const updated = new Date(approval.updatedAt);
-								existing.responseTimeHours.push(
-									(updated.getTime() - created.getTime()) / (1000 * 60 * 60),
-								);
-							}
-
-							managerMap.set(key, existing);
-						}
-
-						// Get team sizes for all managers
-						const managerIds = Array.from(managerMap.keys());
+						const managerEffectiveness = buildApprovalPerformanceData([
+							...approvalRows,
+							...travelRows,
+						]);
+						const managerIds = managerEffectiveness.byManager
+							.map((manager) => manager.managerId)
+							.filter((id) => id !== "unassigned");
 						const teamSizes = yield* _(
 							dbService.query("getTeamSizes", async () => {
 								if (managerIds.length === 0) return [];
@@ -1013,7 +1042,7 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 										count: sql<number>`count(*)::int`,
 									})
 									.from(employeeManagers)
-									.where(sql`${employeeManagers.managerId} = ANY(${managerIds})`)
+									.where(inArray(employeeManagers.managerId, managerIds))
 									.groupBy(employeeManagers.managerId);
 							}),
 						);
@@ -1023,127 +1052,12 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							teamSizeMap.set(ts.managerId, ts.count);
 						}
 
-						const byManager = Array.from(managerMap.entries()).map(([managerId, data]) => {
-							const total = data.approvals + data.rejections;
-							const avgResponseHours =
-								data.responseTimeHours.length > 0
-									? data.responseTimeHours.reduce((sum, t) => sum + t, 0) /
-										data.responseTimeHours.length
-									: 0;
-							const roundedAvgResponse = Math.round((avgResponseHours / 24) * 100) / 100;
-
-							return {
-								managerId,
-								managerName: data.name,
-								avgResponseTime: roundedAvgResponse,
-								avgDecisionTimeHours: Math.round(avgResponseHours * 100) / 100,
-								totalApprovals: data.approvals,
-								totalRejections: data.rejections,
-								approvalRate: total > 0 ? (data.approvals / total) * 100 : 0,
-								teamSize: teamSizeMap.get(managerId) || 0,
-								pendingCount: 0,
-								pendingSlaWarnings: 0,
-							};
-						});
-
-						// Calculate response time distribution
-						const distributionBuckets = {
-							"< 1 day": 0,
-							"1-3 days": 0,
-							"3-7 days": 0,
-							"> 7 days": 0,
-						};
-
-						for (const rt of responseTimeHours) {
-							const days = rt / 24;
-							if (days < 1) {
-								distributionBuckets["< 1 day"]++;
-							} else if (days <= 3) {
-								distributionBuckets["1-3 days"]++;
-							} else if (days <= 7) {
-								distributionBuckets["3-7 days"]++;
-							} else {
-								distributionBuckets["> 7 days"]++;
-							}
-						}
-
-						const responseTimeDistribution = Object.entries(distributionBuckets).map(
-							([bucket, count]) => ({
-								bucket,
-								count,
-								percentage:
-									responseTimeHours.length > 0
-										? Math.round((count / responseTimeHours.length) * 100)
-										: 0,
-							}),
-						);
-
-						// Calculate monthly trends
-						const monthlyMap = new Map<
-							string,
-							{ approvals: number; rejections: number; totalResponseTimeHours: number; count: number }
-						>();
-
-						for (const approval of approvals) {
-							const month = DateTime.fromJSDate(new Date(approval.createdAt)).toFormat("yyyy-MM");
-							const existing = monthlyMap.get(month) || {
-								approvals: 0,
-								rejections: 0,
-								totalResponseTimeHours: 0,
-								count: 0,
-							};
-
-							if (approval.status === "approved") existing.approvals++;
-							if (approval.status === "rejected") existing.rejections++;
-
-							if (
-								(approval.status === "approved" || approval.status === "rejected") &&
-								approval.updatedAt &&
-								approval.createdAt
-							) {
-								const created = new Date(approval.createdAt);
-								const updated = new Date(approval.updatedAt);
-								existing.totalResponseTimeHours +=
-									(updated.getTime() - created.getTime()) / (1000 * 60 * 60);
-								existing.count++;
-							}
-
-							monthlyMap.set(month, existing);
-						}
-
-						const trends = Array.from(monthlyMap.entries())
-							.sort((a, b) => a[0].localeCompare(b[0]))
-							.map(([month, data]) => {
-								const avgResponseTimeHours =
-									data.count > 0 ? data.totalResponseTimeHours / data.count : 0;
-								const avgResponseTime =
-									data.count > 0 ? Math.round((avgResponseTimeHours / 24) * 100) / 100 : 0;
-
-								return {
-									month,
-									approvals: data.approvals,
-									rejections: data.rejections,
-									avgResponseTime,
-									avgDecisionTimeHours: Math.round(avgResponseTimeHours * 100) / 100,
-								};
-							});
-
-						const roundedAvgResponseTime = Math.round((avgResponseTimeHours / 24) * 100) / 100;
-
 						return {
-							approvalMetrics: {
-								avgResponseTime: roundedAvgResponseTime,
-								avgDecisionTimeHours: Math.round(avgResponseTimeHours * 100) / 100,
-								totalApprovals,
-								totalRejections,
-								approvalRate: Math.round(approvalRate * 100) / 100,
-								pendingSlaWarnings: 0,
-							},
-							byManager,
-							byTeam: [],
-							byType: [],
-							responseTimeDistribution,
-							trends,
+							...managerEffectiveness,
+							byManager: managerEffectiveness.byManager.map((manager) => ({
+								...manager,
+								teamSize: teamSizeMap.get(manager.managerId) || 0,
+							})),
 						};
 					}),
 

--- a/apps/webapp/src/lib/effect/services/analytics.service.ts
+++ b/apps/webapp/src/lib/effect/services/analytics.service.ts
@@ -942,12 +942,15 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 						// Calculate metrics
 						const totalApprovals = approvals.filter((a) => a.status === "approved").length;
 						const totalRejections = approvals.filter((a) => a.status === "rejected").length;
-						const approvalRate =
-							approvals.length > 0 ? (totalApprovals / approvals.length) * 100 : 0;
+						const decidedCount = totalApprovals + totalRejections;
+						const approvalRate = decidedCount > 0 ? (totalApprovals / decidedCount) * 100 : 0;
 
 						// Calculate average response time
 						const responseTimeHours = approvals
-							.filter((a) => a.updatedAt && a.createdAt)
+							.filter(
+								(a) =>
+									(a.status === "approved" || a.status === "rejected") && a.updatedAt && a.createdAt,
+							)
 							.map((a) => {
 								const created = new Date(a.createdAt);
 								const updated = new Date(a.updatedAt!);
@@ -984,7 +987,11 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							if (approval.status === "approved") existing.approvals++;
 							if (approval.status === "rejected") existing.rejections++;
 
-							if (approval.updatedAt && approval.createdAt) {
+							if (
+								(approval.status === "approved" || approval.status === "rejected") &&
+								approval.updatedAt &&
+								approval.createdAt
+							) {
 								const created = new Date(approval.createdAt);
 								const updated = new Date(approval.updatedAt);
 								existing.responseTimeHours.push(
@@ -1089,7 +1096,11 @@ export class AnalyticsService extends Context.Tag("AnalyticsService")<
 							if (approval.status === "approved") existing.approvals++;
 							if (approval.status === "rejected") existing.rejections++;
 
-							if (approval.updatedAt && approval.createdAt) {
+							if (
+								(approval.status === "approved" || approval.status === "rejected") &&
+								approval.updatedAt &&
+								approval.createdAt
+							) {
 								const created = new Date(approval.createdAt);
 								const updated = new Date(approval.updatedAt);
 								existing.totalResponseTimeHours +=

--- a/docs/superpowers/plans/2026-04-26-approval-performance-analytics.md
+++ b/docs/superpowers/plans/2026-04-26-approval-performance-analytics.md
@@ -1,0 +1,1071 @@
+# Approval Performance Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hardcoded analytics approval rate with real, organization-scoped approval performance metrics across unified approvals and travel expense claims.
+
+**Architecture:** Add a small pure helper module that normalizes approval-like rows and computes metrics, then use it from `AnalyticsService.getManagerEffectiveness`. Keep database access in the existing service and keep `analytics/page.tsx` as a thin client that renders returned metrics and bottlenecks.
+
+**Tech Stack:** TypeScript, Next.js client page and server actions, Drizzle ORM, Effect services, Luxon for date math, Vitest and React Testing Library.
+
+---
+
+## File Structure
+
+- Create: `apps/webapp/src/lib/analytics/approval-performance.ts`
+  - Owns pure types and calculations for normalized approval analytics rows.
+  - Does not import database schema or React.
+- Create: `apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts`
+  - Tests approval rate, decision time, grouping, travel expense inclusion semantics, draft exclusion semantics, and SLA warning behavior through pure helper inputs.
+- Modify: `apps/webapp/src/lib/analytics/types.ts`
+  - Extends `ManagerEffectivenessData` with decision-time and bottleneck fields.
+- Modify: `apps/webapp/src/lib/effect/services/analytics.service.ts`
+  - Fetches organization-scoped `approval_request` and `travel_expense_claim` rows.
+  - Converts rows to normalized analytics rows and calls the helper.
+- Create: `apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx`
+  - Verifies the page requests manager effectiveness analytics and renders the real approval rate.
+- Modify: `apps/webapp/src/app/[locale]/(app)/analytics/page.tsx`
+  - Loads `getManagerEffectivenessData(dateRange)` and renders real KPI and compact bottlenecks.
+
+## Task 1: Add Pure Approval Performance Calculations
+
+**Files:**
+- Create: `apps/webapp/src/lib/analytics/approval-performance.ts`
+- Create: `apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts`
+
+- [ ] **Step 1: Write failing tests for approval metrics**
+
+Create `apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { buildApprovalPerformanceData } from "../approval-performance";
+
+const baseSubmittedAt = new Date("2026-04-01T08:00:00.000Z");
+
+describe("buildApprovalPerformanceData", () => {
+	const baseRow = {
+		source: "approval_request" as const,
+		type: "absence_entry",
+		organizationId: "org-1",
+		requesterEmployeeId: "employee-1",
+		requesterTeamId: "team-1",
+		requesterTeamName: "Operations",
+		approverEmployeeId: "manager-1",
+		approverName: "Mina Manager",
+		status: "approved" as const,
+		submittedAt: baseSubmittedAt,
+		decidedAt: new Date("2026-04-01T12:00:00.000Z"),
+		slaStatus: "on_time" as const,
+	};
+
+	it("calculates approval rate from decided rows and excludes pending rows", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				status: "rejected",
+				decidedAt: new Date("2026-04-01T10:00:00.000Z"),
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.totalApprovals).toBe(1);
+		expect(result.approvalMetrics.totalRejections).toBe(1);
+		expect(result.approvalMetrics.approvalRate).toBe(50);
+	});
+
+	it("calculates average decision time in hours from decidedAt and submittedAt", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				decidedAt: new Date("2026-04-01T16:00:00.000Z"),
+			},
+		]);
+
+		expect(result.approvalMetrics.avgDecisionTimeHours).toBe(6);
+		expect(result.approvalMetrics.avgResponseTime).toBe(0.25);
+	});
+
+	it("counts pending SLA warnings for approaching and overdue rows", () => {
+		const result = buildApprovalPerformanceData([
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "approaching",
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "overdue",
+			},
+			{
+				...baseRow,
+				status: "pending",
+				decidedAt: null,
+				slaStatus: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.pendingSlaWarnings).toBe(2);
+		expect(result.byManager[0]?.pendingSlaWarnings).toBe(2);
+	});
+
+	it("groups bottlenecks by manager, requester team, and approval type", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				source: "travel_expense_claim",
+				type: "travel_expense_claim",
+				requesterTeamId: "team-2",
+				requesterTeamName: "Field Sales",
+				approverEmployeeId: "manager-2",
+				approverName: "Tara Travel",
+				status: "pending",
+				decidedAt: null,
+				slaStatus: "overdue",
+			},
+		]);
+
+		expect(result.byManager.map((row) => row.managerName)).toEqual(["Tara Travel", "Mina Manager"]);
+		expect(result.byTeam.map((row) => row.label)).toContain("Field Sales");
+		expect(result.byType.map((row) => row.label)).toContain("Travel Expense Claim");
+	});
+
+	it("excludes draft-like rows before calculation", () => {
+		const result = buildApprovalPerformanceData([
+			baseRow,
+			{
+				...baseRow,
+				source: "travel_expense_claim",
+				type: "travel_expense_claim",
+				status: "draft",
+				decidedAt: null,
+			},
+		]);
+
+		expect(result.approvalMetrics.totalApprovals).toBe(1);
+		expect(result.byType).toHaveLength(1);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts`
+
+Expected: FAIL with an import error for `../approval-performance`.
+
+- [ ] **Step 3: Implement the pure helper module**
+
+Create `apps/webapp/src/lib/analytics/approval-performance.ts`:
+
+```ts
+import type { ManagerEffectivenessData } from "./types";
+
+export type ApprovalAnalyticsStatus = "pending" | "approved" | "rejected" | "draft";
+export type ApprovalAnalyticsSource = "approval_request" | "travel_expense_claim";
+export type ApprovalAnalyticsSlaStatus = "on_time" | "approaching" | "overdue" | null;
+
+export type ApprovalAnalyticsRow = {
+	source: ApprovalAnalyticsSource;
+	type: string;
+	organizationId: string;
+	requesterEmployeeId: string;
+	requesterTeamId: string | null;
+	requesterTeamName: string | null;
+	approverEmployeeId: string | null;
+	approverName: string | null;
+	status: ApprovalAnalyticsStatus;
+	submittedAt: Date;
+	decidedAt: Date | null;
+	slaStatus: ApprovalAnalyticsSlaStatus;
+};
+
+type GroupAccumulator = {
+	id: string;
+	label: string;
+	approved: number;
+	rejected: number;
+	pending: number;
+	pendingSlaWarnings: number;
+	decisionTimeHours: number[];
+};
+
+function roundToTwoDecimals(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function decisionTimeHours(row: ApprovalAnalyticsRow): number | null {
+	if (!row.decidedAt) return null;
+	return (row.decidedAt.getTime() - row.submittedAt.getTime()) / (1000 * 60 * 60);
+}
+
+function isSlaWarning(row: ApprovalAnalyticsRow): boolean {
+	return row.status === "pending" && (row.slaStatus === "approaching" || row.slaStatus === "overdue");
+}
+
+function formatTypeLabel(type: string): string {
+	return type
+		.split("_")
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function createGroup(id: string, label: string): GroupAccumulator {
+	return {
+		id,
+		label,
+		approved: 0,
+		rejected: 0,
+		pending: 0,
+		pendingSlaWarnings: 0,
+		decisionTimeHours: [],
+	};
+}
+
+function addRowToGroup(group: GroupAccumulator, row: ApprovalAnalyticsRow): void {
+	if (row.status === "approved") group.approved += 1;
+	if (row.status === "rejected") group.rejected += 1;
+	if (row.status === "pending") group.pending += 1;
+	if (isSlaWarning(row)) group.pendingSlaWarnings += 1;
+
+	const hours = decisionTimeHours(row);
+	if (hours !== null) group.decisionTimeHours.push(hours);
+}
+
+function average(values: number[]): number {
+	if (values.length === 0) return 0;
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function toBottleneckRow(group: GroupAccumulator) {
+	const decided = group.approved + group.rejected;
+	const avgDecisionTimeHours = roundToTwoDecimals(average(group.decisionTimeHours));
+
+	return {
+		id: group.id,
+		label: group.label,
+		approvedCount: group.approved,
+		rejectedCount: group.rejected,
+		pendingCount: group.pending,
+		pendingSlaWarnings: group.pendingSlaWarnings,
+		avgDecisionTimeHours,
+		approvalRate: decided > 0 ? roundToTwoDecimals((group.approved / decided) * 100) : 0,
+	};
+}
+
+function sortBottlenecks<T extends { pendingSlaWarnings: number; pendingCount: number; avgDecisionTimeHours: number }>(
+	rows: T[],
+): T[] {
+	return rows.sort(
+		(a, b) =>
+			b.pendingSlaWarnings - a.pendingSlaWarnings ||
+			b.pendingCount - a.pendingCount ||
+			b.avgDecisionTimeHours - a.avgDecisionTimeHours,
+	);
+}
+
+function groupRows(
+	rows: ApprovalAnalyticsRow[],
+	selectGroup: (row: ApprovalAnalyticsRow) => { id: string; label: string },
+) {
+	const groups = new Map<string, GroupAccumulator>();
+
+	for (const row of rows) {
+		const selected = selectGroup(row);
+		const existing = groups.get(selected.id) ?? createGroup(selected.id, selected.label);
+		addRowToGroup(existing, row);
+		groups.set(selected.id, existing);
+	}
+
+	return sortBottlenecks(Array.from(groups.values()).map(toBottleneckRow));
+}
+
+export function buildApprovalPerformanceData(inputRows: ApprovalAnalyticsRow[]): ManagerEffectivenessData {
+	const rows = inputRows.filter((row) => row.status !== "draft");
+	const approvedRows = rows.filter((row) => row.status === "approved");
+	const rejectedRows = rows.filter((row) => row.status === "rejected");
+	const decisionTimes = rows.map(decisionTimeHours).filter((value): value is number => value !== null);
+	const decidedCount = approvedRows.length + rejectedRows.length;
+	const avgDecisionTimeHours = roundToTwoDecimals(average(decisionTimes));
+
+	const byManagerGroups = groupRows(rows, (row) => ({
+		id: row.approverEmployeeId ?? "unassigned",
+		label: row.approverName ?? "Unassigned",
+	}));
+
+	return {
+		approvalMetrics: {
+			avgResponseTime: roundToTwoDecimals(avgDecisionTimeHours / 24),
+			avgDecisionTimeHours,
+			totalApprovals: approvedRows.length,
+			totalRejections: rejectedRows.length,
+			approvalRate: decidedCount > 0 ? roundToTwoDecimals((approvedRows.length / decidedCount) * 100) : 0,
+			pendingSlaWarnings: rows.filter(isSlaWarning).length,
+		},
+		byManager: byManagerGroups.map((row) => ({
+			managerId: row.id,
+			managerName: row.label,
+			avgResponseTime: roundToTwoDecimals(row.avgDecisionTimeHours / 24),
+			avgDecisionTimeHours: row.avgDecisionTimeHours,
+			totalApprovals: row.approvedCount,
+			totalRejections: row.rejectedCount,
+			approvalRate: row.approvalRate,
+			teamSize: 0,
+			pendingCount: row.pendingCount,
+			pendingSlaWarnings: row.pendingSlaWarnings,
+		})),
+		byTeam: groupRows(rows, (row) => ({
+			id: row.requesterTeamId ?? "unassigned",
+			label: row.requesterTeamName ?? "Unassigned",
+		})),
+		byType: groupRows(rows, (row) => ({
+			id: row.type,
+			label: formatTypeLabel(row.type),
+		})),
+		responseTimeDistribution: buildResponseTimeDistribution(decisionTimes),
+		trends: buildMonthlyTrends(rows),
+	};
+}
+
+function buildResponseTimeDistribution(decisionTimes: number[]) {
+	const buckets = [
+		{ bucket: "< 1 day", count: 0 },
+		{ bucket: "1-3 days", count: 0 },
+		{ bucket: "3-7 days", count: 0 },
+		{ bucket: "> 7 days", count: 0 },
+	];
+
+	for (const hours of decisionTimes) {
+		if (hours < 24) buckets[0].count += 1;
+		else if (hours <= 72) buckets[1].count += 1;
+		else if (hours <= 168) buckets[2].count += 1;
+		else buckets[3].count += 1;
+	}
+
+	return buckets.map((bucket) => ({
+		...bucket,
+		percentage: decisionTimes.length > 0 ? Math.round((bucket.count / decisionTimes.length) * 100) : 0,
+	}));
+}
+
+function buildMonthlyTrends(rows: ApprovalAnalyticsRow[]) {
+	const monthly = new Map<string, { approvals: number; rejections: number; decisionTimes: number[] }>();
+
+	for (const row of rows) {
+		const month = row.submittedAt.toISOString().slice(0, 7);
+		const existing = monthly.get(month) ?? { approvals: 0, rejections: 0, decisionTimes: [] };
+		if (row.status === "approved") existing.approvals += 1;
+		if (row.status === "rejected") existing.rejections += 1;
+		const hours = decisionTimeHours(row);
+		if (hours !== null) existing.decisionTimes.push(hours);
+		monthly.set(month, existing);
+	}
+
+	return Array.from(monthly.entries())
+		.sort((a, b) => a[0].localeCompare(b[0]))
+		.map(([month, data]) => ({
+			month,
+			approvals: data.approvals,
+			rejections: data.rejections,
+			avgResponseTime: roundToTwoDecimals(average(data.decisionTimes) / 24),
+			avgDecisionTimeHours: roundToTwoDecimals(average(data.decisionTimes)),
+		}));
+}
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit helper and tests**
+
+Run:
+
+```bash
+git add apps/webapp/src/lib/analytics/approval-performance.ts apps/webapp/src/lib/analytics/__tests__/approval-performance.test.ts
+git commit -m "feat: add approval performance calculations"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Extend Analytics Types
+
+**Files:**
+- Modify: `apps/webapp/src/lib/analytics/types.ts:143-170`
+- Test: `apps/webapp/src/lib/analytics/__tests__/types.approval-performance.test.ts`
+
+- [ ] **Step 1: Add type-level test for new analytics shape**
+
+Create `apps/webapp/src/lib/analytics/__tests__/types.approval-performance.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import type { ManagerEffectivenessData } from "../types";
+
+describe("ManagerEffectivenessData approval performance shape", () => {
+	it("supports decision-time and bottleneck metrics", () => {
+		const data = {
+			approvalMetrics: {
+				avgResponseTime: 0.25,
+				avgDecisionTimeHours: 6,
+				totalApprovals: 2,
+				totalRejections: 1,
+				approvalRate: 66.67,
+				pendingSlaWarnings: 3,
+			},
+			byManager: [
+				{
+					managerId: "manager-1",
+					managerName: "Mina Manager",
+					avgResponseTime: 0.25,
+					avgDecisionTimeHours: 6,
+					totalApprovals: 2,
+					totalRejections: 1,
+					approvalRate: 66.67,
+					teamSize: 4,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+				},
+			],
+			byTeam: [
+				{
+					id: "team-1",
+					label: "Operations",
+					approvedCount: 2,
+					rejectedCount: 1,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+					avgDecisionTimeHours: 6,
+					approvalRate: 66.67,
+				},
+			],
+			byType: [
+				{
+					id: "absence_entry",
+					label: "Absence Entry",
+					approvedCount: 2,
+					rejectedCount: 1,
+					pendingCount: 2,
+					pendingSlaWarnings: 1,
+					avgDecisionTimeHours: 6,
+					approvalRate: 66.67,
+				},
+			],
+			responseTimeDistribution: [{ bucket: "< 1 day", count: 3, percentage: 100 }],
+			trends: [
+				{
+					month: "2026-04",
+					approvals: 2,
+					rejections: 1,
+					avgResponseTime: 0.25,
+					avgDecisionTimeHours: 6,
+				},
+			],
+		} satisfies ManagerEffectivenessData;
+
+		expect(data.approvalMetrics.pendingSlaWarnings).toBe(3);
+	});
+});
+```
+
+- [ ] **Step 2: Run type test to verify it fails**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/types.approval-performance.test.ts`
+
+Expected: FAIL with TypeScript errors for missing fields in `ManagerEffectivenessData`.
+
+- [ ] **Step 3: Extend `ManagerEffectivenessData`**
+
+In `apps/webapp/src/lib/analytics/types.ts`, replace the `ManagerEffectivenessData` type with:
+
+```ts
+export type ApprovalBottleneckRow = {
+	id: string;
+	label: string;
+	approvedCount: number;
+	rejectedCount: number;
+	pendingCount: number;
+	pendingSlaWarnings: number;
+	avgDecisionTimeHours: number;
+	approvalRate: number;
+};
+
+export type ManagerEffectivenessData = {
+	approvalMetrics: {
+		avgResponseTime: number;
+		avgDecisionTimeHours: number;
+		totalApprovals: number;
+		totalRejections: number;
+		approvalRate: number;
+		pendingSlaWarnings: number;
+	};
+	byManager: Array<{
+		managerId: string;
+		managerName: string;
+		avgResponseTime: number;
+		avgDecisionTimeHours: number;
+		totalApprovals: number;
+		totalRejections: number;
+		approvalRate: number;
+		teamSize: number;
+		pendingCount: number;
+		pendingSlaWarnings: number;
+	}>;
+	byTeam: ApprovalBottleneckRow[];
+	byType: ApprovalBottleneckRow[];
+	responseTimeDistribution: Array<{
+		bucket: string;
+		count: number;
+		percentage: number;
+	}>;
+	trends: Array<{
+		month: string;
+		approvals: number;
+		rejections: number;
+		avgResponseTime: number;
+		avgDecisionTimeHours: number;
+	}>;
+};
+```
+
+- [ ] **Step 4: Run analytics type and helper tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/types.approval-performance.test.ts src/lib/analytics/__tests__/approval-performance.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit type changes**
+
+Run:
+
+```bash
+git add apps/webapp/src/lib/analytics/types.ts apps/webapp/src/lib/analytics/__tests__/types.approval-performance.test.ts
+git commit -m "feat: extend approval analytics types"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Use Real Approval Sources In AnalyticsService
+
+**Files:**
+- Modify: `apps/webapp/src/lib/effect/services/analytics.service.ts:9-19`
+- Modify: `apps/webapp/src/lib/effect/services/analytics.service.ts:912-1114`
+
+- [ ] **Step 1: Run current analytics helper tests before service changes**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Update imports in `analytics.service.ts`**
+
+Add `inArray` to the Drizzle imports and add travel expense schema plus helper imports:
+
+```ts
+import { and, eq, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import {
+	absenceEntry,
+	approvalRequest,
+	employee,
+	employeeCostCenterAssignment,
+	employeeManagers,
+	travelExpenseClaim,
+	workPeriod,
+} from "@/db/schema";
+import {
+	buildApprovalPerformanceData,
+	type ApprovalAnalyticsRow,
+} from "@/lib/analytics/approval-performance";
+import { calculateSLADeadline, calculateSLAStatus } from "@/lib/approvals/domain/sla-calculator";
+import type { ApprovalPriority, ApprovalType } from "@/lib/approvals/domain/types";
+```
+
+- [ ] **Step 3: Replace `getManagerEffectiveness` implementation**
+
+Replace the body of `getManagerEffectiveness: (params: ManagerEffectivenessParams) => Effect.gen(...)` with this implementation:
+
+```ts
+getManagerEffectiveness: (params: ManagerEffectivenessParams) =>
+	Effect.gen(function* (_) {
+		const { organizationId, dateRange, managerId } = params;
+
+		const approvalRequests = yield* _(
+			dbService.query("getApprovalRequestsForEffectiveness", async () => {
+				return await dbService.db.query.approvalRequest.findMany({
+					where: and(
+						eq(approvalRequest.organizationId, organizationId),
+						gte(approvalRequest.createdAt, dateRange.start),
+						lte(approvalRequest.createdAt, dateRange.end),
+						managerId ? eq(approvalRequest.approverId, managerId) : undefined,
+					),
+					with: {
+						approver: { with: { user: true } },
+						requester: { with: { user: true, team: true } },
+					},
+				});
+			}),
+		);
+
+		const travelClaims = yield* _(
+			dbService.query("getTravelExpenseClaimsForEffectiveness", async () => {
+				return await dbService.db.query.travelExpenseClaim.findMany({
+					where: and(
+						eq(travelExpenseClaim.organizationId, organizationId),
+						gte(travelExpenseClaim.submittedAt, dateRange.start),
+						lte(travelExpenseClaim.submittedAt, dateRange.end),
+						inArray(travelExpenseClaim.status, ["submitted", "approved", "rejected"]),
+						managerId ? eq(travelExpenseClaim.approverId, managerId) : undefined,
+					),
+					with: {
+						employee: { with: { user: true, team: true } },
+						approver: { with: { user: true } },
+					},
+				});
+			}),
+		);
+
+		const approvalRows: ApprovalAnalyticsRow[] = approvalRequests.map((request) => {
+			const type = request.entityType as ApprovalType;
+			const slaDeadline = calculateSLADeadline(type, "normal" satisfies ApprovalPriority, request.createdAt);
+			const slaStatus = request.status === "pending" ? calculateSLAStatus(slaDeadline).status : null;
+
+			return {
+				source: "approval_request",
+				type: request.entityType,
+				organizationId: request.organizationId,
+				requesterEmployeeId: request.requestedBy,
+				requesterTeamId: request.requester?.teamId ?? null,
+				requesterTeamName: request.requester?.team?.name ?? null,
+				approverEmployeeId: request.approverId,
+				approverName: request.approver?.user.name ?? null,
+				status: request.status,
+				submittedAt: request.createdAt,
+				decidedAt: request.approvedAt,
+				slaStatus,
+			};
+		});
+
+		const travelRows: ApprovalAnalyticsRow[] = travelClaims
+			.filter((claim) => claim.submittedAt !== null)
+			.map((claim) => {
+				const slaDeadline = calculateSLADeadline(
+					"travel_expense_claim",
+					"normal" satisfies ApprovalPriority,
+					claim.submittedAt!,
+				);
+				const status = claim.status === "submitted" ? "pending" : claim.status;
+				const slaStatus = status === "pending" ? calculateSLAStatus(slaDeadline).status : null;
+
+				return {
+					source: "travel_expense_claim",
+					type: "travel_expense_claim",
+					organizationId: claim.organizationId,
+					requesterEmployeeId: claim.employeeId,
+					requesterTeamId: claim.employee?.teamId ?? null,
+					requesterTeamName: claim.employee?.team?.name ?? null,
+					approverEmployeeId: claim.approverId,
+					approverName: claim.approver?.user.name ?? null,
+					status,
+					submittedAt: claim.submittedAt!,
+					decidedAt: claim.decidedAt,
+					slaStatus,
+				};
+			});
+
+		const data = buildApprovalPerformanceData([...approvalRows, ...travelRows]);
+
+		const managerIds = data.byManager
+			.map((row) => row.managerId)
+			.filter((id) => id !== "unassigned");
+
+		const teamSizes = yield* _(
+			dbService.query("getApprovalAnalyticsTeamSizes", async () => {
+				if (managerIds.length === 0) return [];
+				return await dbService.db
+					.select({
+						managerId: employeeManagers.managerId,
+						count: sql<number>`count(*)::int`,
+					})
+					.from(employeeManagers)
+					.where(inArray(employeeManagers.managerId, managerIds))
+					.groupBy(employeeManagers.managerId);
+			}),
+		);
+
+		const teamSizeMap = new Map(teamSizes.map((row) => [row.managerId, row.count]));
+
+		return {
+			...data,
+			byManager: data.byManager.map((row) => ({
+				...row,
+				teamSize: teamSizeMap.get(row.managerId) ?? 0,
+			})),
+		};
+	}),
+```
+
+- [ ] **Step 4: Fix type errors from unsupported SLA type if needed**
+
+If TypeScript rejects `"travel_expense_claim"` for `calculateSLADeadline`, update `apps/webapp/src/lib/approvals/domain/sla-calculator.ts` default rules by adding normal travel expense defaults after the time correction rules:
+
+```ts
+	{
+		approvalType: "travel_expense_claim",
+		priority: "normal",
+		deadlineHours: 48,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "high",
+		deadlineHours: 24,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "urgent",
+		deadlineHours: 8,
+		escalationEnabled: true,
+	},
+	{
+		approvalType: "travel_expense_claim",
+		priority: "low",
+		deadlineHours: 72,
+		escalationEnabled: false,
+	},
+```
+
+- [ ] **Step 5: Run targeted tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts src/lib/analytics/__tests__/types.approval-performance.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run TypeScript/build check for service integration**
+
+Run: `pnpm --dir apps/webapp build`
+
+Expected: build completes without TypeScript errors. If it fails because environment variables are unavailable, stop the build and record the exact missing variable message in the final verification notes.
+
+- [ ] **Step 7: Commit service integration**
+
+Run:
+
+```bash
+git add apps/webapp/src/lib/effect/services/analytics.service.ts apps/webapp/src/lib/approvals/domain/sla-calculator.ts
+git commit -m "feat: include approval sources in analytics"
+```
+
+Expected: commit succeeds. If `sla-calculator.ts` was not changed, omit it from `git add`.
+
+## Task 4: Render Real Approval Analytics On Overview Page
+
+**Files:**
+- Create: `apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(app)/analytics/page.tsx:20-67`
+- Modify: `apps/webapp/src/app/[locale]/(app)/analytics/page.tsx:145-154`
+- Modify: `apps/webapp/src/app/[locale]/(app)/analytics/page.tsx:222-223`
+
+- [ ] **Step 1: Write failing page test**
+
+Create `apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx`:
+
+```tsx
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getTeamPerformanceDataMock, getAbsencePatternsDataMock, getManagerEffectivenessDataMock } = vi.hoisted(
+	() => ({
+		getTeamPerformanceDataMock: vi.fn(),
+		getAbsencePatternsDataMock: vi.fn(),
+		getManagerEffectivenessDataMock: vi.fn(),
+	}),
+);
+
+vi.mock("next/dynamic", () => ({
+	default: () => () => null,
+}));
+
+vi.mock("sonner", () => ({
+	toast: { error: vi.fn() },
+}));
+
+vi.mock("@/components/analytics/export-button", () => ({
+	ExportButton: () => <button type="button">Export</button>,
+}));
+
+vi.mock("@/components/reports/date-range-picker", () => ({
+	DateRangePicker: () => <div>Date range</div>,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+	Card: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+	CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+	CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	CardTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/chart", () => ({
+	ChartContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	ChartTooltip: () => null,
+	ChartTooltipContent: () => null,
+}));
+
+vi.mock("./actions", () => ({
+	getTeamPerformanceData: getTeamPerformanceDataMock,
+	getAbsencePatternsData: getAbsencePatternsDataMock,
+	getManagerEffectivenessData: getManagerEffectivenessDataMock,
+}));
+
+import AnalyticsOverviewPage from "./page";
+
+describe("AnalyticsOverviewPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getTeamPerformanceDataMock.mockResolvedValue({
+			success: true,
+			data: { teams: [], organizationTotal: 0, dateRange: { start: new Date(), end: new Date() } },
+		});
+		getAbsencePatternsDataMock.mockResolvedValue({
+			success: true,
+			data: {
+				summary: { totalAbsences: 0, totalDays: 0, avgDaysPerAbsence: 0, absenceRate: 0 },
+				byType: [],
+				byTeam: [],
+				patterns: {
+					sickLeavePatterns: { avgDuration: 0, peakMonths: [], frequentEmployees: [] },
+					vacationClustering: { score: 0, hotspots: [] },
+				},
+				timeline: [],
+			},
+		});
+		getManagerEffectivenessDataMock.mockResolvedValue({
+			success: true,
+			data: {
+				approvalMetrics: {
+					avgResponseTime: 0.25,
+					avgDecisionTimeHours: 6,
+					totalApprovals: 8,
+					totalRejections: 2,
+					approvalRate: 80,
+					pendingSlaWarnings: 3,
+				},
+				byManager: [],
+				byTeam: [{ id: "team-1", label: "Operations", approvedCount: 8, rejectedCount: 2, pendingCount: 4, pendingSlaWarnings: 3, avgDecisionTimeHours: 6, approvalRate: 80 }],
+				byType: [],
+				responseTimeDistribution: [],
+				trends: [],
+			},
+		});
+	});
+
+	it("renders approval rate from manager effectiveness analytics", async () => {
+		render(<AnalyticsOverviewPage />);
+
+		await waitFor(() => {
+			expect(getManagerEffectivenessDataMock).toHaveBeenCalled();
+		});
+
+		expect(screen.getByText("80.0%")).toBeTruthy();
+		expect(screen.getByText("Of decided requests approved")).toBeTruthy();
+		expect(screen.getByText("Approval Bottlenecks")).toBeTruthy();
+		expect(screen.getByText("Operations")).toBeTruthy();
+	});
+});
+```
+
+- [ ] **Step 2: Run page test to verify it fails**
+
+Run: `pnpm --dir apps/webapp test 'src/app/[locale]/(app)/analytics/page.test.tsx'`
+
+Expected: FAIL because `getManagerEffectivenessData` is not imported or rendered by the page.
+
+- [ ] **Step 3: Update page state and data loading**
+
+In `apps/webapp/src/app/[locale]/(app)/analytics/page.tsx`, update imports and state:
+
+```tsx
+import type { AbsencePatternsData, ManagerEffectivenessData, TeamPerformanceData } from "@/lib/analytics/types";
+import { getAbsencePatternsData, getManagerEffectivenessData, getTeamPerformanceData } from "./actions";
+
+const [managerData, setManagerData] = useState<ManagerEffectivenessData | null>(null);
+```
+
+Replace the `Promise.all` block with:
+
+```tsx
+const [teamResult, absenceResult, managerResult] = await Promise.all([
+	getTeamPerformanceData(dateRange),
+	getAbsencePatternsData(dateRange),
+	getManagerEffectivenessData(dateRange),
+]);
+
+if (teamResult.success && teamResult.data) {
+	setTeamData(teamResult.data);
+}
+if (absenceResult.success && absenceResult.data) {
+	setAbsenceData(absenceResult.data);
+}
+if (managerResult.success && managerResult.data) {
+	setManagerData(managerResult.data);
+} else {
+	setManagerData(null);
+}
+```
+
+Replace the approval KPI calculation with:
+
+```tsx
+approvalRate: managerData?.approvalMetrics.approvalRate ?? 0,
+```
+
+- [ ] **Step 4: Update KPI helper text and add bottleneck rows**
+
+Change the Approval Rate helper text to:
+
+```tsx
+<p className="text-xs text-muted-foreground">Of decided requests approved</p>
+```
+
+Add this card after the existing chart grid and before the closing fragment:
+
+```tsx
+<Card>
+	<CardHeader>
+		<CardTitle>Approval Bottlenecks</CardTitle>
+		<CardDescription>Pending approvals with SLA warnings by team and type</CardDescription>
+	</CardHeader>
+	<CardContent>
+		{managerData && (managerData.byTeam.length > 0 || managerData.byType.length > 0) ? (
+			<div className="grid gap-4 md:grid-cols-2">
+				<BottleneckList title="Teams" rows={managerData.byTeam.slice(0, 5)} />
+				<BottleneckList title="Types" rows={managerData.byType.slice(0, 5)} />
+			</div>
+		) : (
+			<div className="py-8 text-center text-muted-foreground">No approval bottlenecks found</div>
+		)}
+	</CardContent>
+</Card>
+```
+
+Add this local component below the page component in the same file:
+
+```tsx
+function BottleneckList({
+	title,
+	rows,
+}: {
+	title: string;
+	rows: NonNullable<ManagerEffectivenessData["byTeam"]>;
+}) {
+	return (
+		<div className="space-y-3">
+			<h3 className="font-medium text-sm">{title}</h3>
+			{rows.length > 0 ? (
+				<div className="space-y-2">
+					{rows.map((row) => (
+						<div key={row.id} className="flex items-center justify-between rounded-lg border p-3">
+							<div>
+								<div className="font-medium text-sm">{row.label}</div>
+								<div className="text-muted-foreground text-xs">
+									{row.pendingCount} pending · {row.avgDecisionTimeHours.toFixed(1)}h avg decision
+								</div>
+							</div>
+							<div className="text-right">
+								<div className="font-semibold text-amber-600 text-sm">{row.pendingSlaWarnings}</div>
+								<div className="text-muted-foreground text-xs">SLA warnings</div>
+							</div>
+						</div>
+					))}
+				</div>
+			) : (
+				<div className="rounded-lg border p-3 text-muted-foreground text-sm">No bottlenecks</div>
+			)}
+		</div>
+	);
+}
+```
+
+- [ ] **Step 5: Run page test**
+
+Run: `pnpm --dir apps/webapp test 'src/app/[locale]/(app)/analytics/page.test.tsx'`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit page integration**
+
+Run:
+
+```bash
+git add 'apps/webapp/src/app/[locale]/(app)/analytics/page.tsx' 'apps/webapp/src/app/[locale]/(app)/analytics/page.test.tsx'
+git commit -m "feat: show approval performance analytics"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run targeted analytics tests**
+
+Run:
+
+```bash
+pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts src/lib/analytics/__tests__/types.approval-performance.test.ts 'src/app/[locale]/(app)/analytics/page.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full webapp tests**
+
+Run: `pnpm --dir apps/webapp test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build if environment permits**
+
+Run: `pnpm --dir apps/webapp build`
+
+Expected: PASS. If build fails because Phase-managed environment variables are unavailable to agents, record the exact skipped build reason and do not change environment configuration.
+
+- [ ] **Step 4: Inspect git status**
+
+Run: `git status --short`
+
+Expected: no uncommitted files from this implementation. If test snapshots or generated files appear, inspect them and commit only files directly caused by this work.
+
+- [ ] **Step 5: Final commit if verification fixes were needed**
+
+If Task 5 required fixes, commit them:
+
+```bash
+git add <changed-files>
+git commit -m "fix: stabilize approval analytics verification"
+```
+
+Expected: commit succeeds. If there were no fixes, skip this step.
+
+## Self-Review Notes
+
+- Spec coverage: Tasks cover the normalized row, approval rate, decision time, manager/team/type bottlenecks, SLA warnings, UI rendering, error/empty-state behavior, and tests.
+- Placeholder scan: The plan contains concrete files, commands, and code snippets for each implementation step.
+- Type consistency: `avgDecisionTimeHours`, `pendingSlaWarnings`, `byTeam`, and `byType` are introduced in Task 2 and used consistently in later tasks.

--- a/docs/superpowers/specs/2026-04-26-approval-performance-analytics-design.md
+++ b/docs/superpowers/specs/2026-04-26-approval-performance-analytics-design.md
@@ -1,0 +1,107 @@
+# Approval Performance Analytics Design
+
+## Goal
+
+Replace the hardcoded approval rate on `analytics/page.tsx` with real approval performance analytics. The first version will calculate approval rate, average decision time, bottlenecks by manager/team/type, and SLA warnings for the selected date range.
+
+## Current Context
+
+The analytics overview page currently derives team and absence metrics from server actions, but its approval KPI is hardcoded as `95.0`. A `getManagerEffectivenessData` server action and `AnalyticsService.getManagerEffectiveness` implementation already exist, but the current service query is incomplete for this feature because it does not consistently scope results by organization, uses `updatedAt` as a response-time proxy, and only reads `approval_request` records. Travel expense approvals use `travel_expense_claim.submittedAt` and `travel_expense_claim.decidedAt`, with decision audit data in `travel_expense_decision_log`.
+
+## Data Sources
+
+Approval analytics will include two sources:
+
+- `approval_request` for existing absence, time, and other unified approval requests.
+- `travel_expense_claim` for submitted travel expense approvals.
+
+Draft travel expense claims are excluded because they were not submitted for approval.
+
+All data must be filtered by the authenticated employee's `organizationId` on the server. The client must not provide an organization identifier.
+
+## Normalized Analytics Row
+
+Inside `AnalyticsService.getManagerEffectiveness`, records from both sources will be normalized into one internal row shape:
+
+- `source`: `approval_request` or `travel_expense_claim`.
+- `type`: the approval type, including `travel_expense_claim`.
+- `organizationId`.
+- `requesterEmployeeId`.
+- `requesterTeamId`.
+- `approverEmployeeId`.
+- `status`: `pending`, `approved`, or `rejected`.
+- `submittedAt`.
+- `decidedAt`.
+- `slaDeadline`.
+- `slaStatus`.
+
+For `approval_request`, `submittedAt` is `createdAt` and `decidedAt` is `approvedAt` when that timestamp is present. Rejected `approval_request` records without a decision timestamp still count as rejected decisions for approval-rate totals, but they are excluded from average decision time because the actual decision time is unknown. For travel expenses, `submittedAt` is `submittedAt` and `decidedAt` is `decidedAt`.
+
+## Calculations
+
+Approval rate is calculated as approved divided by decided requests. Pending requests are excluded from the denominator so the rate describes completed decisions rather than open workload.
+
+Average decision time is calculated from actual decision timestamps: `decidedAt - submittedAt`. It is reported in hours. Records without a decision timestamp are excluded from this average.
+
+SLA warnings count pending records whose SLA status is `approaching` or `overdue`. Existing SLA calculation rules should be reused where possible. If a type is unsupported by the SLA calculator, it is excluded from SLA warning calculations rather than assigned a guessed deadline.
+
+Bottleneck groups will be calculated by:
+
+- Manager: approver employee.
+- Team: requester team.
+- Type: approval type.
+
+Rows should be sorted by highest SLA warnings first, then by highest pending count or average decision time so the most operationally relevant bottlenecks appear first.
+
+## API Shape
+
+The existing `ManagerEffectivenessData` type will be extended rather than replaced. The current `approvalMetrics`, `byManager`, `responseTimeDistribution`, and `trends` fields remain available, but response-time fields should represent real decision time rather than `updatedAt` drift.
+
+The shape will add fields for:
+
+- `approvalMetrics.avgDecisionTimeHours`.
+- `approvalMetrics.pendingSlaWarnings`.
+- `byManager[].pendingSlaWarnings`.
+- `byManager[].pendingCount`.
+- `byTeam` bottleneck rows.
+- `byType` bottleneck rows.
+
+This keeps the analytics page simple and leaves aggregation logic server-side.
+
+## UI Behavior
+
+`analytics/page.tsx` will call `getManagerEffectivenessData(dateRange)` alongside the existing team and absence analytics calls.
+
+The Approval Rate KPI card will use `managerEffectiveness.approvalMetrics.approvalRate` instead of the hardcoded `95.0`. Its helper text will describe decided requests, not all submitted requests.
+
+The page will add a compact approval bottlenecks section below the existing charts. It will show the most important manager, team, and type bottlenecks using the returned grouped rows. The UI should stay consistent with the existing restrained analytics layout and avoid introducing a new visual system.
+
+If approval analytics fails while other analytics succeed, the page should still render available data. The approval KPI should show an empty or zero state and must not fall back to fake data.
+
+## Error Handling
+
+Server-side errors should use the existing Effect and `runServerActionSafe` path. Empty datasets should return zero metrics and empty bottleneck arrays.
+
+Records with missing decision timestamps are excluded from average decision time, but they still contribute to pending counts if pending.
+
+Unknown or unsupported approval types are excluded from SLA warning counts. They can still contribute to approval rate and decision-time metrics when their status and timestamps are valid.
+
+## Testing
+
+Tests should cover:
+
+- Approval rate excludes pending requests from the denominator.
+- Average decision time uses actual decision timestamps, not `updatedAt`.
+- `approval_request` analytics are organization-scoped.
+- Submitted travel expense claims are included in approval rate and decision-time metrics.
+- Draft travel expense claims are excluded.
+- Pending SLA warnings use existing SLA rules and exclude unsupported types.
+- The analytics overview page consumes the real approval metric instead of using the hardcoded `95.0`.
+
+## Scope Boundaries
+
+This work does not add organization-specific SLA configuration. It reuses the existing SLA defaults and supported rules.
+
+This work does not add a new analytics database table or background aggregation job. Metrics are computed on demand for the selected date range.
+
+This work does not redesign the analytics page beyond adding the approval KPI data source and a compact bottleneck section.


### PR DESCRIPTION
## Summary
- Replace the hardcoded analytics approval rate with real organization-scoped approval performance calculations.
- Include approval requests and travel expense claims in manager effectiveness analytics with SLA warnings and bottlenecks.
- Render approval KPI and manager/team/type bottlenecks with failure-safe UI states.

## Test Plan
- [x] pnpm --dir apps/webapp test src/lib/analytics/__tests__/approval-performance.test.ts src/lib/analytics/__tests__/types.approval-performance.test.ts 'src/app/[locale]/(app)/analytics/page.test.tsx'
- [x] pnpm --dir apps/webapp test
- [x] pnpm --dir apps/webapp build compiled and TypeScript completed; page data collection stopped because Phase-managed env vars are unavailable to agents: BETTER_AUTH_SECRET, S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_ENDPOINT, S3_PUBLIC_URL