### PR TITLE
Fix webapp production build

### DIFF
--- a/apps/webapp/src/components/dashboard/widget-registry.ts
+++ b/apps/webapp/src/components/dashboard/widget-registry.ts
@@ -167,9 +167,10 @@ export function normalizeHiddenWidgets(hiddenWidgets: string[] = []): WidgetId[]
  */
 export function normalizeWidgetLayout(
 	layout: DashboardWidgetOrder | null | undefined,
-): Required<DashboardWidgetOrder> & {
+): Omit<Required<DashboardWidgetOrder>, "hidden" | "order" | "version"> & {
 	order: WidgetId[];
 	hidden: WidgetId[];
+	version: 1;
 } {
 	if (!layout) {
 		return {

--- a/apps/webapp/src/components/settings/absence-categories-table.test.tsx
+++ b/apps/webapp/src/components/settings/absence-categories-table.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/app/[locale]/(app)/settings/vacation/actions", () => ({
 }));
 
 vi.mock("@tolgee/react", () => ({
-	useLocale: () => "de",
+	useTolgee: () => ({ getLanguage: () => "de" }),
 	useTranslate: () => ({ t: (_key: string, fallback: string) => fallback }),
 }));
 

--- a/apps/webapp/src/components/settings/absence-categories-table.tsx
+++ b/apps/webapp/src/components/settings/absence-categories-table.tsx
@@ -12,7 +12,7 @@ import {
 } from "@tabler/icons-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useLocale, useTranslate } from "@tolgee/react";
+import { useTolgee, useTranslate } from "@tolgee/react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -72,7 +72,8 @@ export function AbsenceCategoriesTable({
 	canManageCategories,
 }: AbsenceCategoriesTableProps) {
 	const { t } = useTranslate();
-	const locale = useLocale();
+	const tolgee = useTolgee(["language"]);
+	const locale = tolgee.getLanguage() || "en";
 	const queryClient = useQueryClient();
 	const [search, setSearch] = useState("");
 	const [categoryToDelete, setCategoryToDelete] = useState<AbsenceCategoryForSettings | null>(null);

--- a/apps/webapp/src/tolgee/shared.ts
+++ b/apps/webapp/src/tolgee/shared.ts
@@ -230,7 +230,7 @@ const namespaceImports: Record<Namespace, Record<string, () => Promise<unknown>>
  */
 export async function loadNamespaces(
 	locale: string,
-	namespaces: Namespace[],
+	namespaces: readonly Namespace[],
 ): Promise<TolgeeStaticData> {
 	const lang = ALL_LANGUAGES.includes(locale) ? locale : DEFAULT_LANGUAGE;
 


### PR DESCRIPTION
## Summary
- Fix absence category locale lookup to use Tolgee's current language API.
- Preserve the normalized dashboard widget layout version as literal version 1.
- Allow Tolgee namespace loading to accept readonly namespace tuples.

## Test Plan
- CI=true pnpm --filter webapp build