### PR TITLE
Fix Next.js Docker image startup

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -95,4 +95,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3001 || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["pnpm", "start"]
+CMD ["node", "node_modules/next/dist/bin/next", "start"]

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -89,7 +89,7 @@ WORKDIR /app/apps/webapp
 USER app
 EXPOSE 3000
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["pnpm", "start"]
+CMD ["node", "node_modules/next/dist/bin/next", "start"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3000/api/health || exit 1

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -74,6 +74,20 @@ test("non-root runtime Dockerfiles can run pnpm without writing root-owned Corep
 	}
 });
 
+test("Next.js runtime Dockerfiles start without pnpm dependency status checks", async () => {
+	const dockerfiles = ["Dockerfile.docs", "Dockerfile.webapp"];
+
+	for (const dockerfile of dockerfiles) {
+		const contents = await fs.readFile(new URL(`../${dockerfile}`, import.meta.url), "utf8");
+
+		assert.doesNotMatch(
+			contents,
+			/CMD \["pnpm", "start"\]/,
+			`${dockerfile} must not invoke pnpm at runtime because pnpm may try to repair node_modules without a TTY`,
+		);
+	}
+});
+
 test("collectTarget lists traced worker runtime files and packages", async () => {
 	const result = await collectTarget("worker");
 


### PR DESCRIPTION
## Summary
- Start webapp and docs runtime images by invoking Next directly instead of pnpm.
- Add a regression test preventing pnpm runtime startup in Next.js Dockerfiles.

## Test Plan
- node --test docker/scripts/prepare-target-runtime.test.mjs