### PR TITLE
Fix pnpm workspace config in target Docker images

### DIFF
--- a/docker/Dockerfile.db-seed
+++ b/docker/Dockerfile.db-seed
@@ -39,9 +39,10 @@ RUN pnpm add -g tsx@${TSX_VERSION}
 
 COPY --from=assembler /runtime/package.json ./package.json
 COPY --from=assembler /runtime/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=assembler /runtime/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --prod --frozen-lockfile --ignore-workspace
+    pnpm install --prod --frozen-lockfile
 
 COPY --from=assembler /runtime/ ./
 

--- a/docker/Dockerfile.migration
+++ b/docker/Dockerfile.migration
@@ -36,9 +36,10 @@ WORKDIR /app
 
 COPY --from=assembler /runtime/package.json ./package.json
 COPY --from=assembler /runtime/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=assembler /runtime/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --prod --frozen-lockfile --ignore-workspace
+    pnpm install --prod --frozen-lockfile
 
 COPY --from=assembler /runtime/ ./
 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -40,9 +40,10 @@ WORKDIR /app
 
 COPY --from=assembler /runtime/package.json ./package.json
 COPY --from=assembler /runtime/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=assembler /runtime/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm install --prod --frozen-lockfile --ignore-workspace
+    pnpm install --prod --frozen-lockfile
 
 COPY --from=assembler --chown=app:nodejs /runtime/ ./
 

--- a/docker/scripts/prepare-target-runtime.mjs
+++ b/docker/scripts/prepare-target-runtime.mjs
@@ -256,6 +256,10 @@ async function copyTargetRuntime(target, outputDirectory) {
     path.join(TARGETS_ROOT, target, "pnpm-lock.yaml"),
     path.join(outputPath, "pnpm-lock.yaml"),
   );
+  await fs.copyFile(
+    path.join(TARGETS_ROOT, target, "pnpm-workspace.yaml"),
+    path.join(outputPath, "pnpm-workspace.yaml"),
+  );
 }
 
 async function main() {

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -118,6 +118,54 @@ test("generated non-web manifests exclude obvious web-only type overrides", asyn
 	assert.doesNotMatch(targetWorkspaceConfig, /@types\/react-dom:/);
 });
 
+test("copied migration runtime includes pnpm workspace config for frozen installs", async () => {
+	const outputUrl = new URL("../targets/.tmp-migration-runtime/", import.meta.url);
+
+	try {
+		await execFileAsync(process.execPath, [
+			"docker/scripts/prepare-target-runtime.mjs",
+			"copy",
+			"migration",
+			new URL(".", outputUrl).pathname,
+		], {
+			cwd: new URL("../../", import.meta.url),
+		});
+
+		const workspaceConfig = await fs.readFile(new URL("pnpm-workspace.yaml", outputUrl), "utf8");
+		assert.match(workspaceConfig, /^overrides:/m);
+		assert.match(workspaceConfig, /"postcss":/);
+	} finally {
+		await fs.rm(outputUrl, { recursive: true, force: true });
+	}
+});
+
+test("trimmed runtime Dockerfiles copy pnpm workspace config before install", async () => {
+	const dockerfiles = ["Dockerfile.db-seed", "Dockerfile.migration", "Dockerfile.worker"];
+
+	for (const dockerfile of dockerfiles) {
+		const contents = await fs.readFile(new URL(`../${dockerfile}`, import.meta.url), "utf8");
+		const workspaceCopyIndex = contents.indexOf("/runtime/pnpm-workspace.yaml");
+		const installIndex = contents.indexOf("pnpm install --prod --frozen-lockfile");
+
+		assert.notEqual(workspaceCopyIndex, -1, `${dockerfile} must copy pnpm-workspace.yaml`);
+		assert.notEqual(installIndex, -1, `${dockerfile} must run a frozen production install`);
+		assert.ok(workspaceCopyIndex < installIndex, `${dockerfile} must copy pnpm-workspace.yaml before install`);
+	}
+});
+
+test("trimmed runtime Dockerfiles allow pnpm to read workspace overrides", async () => {
+	const dockerfiles = ["Dockerfile.db-seed", "Dockerfile.migration", "Dockerfile.worker"];
+
+	for (const dockerfile of dockerfiles) {
+		const contents = await fs.readFile(new URL(`../${dockerfile}`, import.meta.url), "utf8");
+		assert.doesNotMatch(
+			contents,
+			/pnpm install --prod --frozen-lockfile --ignore-workspace/,
+			`${dockerfile} must not ignore the generated pnpm-workspace.yaml during frozen install`,
+		);
+	}
+});
+
 test("production worker and migration manifests use the trimmed runtime layout", async () => {
   const [workerManifest, migrationManifest] = await Promise.all([
     fs.readFile(new URL("../../infra/hetzner-k8s/k8s/app/worker-deployment.yaml", import.meta.url), "utf8"),


### PR DESCRIPTION
## Summary
- copy generated pnpm-workspace.yaml into trimmed target runtimes
- let target image installs read generated workspace overrides during frozen pnpm installs
- add regression coverage for target runtime pnpm config and Dockerfile install contracts

## Verification
- node --test docker/scripts/prepare-target-runtime.test.mjs
- docker buildx build --build-arg NEXT_PUBLIC_BUILD_HASH=12d3c276466e257b1cd046e0b7786beb6fec0998 --file ./docker/Dockerfile.migration --platform linux/amd64 --load --tag z8-migration-debug .
- docker buildx build --file ./docker/Dockerfile.worker --platform linux/amd64 --load --tag z8-worker-debug .
- docker buildx build --file ./docker/Dockerfile.db-seed --platform linux/amd64 --load --tag z8-db-seed-debug .
- pnpm test