### PR TITLE
Fix pnpm global bin path in Dockerfiles

### DIFF
--- a/docker/Dockerfile.db-seed
+++ b/docker/Dockerfile.db-seed
@@ -17,7 +17,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1
 

--- a/docker/Dockerfile.deploy-webhook
+++ b/docker/Dockerfile.deploy-webhook
@@ -17,7 +17,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     PORT=8080
 

--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -17,7 +17,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \

--- a/docker/Dockerfile.marketing
+++ b/docker/Dockerfile.marketing
@@ -17,7 +17,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \

--- a/docker/Dockerfile.migration
+++ b/docker/Dockerfile.migration
@@ -15,7 +15,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1
 

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -18,7 +18,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
     PORT=3000 \

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -15,7 +15,7 @@ ARG PNPM_VERSION
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 ENV PNPM_HOME=/pnpm
-ENV PATH=${PNPM_HOME}:${PATH}
+ENV PATH=${PNPM_HOME}/bin:${PNPM_HOME}:${PATH}
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1
 

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -28,6 +28,32 @@ test("pnpm settings live in workspace config", async () => {
 	assert.match(workspaceConfig, /^allowBuilds:/m);
 });
 
+test("Dockerfiles with global pnpm installs put pnpm global bin on PATH", async () => {
+	const dockerfiles = [
+		"Dockerfile.db-seed",
+		"Dockerfile.deploy-webhook",
+		"Dockerfile.docs",
+		"Dockerfile.marketing",
+		"Dockerfile.migration",
+		"Dockerfile.webapp",
+		"Dockerfile.worker",
+	];
+
+	for (const dockerfile of dockerfiles) {
+		const contents = await fs.readFile(new URL(`../${dockerfile}`, import.meta.url), "utf8");
+
+		if (!contents.includes("pnpm add -g")) {
+			continue;
+		}
+
+		assert.match(
+			contents,
+			/ENV PATH=\$\{PNPM_HOME\}\/bin:\$\{PNPM_HOME\}:\$\{PATH\}/,
+			`${dockerfile} must put pnpm global bin on PATH before pnpm add -g`,
+		);
+	}
+});
+
 test("collectTarget lists traced worker runtime files and packages", async () => {
 	const result = await collectTarget("worker");
 


### PR DESCRIPTION
## Summary
- Add pnpm's global bin directory to PATH in Docker image bases.
- Add a Dockerfile regression test for global pnpm installs.

## Test Plan
- node --test docker/scripts/prepare-target-runtime.test.mjs
- pnpm test

Note: local Docker verification was skipped because Docker is not available in this WSL environment.