### PR TITLE
Fix docs Docker runtime port

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -95,4 +95,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:3001 || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "node_modules/next/dist/bin/next", "start"]
+CMD ["node", "node_modules/next/dist/bin/next", "start", "-p", "3001"]

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -88,6 +88,12 @@ test("Next.js runtime Dockerfiles start without pnpm dependency status checks", 
 	}
 });
 
+test("docs runtime Dockerfile starts Next.js on the Kubernetes service port", async () => {
+	const contents = await fs.readFile(new URL("../Dockerfile.docs", import.meta.url), "utf8");
+
+	assert.match(contents, /CMD \["node", "node_modules\/next\/dist\/bin\/next", "start", "-p", "3001"\]/);
+});
+
 test("collectTarget lists traced worker runtime files and packages", async () => {
 	const result = await collectTarget("worker");
 


### PR DESCRIPTION
## Summary
- Keep docs runtime image on port 3001 when bypassing pnpm startup.
- Add a regression test for the docs runtime Dockerfile command.

## Test Plan
- node --test docker/scripts/prepare-target-runtime.test.mjs