### PR TITLE
Fix absence calendar holiday spans

### DIFF
--- a/apps/webapp/src/components/absences/absence-calendar.tsx
+++ b/apps/webapp/src/components/absences/absence-calendar.tsx
@@ -8,6 +8,7 @@ import { useWeekStartDay } from "@/components/providers/user-preferences-provide
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { isHolidayOnDate } from "@/lib/absences/absence-calendar-adapter";
 import type { AbsenceWithCategory, DayPeriod, Holiday } from "@/lib/absences/types";
 import { cn } from "@/lib/utils";
 
@@ -87,10 +88,7 @@ export function AbsenceCalendar({ absences, holidays }: AbsenceCalendarProps) {
 		// Check for holidays
 		const matchingHolidays: Array<Pick<Holiday, "id" | "name">> = [];
 		for (const holiday of holidays) {
-			const start = DateTime.fromJSDate(holiday.startDate);
-			const end = DateTime.fromJSDate(holiday.endDate);
-
-			if (date >= start.startOf("day") && date <= end.endOf("day")) {
+			if (isHolidayOnDate(holiday, date.toJSDate())) {
 				matchingHolidays.push({ id: holiday.id, name: holiday.name });
 			}
 		}

--- a/apps/webapp/src/components/dashboard/use-widget-data.test.tsx
+++ b/apps/webapp/src/components/dashboard/use-widget-data.test.tsx
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWidgetData } from "./use-widget-data";
+
+const { toastErrorMock } = vi.hoisted(() => ({
+	toastErrorMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { error: toastErrorMock },
+}));
+
+vi.mock("@/hooks/use-organization", () => ({
+	useOrganization: () => ({ organizationId: "org-1" }),
+}));
+
+describe("useWidgetData", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not show a load failure toast after the widget unmounts", async () => {
+		let rejectLoad: (error: Error) => void = () => {};
+		const fetcher = vi.fn(
+			() =>
+				new Promise<{ success: boolean }>((_resolve, reject) => {
+					rejectLoad = reject;
+				}),
+		);
+
+		const { unmount } = renderHook(() =>
+			useWidgetData(fetcher, { errorMessage: "Failed to load quick stats" }),
+		);
+
+		await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+		unmount();
+
+		await act(async () => {
+			rejectLoad(new Error("Route changed before the widget finished loading"));
+		});
+
+		expect(toastErrorMock).not.toHaveBeenCalled();
+	});
+
+	it("shows a load failure toast while the widget is still mounted", async () => {
+		const fetcher = vi.fn().mockRejectedValue(new Error("Network failed"));
+
+		renderHook(() => useWidgetData(fetcher, { errorMessage: "Failed to load quick stats" }));
+
+		await waitFor(() =>
+			expect(toastErrorMock).toHaveBeenCalledWith("Failed to load quick stats"),
+		);
+	});
+});

--- a/apps/webapp/src/components/dashboard/use-widget-data.ts
+++ b/apps/webapp/src/components/dashboard/use-widget-data.ts
@@ -23,6 +23,7 @@ export function useWidgetData<T>(
 	const [loading, setLoading] = useState(true);
 	const [refreshing, setRefreshing] = useState(false);
 	const prevOrgIdRef = useRef<string | null>(null);
+	const mountedRef = useRef(false);
 
 	const loadData = useCallback(
 		async (isRefresh = false) => {
@@ -31,18 +32,35 @@ export function useWidgetData<T>(
 			}
 			try {
 				const result = await fetcher();
+				if (!mountedRef.current) {
+					return;
+				}
 				if (result.success && result.data) {
 					setData(result.data);
 				}
 			} catch {
+				if (!mountedRef.current) {
+					return;
+				}
 				toast.error(options?.errorMessage ?? "Failed to load data");
 			} finally {
+				if (!mountedRef.current) {
+					return;
+				}
 				setLoading(false);
 				setRefreshing(false);
 			}
 		},
 		[fetcher, options?.errorMessage],
 	);
+
+	useEffect(() => {
+		mountedRef.current = true;
+
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
 
 	// Initial load
 	useEffect(() => {

--- a/apps/webapp/src/lib/absences/absence-calendar-adapter.test.ts
+++ b/apps/webapp/src/lib/absences/absence-calendar-adapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { holidaysToCalendarEvents } from "./absence-calendar-adapter";
+import type { Holiday } from "./types";
+
+describe("holidaysToCalendarEvents", () => {
+	it("keeps holidays on a single day when the stored end date is next-day midnight", () => {
+		const holiday: Holiday = {
+			id: "holiday-1",
+			name: "Labor Day",
+			startDate: new Date("2026-05-01T00:00:00.000Z"),
+			endDate: new Date("2026-05-02T00:00:00.000Z"),
+			categoryId: "category-1",
+		};
+
+		const events = holidaysToCalendarEvents([holiday]);
+
+		expect(events).toHaveLength(1);
+		expect(events[0]?.date.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+	});
+});

--- a/apps/webapp/src/lib/absences/absence-calendar-adapter.ts
+++ b/apps/webapp/src/lib/absences/absence-calendar-adapter.ts
@@ -15,6 +15,10 @@ function formatDateKey(date: Date): string {
 	return `${year}-${month}-${day}`;
 }
 
+export function isHolidayOnDate(holiday: Holiday, date: Date): boolean {
+	return formatDateKey(holiday.startDate) === formatDateKey(date);
+}
+
 /**
  * Transform AbsenceWithCategory[] to CalendarEvent[]
  * Creates one event per day for multi-day absences
@@ -57,34 +61,20 @@ export function absencesToCalendarEvents(absences: AbsenceWithCategory[]): Calen
 
 /**
  * Transform Holiday[] to CalendarEvent[]
- * Creates one event per day for multi-day holidays
+ * Creates one event per holiday. Holidays are displayed on their start date only.
  */
 export function holidaysToCalendarEvents(holidays: Holiday[]): CalendarEvent[] {
-	const events: CalendarEvent[] = [];
-
-	for (const holiday of holidays) {
-		const startDate = new Date(holiday.startDate);
-		const endDate = new Date(holiday.endDate);
-
-		// For multi-day holidays, create an event for each day
-		const current = new Date(startDate);
-		while (current <= endDate) {
-			events.push({
-				id: `holiday-${holiday.id}-${formatDateKey(current)}`,
-				type: "holiday",
-				date: new Date(current),
-				title: holiday.name,
-				color: "#f59e0b", // amber-500
-				metadata: {
-					holidayId: holiday.id,
-					name: holiday.name,
-				},
-			});
-			current.setDate(current.getDate() + 1);
-		}
-	}
-
-	return events;
+	return holidays.map((holiday) => ({
+		id: `holiday-${holiday.id}-${formatDateKey(holiday.startDate)}`,
+		type: "holiday",
+		date: new Date(holiday.startDate),
+		title: holiday.name,
+		color: "#f59e0b", // amber-500
+		metadata: {
+			holidayId: holiday.id,
+			name: holiday.name,
+		},
+	}));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Keep holidays in absence calendar views on their start date only, avoiding next-day-midnight overlap.
- Add a regression test for absence holiday event expansion.
- Prevent dashboard widget load failures from showing toasts after unmount, with hook coverage.

## Test Plan
- pnpm --filter webapp test src/lib/absences/absence-calendar-adapter.test.ts
- pnpm --filter webapp test src/components/dashboard/use-widget-data.test.tsx