### PR TITLE
Optimize image publishing workflows

### DIFF
--- a/.github/workflows/publish-deploy-webhook-image.yml
+++ b/.github/workflows/publish-deploy-webhook-image.yml
@@ -6,6 +6,15 @@ on:
       - main
     tags:
       - "v*.*.*"
+    paths:
+      - ".dockerignore"
+      - "apps/deploy-webhook/**"
+      - "docker/Dockerfile.deploy-webhook"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-docs-image.yml
+++ b/.github/workflows/publish-docs-image.yml
@@ -6,6 +6,15 @@ on:
       - main
     tags:
       - "v*.*.*"
+    paths:
+      - "apps/docs/**"
+      - "docker/Dockerfile.docs"
+      - "docker/Dockerfile.docs.dockerignore"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,6 +6,21 @@ on:
       - main
     tags:
       - "v*.*.*"
+    paths:
+      - "apps/webapp/**"
+      - "docker/Dockerfile.webapp"
+      - "docker/Dockerfile.webapp.dockerignore"
+      - "docker/Dockerfile.worker"
+      - "docker/Dockerfile.worker.dockerignore"
+      - "docker/Dockerfile.migration"
+      - "docker/Dockerfile.migration.dockerignore"
+      - "docker/scripts/**"
+      - "docker/targets/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-marketing-image.yml
+++ b/.github/workflows/publish-marketing-image.yml
@@ -6,6 +6,15 @@ on:
       - main
     tags:
       - "v*.*.*"
+    paths:
+      - "apps/marketing/**"
+      - "docker/Dockerfile.marketing"
+      - "docker/Dockerfile.marketing.dockerignore"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
   workflow_dispatch:
 
 permissions:

--- a/apps/deploy-webhook/src/reconciler.test.ts
+++ b/apps/deploy-webhook/src/reconciler.test.ts
@@ -82,6 +82,22 @@ describe("Reconciler", () => {
     expect(dependencies.kube.setDeploymentImage).not.toHaveBeenCalled();
   });
 
+  it("does not deploy app runtime until webapp worker and migration share the same tag", async () => {
+    const dependencies = createDependencies({
+      observed: { "sha-app123": ["z8-webapp", "z8-worker"] },
+      deployed: {},
+      failures: {}
+    });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-webapp", "sha-app123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalled();
+    expect(dependencies.kube.runMigration).not.toHaveBeenCalled();
+    expect(dependencies.kube.setDeploymentImage).not.toHaveBeenCalled();
+    expect(dependencies.kube.waitForDeploymentRollout).not.toHaveBeenCalled();
+  });
+
   it("runs migration before patching and waiting for web and worker", async () => {
     const dependencies = createDependencies({
       observed: { "sha-abc123": ["z8-webapp", "z8-worker"] },
@@ -118,6 +134,23 @@ describe("Reconciler", () => {
     expect(dependencies.state.update).toHaveBeenCalledWith(expect.any(Function));
   });
 
+  it("deploys docs without requiring app or marketing tags for the same commit", async () => {
+    const dependencies = createDependencies({ observed: {}, deployed: {}, failures: {} });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-docs", "sha-docs123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.calls).toEqual([
+      "hasTag:z8-docs:sha-docs123",
+      "set:docs/docs:ghcr.io/umami-creative-gmbh/z8-docs:sha-docs123",
+      "wait:docs:60000"
+    ]);
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-webapp", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-worker", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-migration", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-marketing", "sha-docs123");
+  });
+
   it("rolls out marketing independently", async () => {
     const dependencies = createDependencies({ observed: {}, deployed: {}, failures: {} });
     const reconciler = new Reconciler(dependencies);
@@ -129,6 +162,23 @@ describe("Reconciler", () => {
       "set:marketing/marketing:ghcr.io/umami-creative-gmbh/z8-marketing:sha-abc123",
       "wait:marketing:60000"
     ]);
+  });
+
+  it("deploys marketing without requiring app or docs tags for the same commit", async () => {
+    const dependencies = createDependencies({ observed: {}, deployed: {}, failures: {} });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-marketing", "sha-market123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.calls).toEqual([
+      "hasTag:z8-marketing:sha-market123",
+      "set:marketing/marketing:ghcr.io/umami-creative-gmbh/z8-marketing:sha-market123",
+      "wait:marketing:60000"
+    ]);
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-webapp", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-worker", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-migration", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-docs", "sha-market123");
   });
 
   it("skips deployment when the registry tag is missing", async () => {

--- a/docs/superpowers/plans/2026-05-10-gha-image-change-filters.md
+++ b/docs/superpowers/plans/2026-05-10-gha-image-change-filters.md
@@ -1,0 +1,471 @@
+# GitHub Actions Image Change Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Only publish GHCR images for changed surfaces on `main` pushes while preserving full tag/manual builds and changed-surface deploy-webhook behavior.
+
+**Architecture:** Add workflow-level `push.paths` filters to the four publishing workflows and extend the existing workflow contract scripts to assert those filters. Preserve deploy-webhook’s current independent group behavior by adding regression tests, not new deployment state or path-detection code.
+
+**Tech Stack:** GitHub Actions YAML, Node.js ESM verifier scripts, Vitest, pnpm.
+
+---
+
+## File Structure
+
+- Modify `.github/workflows/publish-images.yml`: add app-runtime path filters to the `push` trigger.
+- Modify `.github/workflows/publish-marketing-image.yml`: add marketing-specific path filters to the `push` trigger.
+- Modify `.github/workflows/publish-docs-image.yml`: add docs-specific path filters to the `push` trigger.
+- Modify `.github/workflows/publish-deploy-webhook-image.yml`: add deploy-webhook-specific path filters to the `push` trigger.
+- Modify `scripts/ci/verify-publish-images-workflow.mjs`: assert the app-runtime path filter contract.
+- Modify `scripts/ci/verify-publish-marketing-image-workflow.mjs`: assert the marketing path filter contract.
+- Modify `scripts/ci/verify-publish-docs-image-workflow.mjs`: assert the docs path filter contract.
+- Modify `scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`: assert the deploy-webhook path filter contract.
+- Modify `apps/deploy-webhook/src/reconciler.test.ts`: add explicit regression tests that docs and marketing deploy independently and app runtime still waits for its three package tags.
+
+---
+
+### Task 1: Add Workflow Contract Tests For Path Filters
+
+**Files:**
+- Modify: `scripts/ci/verify-publish-images-workflow.mjs`
+- Modify: `scripts/ci/verify-publish-marketing-image-workflow.mjs`
+- Modify: `scripts/ci/verify-publish-docs-image-workflow.mjs`
+- Modify: `scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`
+
+- [ ] **Step 1: Add path filter assertions to the app-runtime verifier**
+
+In `scripts/ci/verify-publish-images-workflow.mjs`, add this helper after `includesAll`:
+
+```js
+function expectPushPathFilters(expectedPaths) {
+	includesAll(
+		workflow,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:"
+		],
+		"push trigger path filters"
+	);
+
+	for (const expectedPath of expectedPaths) {
+		expect(workflow.includes(`      - "${expectedPath}"`), `push trigger paths missing: ${expectedPath}`);
+	}
+}
+```
+
+Then add this call after the job existence `expect(...)` block:
+
+```js
+expectPushPathFilters([
+	"apps/webapp/**",
+	"docker/Dockerfile.webapp",
+	"docker/Dockerfile.webapp.dockerignore",
+	"docker/Dockerfile.worker",
+	"docker/Dockerfile.worker.dockerignore",
+	"docker/Dockerfile.migration",
+	"docker/Dockerfile.migration.dockerignore",
+	"docker/scripts/**",
+	"docker/targets/**",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json"
+]);
+```
+
+- [ ] **Step 2: Add path filter assertions to the marketing verifier**
+
+In `scripts/ci/verify-publish-marketing-image-workflow.mjs`, add this helper after `includesAll`:
+
+```js
+function expectPushPathFilters(expectedPaths) {
+	includesAll(
+		workflow,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:"
+		],
+		"push trigger path filters"
+	);
+
+	for (const expectedPath of expectedPaths) {
+		expect(workflow.includes(`      - "${expectedPath}"`), `push trigger paths missing: ${expectedPath}`);
+	}
+}
+```
+
+Then add this call after the job existence `expect(...)` block:
+
+```js
+expectPushPathFilters([
+	"apps/marketing/**",
+	"docker/Dockerfile.marketing",
+	"docker/Dockerfile.marketing.dockerignore",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json"
+]);
+```
+
+- [ ] **Step 3: Add path filter assertions to the docs verifier**
+
+In `scripts/ci/verify-publish-docs-image-workflow.mjs`, add this helper after `includesAll`:
+
+```js
+function expectPushPathFilters(expectedPaths) {
+	includesAll(
+		workflow,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:"
+		],
+		"push trigger path filters"
+	);
+
+	for (const expectedPath of expectedPaths) {
+		expect(workflow.includes(`      - "${expectedPath}"`), `push trigger paths missing: ${expectedPath}`);
+	}
+}
+```
+
+Then add this call after the job existence `expect(...)` block:
+
+```js
+expectPushPathFilters([
+	"apps/docs/**",
+	"docker/Dockerfile.docs",
+	"docker/Dockerfile.docs.dockerignore",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json"
+]);
+```
+
+- [ ] **Step 4: Add path filter assertions to the deploy-webhook verifier**
+
+In `scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`, add this helper after `includesAll`:
+
+```js
+function expectPushPathFilters(expectedPaths) {
+	includesAll(
+		workflow,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:"
+		],
+		"push trigger path filters"
+	);
+
+	for (const expectedPath of expectedPaths) {
+		expect(workflow.includes(`      - "${expectedPath}"`), `push trigger paths missing: ${expectedPath}`);
+	}
+}
+```
+
+Then add this call after the job existence `expect(...)` block:
+
+```js
+expectPushPathFilters([
+	"apps/deploy-webhook/**",
+	"docker/Dockerfile.deploy-webhook",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json"
+]);
+```
+
+- [ ] **Step 5: Run the app-runtime verifier and confirm it fails**
+
+Run: `node scripts/ci/verify-publish-images-workflow.mjs`
+
+Expected: FAIL with at least `push trigger path filters missing:     paths:` or `push trigger paths missing: apps/webapp/**`.
+
+- [ ] **Step 6: Run the dedicated image verifiers and confirm they fail**
+
+Run: `node scripts/ci/verify-publish-marketing-image-workflow.mjs && node scripts/ci/verify-publish-docs-image-workflow.mjs && node scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`
+
+Expected: FAIL on the first verifier with missing `paths` assertions. If using separate commands, each verifier should fail before workflow YAML is updated.
+
+---
+
+### Task 2: Add Workflow Path Filters
+
+**Files:**
+- Modify: `.github/workflows/publish-images.yml`
+- Modify: `.github/workflows/publish-marketing-image.yml`
+- Modify: `.github/workflows/publish-docs-image.yml`
+- Modify: `.github/workflows/publish-deploy-webhook-image.yml`
+
+- [ ] **Step 1: Add app-runtime path filters**
+
+In `.github/workflows/publish-images.yml`, replace the current `on.push` block with:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+    paths:
+      - "apps/webapp/**"
+      - "docker/Dockerfile.webapp"
+      - "docker/Dockerfile.webapp.dockerignore"
+      - "docker/Dockerfile.worker"
+      - "docker/Dockerfile.worker.dockerignore"
+      - "docker/Dockerfile.migration"
+      - "docker/Dockerfile.migration.dockerignore"
+      - "docker/scripts/**"
+      - "docker/targets/**"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+  workflow_dispatch:
+```
+
+- [ ] **Step 2: Add marketing path filters**
+
+In `.github/workflows/publish-marketing-image.yml`, replace the current `on.push` block with:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+    paths:
+      - "apps/marketing/**"
+      - "docker/Dockerfile.marketing"
+      - "docker/Dockerfile.marketing.dockerignore"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+  workflow_dispatch:
+```
+
+- [ ] **Step 3: Add docs path filters**
+
+In `.github/workflows/publish-docs-image.yml`, replace the current `on.push` block with:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+    paths:
+      - "apps/docs/**"
+      - "docker/Dockerfile.docs"
+      - "docker/Dockerfile.docs.dockerignore"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+  workflow_dispatch:
+```
+
+- [ ] **Step 4: Add deploy-webhook path filters**
+
+In `.github/workflows/publish-deploy-webhook-image.yml`, replace the current `on.push` block with:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
+    paths:
+      - "apps/deploy-webhook/**"
+      - "docker/Dockerfile.deploy-webhook"
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "turbo.json"
+  workflow_dispatch:
+```
+
+- [ ] **Step 5: Run all workflow verifier scripts**
+
+Run: `node scripts/ci/verify-publish-images-workflow.mjs && node scripts/ci/verify-publish-marketing-image-workflow.mjs && node scripts/ci/verify-publish-docs-image-workflow.mjs && node scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`
+
+Expected: PASS with these lines:
+
+```text
+Publish images workflow contract OK
+Publish marketing image workflow contract OK
+Publish docs image workflow contract OK
+Publish deploy webhook image workflow contract OK
+```
+
+- [ ] **Step 6: Commit workflow trigger changes**
+
+```bash
+git add .github/workflows/publish-images.yml .github/workflows/publish-marketing-image.yml .github/workflows/publish-docs-image.yml .github/workflows/publish-deploy-webhook-image.yml scripts/ci/verify-publish-images-workflow.mjs scripts/ci/verify-publish-marketing-image-workflow.mjs scripts/ci/verify-publish-docs-image-workflow.mjs scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs
+git commit -m "ci: filter image publishing workflows by changed files"
+```
+
+---
+
+### Task 3: Add Deploy Webhook Changed-Surface Regression Tests
+
+**Files:**
+- Modify: `apps/deploy-webhook/src/reconciler.test.ts`
+
+- [ ] **Step 1: Add docs-only regression test**
+
+In `apps/deploy-webhook/src/reconciler.test.ts`, add this test after `rolls out docs independently when the registry tag exists`:
+
+```ts
+  it("deploys docs without requiring app or marketing tags for the same commit", async () => {
+    const dependencies = createDependencies({ observed: {}, deployed: {}, failures: {} });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-docs", "sha-docs123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.calls).toEqual([
+      "hasTag:z8-docs:sha-docs123",
+      "set:docs/docs:ghcr.io/umami-creative-gmbh/z8-docs:sha-docs123",
+      "wait:docs:60000"
+    ]);
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-webapp", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-worker", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-migration", "sha-docs123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-marketing", "sha-docs123");
+  });
+```
+
+- [ ] **Step 2: Add marketing-only regression test**
+
+In `apps/deploy-webhook/src/reconciler.test.ts`, add this test after `rolls out marketing independently`:
+
+```ts
+  it("deploys marketing without requiring app or docs tags for the same commit", async () => {
+    const dependencies = createDependencies({ observed: {}, deployed: {}, failures: {} });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-marketing", "sha-market123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.calls).toEqual([
+      "hasTag:z8-marketing:sha-market123",
+      "set:marketing/marketing:ghcr.io/umami-creative-gmbh/z8-marketing:sha-market123",
+      "wait:marketing:60000"
+    ]);
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-webapp", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-worker", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-migration", "sha-market123");
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalledWith("z8-docs", "sha-market123");
+  });
+```
+
+- [ ] **Step 3: Add app-runtime wait regression test**
+
+In `apps/deploy-webhook/src/reconciler.test.ts`, add this test after `records app observations and waits for all app package tags before rollout`:
+
+```ts
+  it("does not deploy app runtime until webapp worker and migration share the same tag", async () => {
+    const dependencies = createDependencies({
+      observed: { "sha-app123": ["z8-webapp", "z8-worker"] },
+      deployed: {},
+      failures: {}
+    });
+    const reconciler = new Reconciler(dependencies);
+
+    await reconciler.reconcile(appObservation("z8-webapp", "sha-app123", "2026-05-08T10:00:00.000Z"));
+
+    expect(dependencies.registry.hasTag).not.toHaveBeenCalled();
+    expect(dependencies.kube.runMigration).not.toHaveBeenCalled();
+    expect(dependencies.kube.setDeploymentImage).not.toHaveBeenCalled();
+    expect(dependencies.kube.waitForDeploymentRollout).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 4: Run deploy-webhook tests**
+
+Run: `pnpm --filter deploy-webhook test -- src/reconciler.test.ts`
+
+Expected: PASS for `src/reconciler.test.ts`.
+
+- [ ] **Step 5: Commit deploy-webhook regression tests**
+
+```bash
+git add apps/deploy-webhook/src/reconciler.test.ts
+git commit -m "test: cover changed-surface deploy webhook behavior"
+```
+
+---
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify: workflow files, verifier scripts, deploy-webhook tests
+
+- [ ] **Step 1: Run workflow contract verifiers**
+
+Run: `node scripts/ci/verify-publish-images-workflow.mjs && node scripts/ci/verify-publish-marketing-image-workflow.mjs && node scripts/ci/verify-publish-docs-image-workflow.mjs && node scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs`
+
+Expected: PASS with all four `workflow contract OK` messages.
+
+- [ ] **Step 2: Run deploy-webhook tests**
+
+Run: `pnpm --filter deploy-webhook test -- src/reconciler.test.ts`
+
+Expected: PASS for `src/reconciler.test.ts`.
+
+- [ ] **Step 3: Run full deploy-webhook package tests**
+
+Run: `pnpm --filter deploy-webhook test`
+
+Expected: PASS for all deploy-webhook Vitest suites.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run: `git diff -- .github/workflows scripts/ci apps/deploy-webhook/src/reconciler.test.ts docs/superpowers/specs/2026-05-10-gha-image-change-filters-design.md docs/superpowers/plans/2026-05-10-gha-image-change-filters.md`
+
+Expected: Diff only contains workflow path filters, verifier assertions, deploy-webhook regression tests, and the approved spec/plan docs.
+
+- [ ] **Step 5: Commit plan document if not already committed**
+
+```bash
+git add docs/superpowers/specs/2026-05-10-gha-image-change-filters-design.md docs/superpowers/plans/2026-05-10-gha-image-change-filters.md
+git commit -m "docs: plan image workflow path filters"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: Task 1 and Task 2 cover workflow path filters and verifier updates. Task 3 covers changed-surface deploy-webhook behavior. Task 4 covers final verification.
+- Placeholder scan: No `TBD`, `TODO`, or unspecified implementation steps remain.
+- Type consistency: Test snippets use existing `ImageObservation` package names, existing `createDependencies`, existing `appObservation`, and existing `Reconciler` APIs.

--- a/docs/superpowers/specs/2026-05-10-gha-image-change-filters-design.md
+++ b/docs/superpowers/specs/2026-05-10-gha-image-change-filters-design.md
@@ -1,0 +1,65 @@
+# GitHub Actions Image Change Filters Design
+
+## Purpose
+
+Reduce unnecessary GHCR image builds on `main` pushes by only running image publishing workflows when files relevant to that image surface changed. Release tag pushes and manual dispatches must continue to publish images without path restrictions.
+
+## Current State
+
+The repo has four image publishing workflows:
+
+- `.github/workflows/publish-images.yml` builds `z8-webapp`, `z8-worker`, and `z8-migration` from a matrix.
+- `.github/workflows/publish-marketing-image.yml` builds `z8-marketing`.
+- `.github/workflows/publish-docs-image.yml` builds `z8-docs`.
+- `.github/workflows/publish-deploy-webhook-image.yml` builds `z8-deploy-webhook`.
+
+All four currently run on every push to `main`, every `v*.*.*` tag, and manual `workflow_dispatch`.
+
+## Design
+
+Add workflow-level `paths` filters under each workflow's `push` trigger. These filters apply to branch pushes and keep unrelated `main` changes from starting image builds. Tag pushes remain configured so release tags still publish images even when the tag points at an already-built commit. Manual dispatch remains available for operator-driven rebuilds.
+
+Deployment should follow a changed-surface model. If a workflow is skipped because its files did not change, the corresponding Kubernetes deployment remains on its previous image tag. The system should not try to keep every deployment on the same commit SHA.
+
+The dedicated workflows get image-specific path sets:
+
+- Marketing: `apps/marketing/**`, `docker/Dockerfile.marketing`, `docker/Dockerfile.marketing.dockerignore`, shared workspace manifests, lockfile, Turbo config, and `packages/**`.
+- Docs: `apps/docs/**`, `docker/Dockerfile.docs`, `docker/Dockerfile.docs.dockerignore`, shared workspace manifests, lockfile, Turbo config, and `packages/**`.
+- Deploy webhook: `apps/deploy-webhook/**`, `docker/Dockerfile.deploy-webhook`, shared workspace manifests, lockfile, Turbo config, and `packages/**`.
+
+The combined app runtime workflow gets a broader path set because webapp, worker, and migration share `apps/webapp`, `docker/scripts`, and `docker/targets` runtime preparation:
+
+- `apps/webapp/**`
+- `docker/Dockerfile.webapp`, `docker/Dockerfile.worker`, `docker/Dockerfile.migration`
+- matching Dockerfile dockerignore files
+- `docker/scripts/**`
+- `docker/targets/**`
+- shared workspace manifests, lockfile, Turbo config, and `packages/**`
+
+## Deploy Webhook Compatibility
+
+The deploy webhook already treats deployment groups independently and this behavior must be preserved:
+
+- App runtime deploys only after `z8-webapp`, `z8-worker`, and `z8-migration` all publish the same tag.
+- Docs deploys when `z8-docs` publishes a tag, without waiting for app runtime or marketing images.
+- Marketing deploys when `z8-marketing` publishes a tag, without waiting for app runtime or docs images.
+
+Because skipped workflows will not publish a new `sha-*` tag, deploy webhook logic must not require every image package to publish every commit. Unchanged surfaces stay deployed at their previous image tag.
+
+## Trade-Offs
+
+This keeps the implementation small and understandable. The trade-off is that `publish-images.yml` still builds webapp, worker, and migration together when any shared runtime path changes. Splitting that workflow later would provide finer-grained builds, but it is not required for the requested optimization and would increase change risk.
+
+## Validation
+
+Update the existing workflow verifier scripts in `scripts/ci` so they assert the expected path filters. Run each verifier after editing the workflows.
+
+Keep or add deploy webhook tests that prove independent deployment groups do not wait on skipped image surfaces:
+
+- A docs image publish deploys docs without requiring app runtime or marketing images for the same tag.
+- A marketing image publish deploys marketing without requiring app runtime or docs images for the same tag.
+- App runtime still waits for `z8-webapp`, `z8-worker`, and `z8-migration` before running migrations or deploying web and worker.
+
+## Scope
+
+This change affects workflow triggering and preserves deploy webhook changed-surface behavior. It does not alter Docker build steps, image tags, manifests, package cleanup, or deployment manifests.

--- a/scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs
+++ b/scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs
@@ -65,6 +65,77 @@ function includesAll(text, snippets, context) {
 	}
 }
 
+function getPushBlock() {
+	const lines = workflow.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "  push:");
+	if (startIndex === -1) {
+		return "";
+	}
+
+	let endIndex = lines.length;
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		if (/^ {2}[a-zA-Z0-9_-]+:$/.test(lines[index])) {
+			endIndex = index;
+			break;
+		}
+	}
+
+	return lines.slice(startIndex, endIndex).join("\n");
+}
+
+function getPushPaths(pushBlock) {
+	const lines = pushBlock.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "    paths:");
+	if (startIndex === -1) {
+		return [];
+	}
+
+	const paths = [];
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		const match = line.match(/^ {6}- (?:"([^"]+)"|(.+?))\s*$/);
+		if (match) {
+			paths.push(match[1] ?? match[2].trim());
+			continue;
+		}
+
+		if (/^ {0,6}\S/.test(line) || line.trim() === "") {
+			break;
+		}
+	}
+
+	return paths;
+}
+
+function expectPushPathFilters(expectedPaths) {
+	const pushBlock = getPushBlock();
+
+	includesAll(
+		pushBlock,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:",
+		],
+		"push trigger path filters",
+	);
+
+	const actualPaths = getPushPaths(pushBlock);
+	const expectedPathSet = new Set(expectedPaths);
+	const actualPathSet = new Set(actualPaths);
+
+	for (const expectedPath of [...expectedPathSet].sort()) {
+		expect(actualPathSet.has(expectedPath), `push trigger paths missing: ${expectedPath}`);
+	}
+
+	for (const actualPath of [...actualPathSet].sort()) {
+		expect(expectedPathSet.has(actualPath), `push trigger paths extra: ${actualPath}`);
+	}
+}
+
 const buildNativeJob = getJobBlock("build-native");
 const publishManifestJob = getJobBlock("publish-manifest");
 const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
@@ -72,6 +143,17 @@ const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 expect(buildNativeJob, "Missing build-native job");
 expect(publishManifestJob, "Missing publish-manifest job");
 expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
+
+expectPushPathFilters([
+	".dockerignore",
+	"apps/deploy-webhook/**",
+	"docker/Dockerfile.deploy-webhook",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json",
+]);
 
 if (buildNativeJob) {
 	includesAll(

--- a/scripts/ci/verify-publish-docs-image-workflow.mjs
+++ b/scripts/ci/verify-publish-docs-image-workflow.mjs
@@ -59,6 +59,77 @@ function includesAll(text, snippets, context) {
 	}
 }
 
+function getPushBlock() {
+	const lines = workflow.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "  push:");
+	if (startIndex === -1) {
+		return "";
+	}
+
+	let endIndex = lines.length;
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		if (/^ {2}[a-zA-Z0-9_-]+:$/.test(lines[index])) {
+			endIndex = index;
+			break;
+		}
+	}
+
+	return lines.slice(startIndex, endIndex).join("\n");
+}
+
+function getPushPaths(pushBlock) {
+	const lines = pushBlock.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "    paths:");
+	if (startIndex === -1) {
+		return [];
+	}
+
+	const paths = [];
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		const match = line.match(/^ {6}- (?:"([^"]+)"|(.+?))\s*$/);
+		if (match) {
+			paths.push(match[1] ?? match[2].trim());
+			continue;
+		}
+
+		if (/^ {0,6}\S/.test(line) || line.trim() === "") {
+			break;
+		}
+	}
+
+	return paths;
+}
+
+function expectPushPathFilters(expectedPaths) {
+	const pushBlock = getPushBlock();
+
+	includesAll(
+		pushBlock,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:",
+		],
+		"push trigger path filters",
+	);
+
+	const actualPaths = getPushPaths(pushBlock);
+	const expectedPathSet = new Set(expectedPaths);
+	const actualPathSet = new Set(actualPaths);
+
+	for (const expectedPath of [...expectedPathSet].sort()) {
+		expect(actualPathSet.has(expectedPath), `push trigger paths missing: ${expectedPath}`);
+	}
+
+	for (const actualPath of [...actualPathSet].sort()) {
+		expect(expectedPathSet.has(actualPath), `push trigger paths extra: ${actualPath}`);
+	}
+}
+
 const buildNativeJob = getJobBlock("build-native");
 const publishManifestJob = getJobBlock("publish-manifest");
 const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
@@ -66,6 +137,17 @@ const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 expect(buildNativeJob, "Missing build-native job");
 expect(publishManifestJob, "Missing publish-manifest job");
 expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
+
+expectPushPathFilters([
+	"apps/docs/**",
+	"docker/Dockerfile.docs",
+	"docker/Dockerfile.docs.dockerignore",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json",
+]);
 
 if (buildNativeJob) {
 	const verifyStep = getStepBlock(buildNativeJob, "Verify workflow contract");

--- a/scripts/ci/verify-publish-images-workflow.mjs
+++ b/scripts/ci/verify-publish-images-workflow.mjs
@@ -56,6 +56,77 @@ function includesAll(text, snippets, context) {
 	}
 }
 
+function getPushBlock() {
+	const lines = workflow.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "  push:");
+	if (startIndex === -1) {
+		return "";
+	}
+
+	let endIndex = lines.length;
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		if (/^ {2}[a-zA-Z0-9_-]+:$/.test(lines[index])) {
+			endIndex = index;
+			break;
+		}
+	}
+
+	return lines.slice(startIndex, endIndex).join("\n");
+}
+
+function getPushPaths(pushBlock) {
+	const lines = pushBlock.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "    paths:");
+	if (startIndex === -1) {
+		return [];
+	}
+
+	const paths = [];
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		const match = line.match(/^ {6}- (?:"([^"]+)"|(.+?))\s*$/);
+		if (match) {
+			paths.push(match[1] ?? match[2].trim());
+			continue;
+		}
+
+		if (/^ {0,6}\S/.test(line) || line.trim() === "") {
+			break;
+		}
+	}
+
+	return paths;
+}
+
+function expectPushPathFilters(expectedPaths) {
+	const pushBlock = getPushBlock();
+
+	includesAll(
+		pushBlock,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:",
+		],
+		"push trigger path filters",
+	);
+
+	const actualPaths = getPushPaths(pushBlock);
+	const expectedPathSet = new Set(expectedPaths);
+	const actualPathSet = new Set(actualPaths);
+
+	for (const expectedPath of [...expectedPathSet].sort()) {
+		expect(actualPathSet.has(expectedPath), `push trigger paths missing: ${expectedPath}`);
+	}
+
+	for (const actualPath of [...actualPathSet].sort()) {
+		expect(expectedPathSet.has(actualPath), `push trigger paths extra: ${actualPath}`);
+	}
+}
+
 const publishTargetsJob = getJobBlock("publish-targets");
 const publishManifestsJob = getJobBlock("publish-manifests");
 const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
@@ -63,6 +134,23 @@ const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 expect(publishTargetsJob, "Missing publish-targets job");
 expect(publishManifestsJob, "Missing publish-manifests job");
 expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
+
+expectPushPathFilters([
+	"apps/webapp/**",
+	"docker/Dockerfile.webapp",
+	"docker/Dockerfile.webapp.dockerignore",
+	"docker/Dockerfile.worker",
+	"docker/Dockerfile.worker.dockerignore",
+	"docker/Dockerfile.migration",
+	"docker/Dockerfile.migration.dockerignore",
+	"docker/scripts/**",
+	"docker/targets/**",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json",
+]);
 
 if (publishTargetsJob) {
 	const verifyStep = getStepBlock(publishTargetsJob, "Verify workflow contract");

--- a/scripts/ci/verify-publish-marketing-image-workflow.mjs
+++ b/scripts/ci/verify-publish-marketing-image-workflow.mjs
@@ -59,6 +59,77 @@ function includesAll(text, snippets, context) {
 	}
 }
 
+function getPushBlock() {
+	const lines = workflow.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "  push:");
+	if (startIndex === -1) {
+		return "";
+	}
+
+	let endIndex = lines.length;
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		if (/^ {2}[a-zA-Z0-9_-]+:$/.test(lines[index])) {
+			endIndex = index;
+			break;
+		}
+	}
+
+	return lines.slice(startIndex, endIndex).join("\n");
+}
+
+function getPushPaths(pushBlock) {
+	const lines = pushBlock.split(/\r?\n/);
+	const startIndex = lines.findIndex((line) => line === "    paths:");
+	if (startIndex === -1) {
+		return [];
+	}
+
+	const paths = [];
+	for (let index = startIndex + 1; index < lines.length; index += 1) {
+		const line = lines[index];
+		const match = line.match(/^ {6}- (?:"([^"]+)"|(.+?))\s*$/);
+		if (match) {
+			paths.push(match[1] ?? match[2].trim());
+			continue;
+		}
+
+		if (/^ {0,6}\S/.test(line) || line.trim() === "") {
+			break;
+		}
+	}
+
+	return paths;
+}
+
+function expectPushPathFilters(expectedPaths) {
+	const pushBlock = getPushBlock();
+
+	includesAll(
+		pushBlock,
+		[
+			"  push:",
+			"    branches:",
+			"      - main",
+			"    tags:",
+			'      - "v*.*.*"',
+			"    paths:",
+		],
+		"push trigger path filters",
+	);
+
+	const actualPaths = getPushPaths(pushBlock);
+	const expectedPathSet = new Set(expectedPaths);
+	const actualPathSet = new Set(actualPaths);
+
+	for (const expectedPath of [...expectedPathSet].sort()) {
+		expect(actualPathSet.has(expectedPath), `push trigger paths missing: ${expectedPath}`);
+	}
+
+	for (const actualPath of [...actualPathSet].sort()) {
+		expect(expectedPathSet.has(actualPath), `push trigger paths extra: ${actualPath}`);
+	}
+}
+
 const buildNativeJob = getJobBlock("build-native");
 const publishManifestJob = getJobBlock("publish-manifest");
 const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
@@ -66,6 +137,17 @@ const cleanupPackageVersionsJob = getJobBlock("cleanup-package-versions");
 expect(buildNativeJob, "Missing build-native job");
 expect(publishManifestJob, "Missing publish-manifest job");
 expect(cleanupPackageVersionsJob, "Missing cleanup-package-versions job");
+
+expectPushPathFilters([
+	"apps/marketing/**",
+	"docker/Dockerfile.marketing",
+	"docker/Dockerfile.marketing.dockerignore",
+	"packages/**",
+	"package.json",
+	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+	"turbo.json",
+]);
 
 if (buildNativeJob) {
 	const verifyStep = getStepBlock(buildNativeJob, "Verify workflow contract");


### PR DESCRIPTION
## Summary
- Add file-change path filters to image publishing workflows so unrelated `main` pushes skip unnecessary image builds.
- Preserve tag/manual image publishing and add workflow contract checks for the expected path filters.
- Cover deploy-webhook changed-surface behavior with regression tests.

## Test Plan
- [x] node scripts/ci/verify-publish-images-workflow.mjs && node scripts/ci/verify-publish-marketing-image-workflow.mjs && node scripts/ci/verify-publish-docs-image-workflow.mjs && node scripts/ci/verify-publish-deploy-webhook-image-workflow.mjs
- [x] pnpm --filter deploy-webhook test
- [x] pnpm test