### PR TITLE
fix: stabilize platform diagnostics identifiers

### DIFF
--- a/apps/webapp/src/lib/platform-diagnostics/collector.test.ts
+++ b/apps/webapp/src/lib/platform-diagnostics/collector.test.ts
@@ -20,6 +20,7 @@ function buildDeps(overrides: Partial<Parameters<typeof collectPlatformDiagnosti
 			STRIPE_PRICE_YEARLY_ID: "price_yearly_123",
 		},
 		getDeploymentId: async () => "deployment-123",
+		getBuildHash: () => overrides.env?.NEXT_PUBLIC_BUILD_HASH ?? "build-123",
 		getCookieConsentConfigured: async () => true,
 		checkDatabase: async () => true,
 		checkQueue: async () => true,
@@ -92,6 +93,25 @@ describe("collectPlatformDiagnostics", () => {
 		);
 		expect(snapshot.recommendedActions).toContain(
 			"Configure missing Stripe variables before enabling billing workflows.",
+		);
+	});
+
+	it("uses the injected build hash when the diagnostics env object does not include it", async () => {
+		const snapshot = await collectPlatformDiagnostics(
+			buildDeps({
+				env: {
+					BILLING_ENABLED: "false",
+					NODE_ENV: "production",
+					NEXT_RUNTIME: "nodejs",
+				},
+				getBuildHash: () => "injected-build-hash",
+			}),
+		);
+
+		expect(snapshot.configuration).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ title: "Build hash", status: "healthy", value: "injected-build-hash" }),
+			]),
 		);
 	});
 
@@ -171,5 +191,12 @@ describe("collectPlatformDiagnostics", () => {
 
 		expect(source).toContain("cookie_consent_script");
 		expect(source).not.toContain("getCookieConsentScript");
+	});
+
+	it("creates the deployment ID through the telemetry helper in default dependencies", () => {
+		const source = readFileSync(fileURLToPath(new URL("./collector.ts", import.meta.url)), "utf8");
+
+		expect(source).toContain("getOrCreateDeploymentId");
+		expect(source).not.toContain('where(eq(systemConfig.key, "deployment_id"))');
 	});
 });

--- a/apps/webapp/src/lib/platform-diagnostics/collector.ts
+++ b/apps/webapp/src/lib/platform-diagnostics/collector.ts
@@ -4,6 +4,7 @@ import { DateTime } from "luxon";
 import { db } from "@/db";
 import { systemConfig } from "@/db/schema";
 import { getJobQueue, isQueueHealthy } from "@/lib/queue";
+import { getOrCreateDeploymentId } from "@/lib/telemetry";
 
 import type { DiagnosticsItem, PlatformDiagnosticsSnapshot, QueueSummary } from "./types";
 
@@ -13,6 +14,7 @@ export interface PlatformDiagnosticsDependencies {
 	now: () => string;
 	env: DiagnosticsEnv;
 	getDeploymentId: () => Promise<string | null>;
+	getBuildHash: () => string | undefined;
 	getCookieConsentConfigured: () => Promise<boolean>;
 	checkDatabase: () => Promise<boolean>;
 	checkQueue: () => Promise<boolean>;
@@ -127,15 +129,8 @@ function getRecommendedActions(items: DiagnosticsItem[]): string[] {
 export const defaultPlatformDiagnosticsDependencies: PlatformDiagnosticsDependencies = {
 	now: () => DateTime.utc().toISO() ?? DateTime.utc().toString(),
 	env: process.env,
-	getDeploymentId: async () => {
-		const [row] = await db
-			.select({ value: systemConfig.value })
-			.from(systemConfig)
-			.where(eq(systemConfig.key, "deployment_id"))
-			.limit(1);
-
-		return row?.value ?? null;
-	},
+	getDeploymentId: async () => getOrCreateDeploymentId(),
+	getBuildHash: () => process.env.NEXT_PUBLIC_BUILD_HASH,
 	getCookieConsentConfigured: async () => {
 		const [row] = await db
 			.select({ value: systemConfig.value })
@@ -182,6 +177,7 @@ export async function collectPlatformDiagnostics(
 
 	const billingEnabled = deps.env.BILLING_ENABLED === "true";
 	const runtimeParts = [deps.env.NODE_ENV ?? "unknown", deps.env.NEXT_RUNTIME ?? "nodejs"].filter(Boolean);
+	const buildHash = deps.env.NEXT_PUBLIC_BUILD_HASH ?? deps.getBuildHash();
 
 	const configuration: DiagnosticsItem[] = [
 		{
@@ -238,8 +234,8 @@ export async function collectPlatformDiagnostics(
 		},
 		{
 			title: "Build hash",
-			status: isConfigured(deps.env.NEXT_PUBLIC_BUILD_HASH) ? "healthy" : "warning",
-			value: deps.env.NEXT_PUBLIC_BUILD_HASH ?? "Missing",
+			status: isConfigured(buildHash) ? "healthy" : "warning",
+			value: buildHash ?? "Missing",
 			description: "Public build identifier when provided by deployment.",
 		},
 	];


### PR DESCRIPTION
## Summary
- Create the diagnostics deployment ID via the telemetry helper instead of reporting a missing row indefinitely.
- Read the build hash through an injected fallback so Next build-time values are visible to diagnostics.
- Add regression tests for both diagnostics identifier paths.

## Test Plan
- pnpm --dir apps/webapp exec vitest run src/lib/platform-diagnostics/collector.test.ts
- pnpm --dir apps/webapp exec tsc --noEmit --pretty false