### PR TITLE
chore: clean up old GHCR package versions

### DIFF
--- a/.github/workflows/publish-docs-image.yml
+++ b/.github/workflows/publish-docs-image.yml
@@ -138,3 +138,20 @@ jobs:
               "$IMAGE_NAME@$AMD64_DIGEST" \
               "$IMAGE_NAME@$ARM64_DIGEST"
           done
+
+  cleanup-package-versions:
+    name: Cleanup Package Versions
+    needs: publish-manifest
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Delete old package versions
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: umami-creative-gmbh
+          package-name: z8-docs
+          package-type: container
+          min-versions-to-keep: 10
+          ignore-versions: '^(latest|v.*)$'

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -267,3 +267,28 @@ jobs:
               "$AMD64_REFERENCE" \
               "$ARM64_REFERENCE"
           done
+
+  cleanup-package-versions:
+    name: Cleanup Package Versions (${{ matrix.repository }})
+    needs: publish-manifests
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repository:
+          - z8-webapp
+          - z8-worker
+          - z8-migration
+
+    steps:
+      - name: Delete old package versions
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ env.IMAGE_NAMESPACE }}
+          package-name: ${{ matrix.repository }}
+          package-type: container
+          min-versions-to-keep: 10
+          ignore-versions: '^(latest|v.*)$'

--- a/.github/workflows/publish-marketing-image.yml
+++ b/.github/workflows/publish-marketing-image.yml
@@ -135,3 +135,20 @@ jobs:
               "$IMAGE_NAME@$AMD64_DIGEST" \
               "$IMAGE_NAME@$ARM64_DIGEST"
           done
+
+  cleanup-package-versions:
+    name: Cleanup Package Versions
+    needs: publish-manifest
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Delete old package versions
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: umami-creative-gmbh
+          package-name: z8-marketing
+          package-type: container
+          min-versions-to-keep: 10
+          ignore-versions: '^(latest|v.*)$'

--- a/scripts/ci/verify-publish-docs-image-workflow.mjs
+++ b/scripts/ci/verify-publish-docs-image-workflow.mjs
@@ -18,7 +18,7 @@ function expect(condition, message) {
 }
 
 function getJobBlock(jobName) {
-	const lines = workflow.split("\n");
+	const lines = workflow.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `  ${jobName}:`);
 	if (startIndex === -1) {
 		return null;
@@ -36,7 +36,7 @@ function getJobBlock(jobName) {
 }
 
 function getStepBlock(jobBlock, stepName) {
-	const lines = jobBlock.split("\n");
+	const lines = jobBlock.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `      - name: ${stepName}`);
 	if (startIndex === -1) {
 		return null;
@@ -61,9 +61,11 @@ function includesAll(text, snippets, context) {
 
 const buildNativeJob = getJobBlock("build-native");
 const publishManifestJob = getJobBlock("publish-manifest");
+const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 
 expect(buildNativeJob, "Missing build-native job");
 expect(publishManifestJob, "Missing publish-manifest job");
+expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
 
 if (buildNativeJob) {
 	const verifyStep = getStepBlock(buildNativeJob, "Verify workflow contract");
@@ -158,6 +160,24 @@ if (publishManifestJob) {
 			"publish-manifest Create and push multi-arch manifests",
 		);
 	}
+}
+
+if (cleanupPackageVersionsJob) {
+	includesAll(
+		cleanupPackageVersionsJob,
+		[
+			"name: Cleanup Package Versions",
+			"needs: publish-manifest",
+			"if: ${{ github.event_name != 'pull_request' }}",
+			"uses: actions/delete-package-versions@v5",
+			"owner: umami-creative-gmbh",
+			"package-name: z8-docs",
+			"package-type: container",
+			"min-versions-to-keep: 10",
+			"ignore-versions: '^(latest|v.*)$'",
+		],
+		"cleanup-package-versions",
+	);
 }
 
 if (errors.length > 0) {

--- a/scripts/ci/verify-publish-images-workflow.mjs
+++ b/scripts/ci/verify-publish-images-workflow.mjs
@@ -15,7 +15,7 @@ function expect(condition, message) {
 }
 
 function getJobBlock(jobName) {
-	const lines = workflow.split("\n");
+	const lines = workflow.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `  ${jobName}:`);
 	if (startIndex === -1) {
 		return null;
@@ -33,7 +33,7 @@ function getJobBlock(jobName) {
 }
 
 function getStepBlock(jobBlock, stepName) {
-	const lines = jobBlock.split("\n");
+	const lines = jobBlock.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `      - name: ${stepName}`);
 	if (startIndex === -1) {
 		return null;
@@ -58,9 +58,11 @@ function includesAll(text, snippets, context) {
 
 const publishTargetsJob = getJobBlock("publish-targets");
 const publishManifestsJob = getJobBlock("publish-manifests");
+const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 
 expect(publishTargetsJob, "Missing publish-targets job");
 expect(publishManifestsJob, "Missing publish-manifests job");
+expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
 
 if (publishTargetsJob) {
 	const verifyStep = getStepBlock(publishTargetsJob, "Verify workflow contract");
@@ -184,6 +186,28 @@ if (publishManifestsJob) {
 			"publish-manifests Validate target artifacts",
 		);
 	}
+}
+
+if (cleanupPackageVersionsJob) {
+	includesAll(
+		cleanupPackageVersionsJob,
+		[
+			"name: Cleanup Package Versions (${{ matrix.repository }})",
+			"needs: publish-manifests",
+			"if: ${{ github.event_name != 'pull_request' }}",
+			"repository:",
+			"- z8-webapp",
+			"- z8-worker",
+			"- z8-migration",
+			"uses: actions/delete-package-versions@v5",
+			"owner: ${{ env.IMAGE_NAMESPACE }}",
+			"package-name: ${{ matrix.repository }}",
+			"package-type: container",
+			"min-versions-to-keep: 10",
+			"ignore-versions: '^(latest|v.*)$'",
+		],
+		"cleanup-package-versions",
+	);
 }
 
 expect(

--- a/scripts/ci/verify-publish-marketing-image-workflow.mjs
+++ b/scripts/ci/verify-publish-marketing-image-workflow.mjs
@@ -18,7 +18,7 @@ function expect(condition, message) {
 }
 
 function getJobBlock(jobName) {
-	const lines = workflow.split("\n");
+	const lines = workflow.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `  ${jobName}:`);
 	if (startIndex === -1) {
 		return null;
@@ -36,7 +36,7 @@ function getJobBlock(jobName) {
 }
 
 function getStepBlock(jobBlock, stepName) {
-	const lines = jobBlock.split("\n");
+	const lines = jobBlock.split(/\r?\n/);
 	const startIndex = lines.findIndex((line) => line === `      - name: ${stepName}`);
 	if (startIndex === -1) {
 		return null;
@@ -61,9 +61,11 @@ function includesAll(text, snippets, context) {
 
 const buildNativeJob = getJobBlock("build-native");
 const publishManifestJob = getJobBlock("publish-manifest");
+const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 
 expect(buildNativeJob, "Missing build-native job");
 expect(publishManifestJob, "Missing publish-manifest job");
+expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
 
 if (buildNativeJob) {
 	const verifyStep = getStepBlock(buildNativeJob, "Verify workflow contract");
@@ -128,6 +130,24 @@ if (publishManifestJob) {
 		"Create and push multi-arch manifests",
 	);
 	expect(publishStep, "Missing multi-arch manifest publish step");
+}
+
+if (cleanupPackageVersionsJob) {
+	includesAll(
+		cleanupPackageVersionsJob,
+		[
+			"name: Cleanup Package Versions",
+			"needs: publish-manifest",
+			"if: ${{ github.event_name != 'pull_request' }}",
+			"uses: actions/delete-package-versions@v5",
+			"owner: umami-creative-gmbh",
+			"package-name: z8-marketing",
+			"package-type: container",
+			"min-versions-to-keep: 10",
+			"ignore-versions: '^(latest|v.*)$'",
+		],
+		"cleanup-package-versions",
+	);
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- Add post-publish GHCR cleanup jobs for webapp, worker, migration, docs, and marketing images.
- Keep 10 package versions while preserving `latest` and `v*` release tags.
- Extend publish workflow contract verifiers and make their line parsing CRLF-safe.

## Test Plan
- [x] `node scripts/ci/verify-publish-images-workflow.mjs`
- [x] `node scripts/ci/verify-publish-docs-image-workflow.mjs`
- [x] `node scripts/ci/verify-publish-marketing-image-workflow.mjs`