### PR TITLE
Calendar Holidays Now Carry Workload Authority

### DIFF
--- a/apps/webapp/src/app/api/calendar/events/route.test.ts
+++ b/apps/webapp/src/app/api/calendar/events/route.test.ts
@@ -5,6 +5,8 @@ const mockState = vi.hoisted(() => ({
 	connection: vi.fn(),
 	getVerifiedOrgContext: vi.fn(),
 	getAbsencesForMonth: vi.fn(async () => []),
+	getAssignedHolidaysForEmployee: vi.fn(async () => []),
+	assignedHolidayToCalendarEvent: vi.fn(),
 	getHolidaysForMonth: vi.fn(async () => []),
 	getTimeEntriesForMonth: vi.fn(async () => []),
 	getWorkPeriodsForMonth: vi.fn(async () => []),
@@ -45,6 +47,11 @@ vi.mock("@/lib/calendar/absence-service", () => ({
 
 vi.mock("@/lib/calendar/holiday-service", () => ({
 	getHolidaysForMonth: mockState.getHolidaysForMonth,
+}));
+
+vi.mock("@/lib/calendar/assigned-holidays", () => ({
+	getAssignedHolidaysForEmployee: mockState.getAssignedHolidaysForEmployee,
+	assignedHolidayToCalendarEvent: mockState.assignedHolidayToCalendarEvent,
 }));
 
 vi.mock("@/lib/calendar/time-entry-service", () => ({
@@ -198,6 +205,45 @@ describe("GET /api/calendar/events", () => {
 		});
 	});
 
+	it("returns employee-assigned holidays for a scoped employee calendar", async () => {
+		const holiday = {
+			id: "holiday-1",
+			name: "Labor Day",
+			startDate: new Date("2026-05-01T00:00:00.000Z"),
+			endDate: new Date("2026-05-01T23:59:59.999Z"),
+		};
+		const mappedHolidayEvent = {
+			id: "holiday-1",
+			type: "holiday",
+			date: new Date("2026-05-01T00:00:00.000Z"),
+			title: "Labor Day",
+			color: "#0ea5e9",
+			metadata: { source: "assigned" },
+		};
+		mockState.getAssignedHolidaysForEmployee.mockResolvedValueOnce([holiday]);
+		mockState.assignedHolidayToCalendarEvent.mockReturnValueOnce(mappedHolidayEvent);
+
+		const response = await GET(
+			createRequest(
+				"https://app.example.com/api/calendar/events?organizationId=org-1&year=2026&month=4&showHolidays=true&showWorkPeriods=true",
+			),
+		);
+		const body = getResponsePayload(await response.json());
+
+		expect(response.status).toBe(200);
+		expect(mockState.getAssignedHolidaysForEmployee).toHaveBeenCalledWith({
+			organizationId: "org-1",
+			employeeId: "employee-1",
+			startDate: new Date("2026-05-01T00:00:00.000Z"),
+			endDate: new Date("2026-05-31T23:59:59.999Z"),
+		});
+		expect(mockState.getHolidaysForMonth).not.toHaveBeenCalled();
+		expect(body.events).toContainEqual({
+			...mappedHolidayEvent,
+			date: "2026-05-01T00:00:00.000Z",
+		});
+	});
+
 	it("rejects employee-scoped calendar data for an unauthorized requested employee", async () => {
 		mockState.findEmployee
 			.mockResolvedValueOnce({
@@ -223,6 +269,7 @@ describe("GET /api/calendar/events", () => {
 
 		expect(response.status).toBe(403);
 		expect(mockState.getAbsencesForMonth).not.toHaveBeenCalled();
+		expect(mockState.getAssignedHolidaysForEmployee).not.toHaveBeenCalled();
 	});
 
 	it("omits hidden work period events but still returns daily actual minutes", async () => {

--- a/apps/webapp/src/app/api/calendar/events/route.test.ts
+++ b/apps/webapp/src/app/api/calendar/events/route.test.ts
@@ -244,6 +244,33 @@ describe("GET /api/calendar/events", () => {
 		});
 	});
 
+	it("returns organization-wide holidays for a holiday-only calendar request", async () => {
+		const orgWideHolidayEvent = {
+			id: "holiday-org-1",
+			type: "holiday",
+			date: new Date("2026-05-01T00:00:00.000Z"),
+			title: "May Day",
+			color: "#f59e0b",
+			metadata: { source: "organization" },
+		};
+		mockState.getHolidaysForMonth.mockResolvedValueOnce([orgWideHolidayEvent]);
+
+		const response = await GET(
+			createRequest(
+				"https://app.example.com/api/calendar/events?organizationId=org-1&year=2026&month=4&showHolidays=true",
+			),
+		);
+		const body = getResponsePayload(await response.json());
+
+		expect(response.status).toBe(200);
+		expect(mockState.getHolidaysForMonth).toHaveBeenCalledWith("org-1", 4, 2026);
+		expect(mockState.getAssignedHolidaysForEmployee).not.toHaveBeenCalled();
+		expect(body.events).toContainEqual({
+			...orgWideHolidayEvent,
+			date: "2026-05-01T00:00:00.000Z",
+		});
+	});
+
 	it("rejects employee-scoped calendar data for an unauthorized requested employee", async () => {
 		mockState.findEmployee
 			.mockResolvedValueOnce({

--- a/apps/webapp/src/app/api/calendar/events/route.ts
+++ b/apps/webapp/src/app/api/calendar/events/route.ts
@@ -129,6 +129,7 @@ async function fetchMonthEvents(
 	month: number,
 	year: number,
 	employeeId: string | undefined,
+	holidayEmployeeId: string | undefined,
 	showHolidays: boolean,
 	showAbsences: boolean,
 	showTimeEntries: boolean,
@@ -137,7 +138,7 @@ async function fetchMonthEvents(
 ): Promise<{ events: CalendarEvent[]; dailyActualMinutes: DailyWorkActualMinutes }> {
 	// Fetch all event types in parallel - conditional fetches return empty arrays
 	const [holidays, absences, timeEntries, workPeriods] = await Promise.all([
-		fetchHolidayEvents({ organizationId, employeeId, month, year, showHolidays }),
+		fetchHolidayEvents({ organizationId, employeeId: holidayEmployeeId, month, year, showHolidays }),
 		showAbsences ? getAbsencesForMonth(month, year, { organizationId, employeeId }) : [],
 		showTimeEntries ? getTimeEntriesForMonth(month, year, { organizationId, employeeId }) : [],
 		showWorkPeriods || includeWorkPeriodActuals
@@ -229,9 +230,10 @@ export async function GET(request: NextRequest) {
 
 		const organizationId = orgContext.organizationId;
 		const showsEmployeeScopedEvents = showAbsences || showTimeEntries || showWorkPeriods;
+		const holidaysRequestedForEmployee = showHolidays && Boolean(employeeId || showsEmployeeScopedEvents);
 		const scopedEmployeeId = await resolveAuthorizedCalendarEmployeeId(orgContext, employeeId);
 
-		if (showsEmployeeScopedEvents && !scopedEmployeeId) {
+		if ((showsEmployeeScopedEvents || holidaysRequestedForEmployee) && !scopedEmployeeId) {
 			return NextResponse.json({ error: "Forbidden: Employee profile required" }, { status: 403 });
 		}
 
@@ -252,6 +254,7 @@ export async function GET(request: NextRequest) {
 		let events: CalendarEvent[] = [];
 		let workBalance: EmployeeWorkBalancePayload | null = null;
 		const includeWorkPeriodActuals = Boolean(scopedEmployeeId);
+		const holidayEmployeeId = holidaysRequestedForEmployee ? scopedEmployeeId : undefined;
 
 		if (fullYear) {
 			// Fetch all 12 months in parallel
@@ -261,6 +264,7 @@ export async function GET(request: NextRequest) {
 					monthIndex,
 					yearNum,
 					scopedEmployeeId,
+					holidayEmployeeId,
 					showHolidays,
 					showAbsences,
 					showTimeEntries,
@@ -282,6 +286,7 @@ export async function GET(request: NextRequest) {
 				monthNum!,
 				yearNum,
 				scopedEmployeeId,
+				holidayEmployeeId,
 				showHolidays,
 				showAbsences,
 				showTimeEntries,

--- a/apps/webapp/src/app/api/calendar/events/route.ts
+++ b/apps/webapp/src/app/api/calendar/events/route.ts
@@ -6,6 +6,10 @@ import { employee, employeeManagers } from "@/db/schema";
 import { asAppSubject, defineAbilityFor, type PrincipalContext } from "@/lib/authorization";
 import { getVerifiedOrgContext } from "@/lib/auth-helpers";
 import { getAbsencesForMonth } from "@/lib/calendar/absence-service";
+import {
+	assignedHolidayToCalendarEvent,
+	getAssignedHolidaysForEmployee,
+} from "@/lib/calendar/assigned-holidays";
 import { getHolidaysForMonth } from "@/lib/calendar/holiday-service";
 import { getTimeEntriesForMonth } from "@/lib/calendar/time-entry-service";
 import type {
@@ -87,6 +91,35 @@ async function resolveAuthorizedCalendarEmployeeId(
 		: undefined;
 }
 
+async function fetchHolidayEvents(params: {
+	organizationId: string;
+	employeeId: string | undefined;
+	month: number;
+	year: number;
+	showHolidays: boolean;
+}): Promise<CalendarEvent[]> {
+	if (!params.showHolidays) return [];
+	if (!params.employeeId) {
+		return getHolidaysForMonth(params.organizationId, params.month, params.year);
+	}
+
+	const monthStart = DateTime.utc(params.year, params.month + 1, 1).startOf("day");
+	const monthEnd = monthStart.endOf("month");
+
+	try {
+		const holidays = await getAssignedHolidaysForEmployee({
+			organizationId: params.organizationId,
+			employeeId: params.employeeId,
+			startDate: monthStart.toJSDate(),
+			endDate: monthEnd.toJSDate(),
+		});
+		return holidays.map(assignedHolidayToCalendarEvent);
+	} catch (error) {
+		console.error("Error fetching assigned calendar holidays:", error);
+		return [];
+	}
+}
+
 /**
  * Fetch events for a single month
  * Uses Promise.all for parallel fetching to eliminate waterfalls
@@ -104,7 +137,7 @@ async function fetchMonthEvents(
 ): Promise<{ events: CalendarEvent[]; dailyActualMinutes: DailyWorkActualMinutes }> {
 	// Fetch all event types in parallel - conditional fetches return empty arrays
 	const [holidays, absences, timeEntries, workPeriods] = await Promise.all([
-		showHolidays ? getHolidaysForMonth(organizationId, month, year) : [],
+		fetchHolidayEvents({ organizationId, employeeId, month, year, showHolidays }),
 		showAbsences ? getAbsencesForMonth(month, year, { organizationId, employeeId }) : [],
 		showTimeEntries ? getTimeEntriesForMonth(month, year, { organizationId, employeeId }) : [],
 		showWorkPeriods || includeWorkPeriodActuals

--- a/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	type AssignedHolidayRange,
 	applyAssignedHolidayAdjustmentsToRequirements,
+	expandCustomAssignedHoliday,
 	getAssignedHolidayDateKeys,
 	getPresetHolidayExpansionYears,
 	overlapsEffectiveWindow,
@@ -73,6 +74,50 @@ describe("assigned holiday requirement adjustments", () => {
 				},
 			]),
 		).toEqual(new Set(["2026-12-24", "2026-12-25"]));
+	});
+
+	it("expands yearly custom assigned holidays into the requested year", () => {
+		const expanded = expandCustomAssignedHoliday(
+			{
+				id: "holiday-6",
+				name: "Labor Day",
+				organizationId: "org-1",
+				startDate: new Date("2024-05-01T00:00:00.000Z"),
+				endDate: new Date("2024-05-01T23:59:59.999Z"),
+				categoryId: "category-1",
+				description: "Recurring labor day",
+				isActive: true,
+				recurrenceType: "yearly",
+				recurrenceRule: JSON.stringify({ month: 5, day: 1 }),
+				recurrenceEndDate: null,
+			},
+			{
+				startDate: new Date("2026-05-01T00:00:00.000Z"),
+				endDate: new Date("2026-05-31T23:59:59.999Z"),
+			},
+		);
+
+		expect(expanded).toHaveLength(1);
+		expect(expanded[0]).toMatchObject({
+			id: "holiday-6-2026",
+			name: "Labor Day",
+			categoryId: "category-1",
+			description: "Recurring labor day",
+		});
+		expect(expanded[0]?.startDate.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+		expect(expanded[0]?.endDate.toISOString()).toBe("2026-05-01T23:59:59.999Z");
+		expect(
+			applyAssignedHolidayAdjustmentsToRequirements(
+				{
+					"2026-05-01": {
+						requiredMinutes: 480,
+						policyId: "policy-1",
+						policyName: "Standard Hours",
+					},
+				},
+				expanded,
+			)["2026-05-01"]?.requiredMinutes,
+		).toBe(0);
 	});
 
 	it("includes the previous UTC year when selecting preset holiday expansion years", () => {

--- a/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
@@ -3,6 +3,8 @@ import {
 	type AssignedHolidayRange,
 	applyAssignedHolidayAdjustmentsToRequirements,
 	getAssignedHolidayDateKeys,
+	getPresetHolidayExpansionYears,
+	overlapsEffectiveWindow,
 } from "./assigned-holidays";
 
 const singleDayHoliday: AssignedHolidayRange = {
@@ -71,5 +73,48 @@ describe("assigned holiday requirement adjustments", () => {
 				},
 			]),
 		).toEqual(new Set(["2026-12-24", "2026-12-25"]));
+	});
+
+	it("includes the previous UTC year when selecting preset holiday expansion years", () => {
+		expect(
+			getPresetHolidayExpansionYears(
+				new Date("2027-01-01T00:00:00.000Z"),
+				new Date("2027-01-31T23:59:59.999Z"),
+			),
+		).toEqual([2026, 2027]);
+	});
+
+	it("keeps an occurrence that overlaps an assignment effective window", () => {
+		expect(
+			overlapsEffectiveWindow(
+				{
+					id: "holiday-4",
+					name: "New Year Shutdown",
+					startDate: new Date("2026-12-31T00:00:00.000Z"),
+					endDate: new Date("2027-01-01T23:59:59.999Z"),
+				},
+				{
+					effectiveFrom: new Date("2027-01-01T00:00:00.000Z"),
+					effectiveUntil: null,
+				},
+			),
+		).toBe(true);
+	});
+
+	it("skips an occurrence outside an assignment effective window", () => {
+		expect(
+			overlapsEffectiveWindow(
+				{
+					id: "holiday-5",
+					name: "Expired Assignment Holiday",
+					startDate: new Date("2027-01-01T00:00:00.000Z"),
+					endDate: new Date("2027-01-01T23:59:59.999Z"),
+				},
+				{
+					effectiveFrom: null,
+					effectiveUntil: new Date("2026-12-31T23:59:59.999Z"),
+				},
+			),
+		).toBe(false);
 	});
 });

--- a/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+	type AssignedHolidayRange,
+	applyAssignedHolidayAdjustmentsToRequirements,
+	getAssignedHolidayDateKeys,
+} from "./assigned-holidays";
+
+const singleDayHoliday: AssignedHolidayRange = {
+	id: "holiday-1",
+	name: "Labor Day",
+	startDate: new Date("2026-05-01T00:00:00.000Z"),
+	endDate: new Date("2026-05-01T23:59:59.999Z"),
+};
+
+describe("assigned holiday requirement adjustments", () => {
+	it("sets required minutes to zero on an assigned holiday", () => {
+		expect(
+			applyAssignedHolidayAdjustmentsToRequirements(
+				{
+					"2026-05-01": {
+						requiredMinutes: 480,
+						policyId: "policy-1",
+						policyName: "Standard Hours",
+					},
+				},
+				[singleDayHoliday],
+			),
+		).toEqual({
+			"2026-05-01": {
+				requiredMinutes: 0,
+				policyId: "policy-1",
+				policyName: "Standard Hours",
+			},
+		});
+	});
+
+	it("zeros every overlapping required date for a multi-day holiday", () => {
+		const adjusted = applyAssignedHolidayAdjustmentsToRequirements(
+			{
+				"2026-05-04": { requiredMinutes: 480, policyId: "policy-1", policyName: "Standard Hours" },
+				"2026-05-05": { requiredMinutes: 360, policyId: "policy-1", policyName: "Standard Hours" },
+				"2026-05-06": { requiredMinutes: 480, policyId: "policy-1", policyName: "Standard Hours" },
+			},
+			[
+				{
+					id: "holiday-2",
+					name: "Company Shutdown",
+					startDate: new Date("2026-05-04T00:00:00.000Z"),
+					endDate: new Date("2026-05-05T23:59:59.999Z"),
+				},
+			],
+		);
+
+		expect(adjusted["2026-05-04"]?.requiredMinutes).toBe(0);
+		expect(adjusted["2026-05-05"]?.requiredMinutes).toBe(0);
+		expect(adjusted["2026-05-06"]?.requiredMinutes).toBe(480);
+	});
+
+	it("does not create requirement entries for holiday dates without policy requirements", () => {
+		expect(applyAssignedHolidayAdjustmentsToRequirements({}, [singleDayHoliday])).toEqual({});
+	});
+
+	it("expands assigned holiday ranges into UTC date keys", () => {
+		expect(
+			getAssignedHolidayDateKeys([
+				{
+					id: "holiday-3",
+					name: "Two Day Holiday",
+					startDate: new Date("2026-12-24T00:00:00.000Z"),
+					endDate: new Date("2026-12-25T23:59:59.999Z"),
+				},
+			]),
+		).toEqual(new Set(["2026-12-24", "2026-12-25"]));
+	});
+});

--- a/apps/webapp/src/lib/calendar/assigned-holidays.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.ts
@@ -37,6 +37,8 @@ type HolidayAssignmentWithHoliday = {
 };
 
 type HolidayPresetAssignmentWithPreset = {
+	effectiveFrom: Date | null;
+	effectiveUntil: Date | null;
 	preset:
 		| (Pick<
 				typeof holidayPreset.$inferSelect,
@@ -121,9 +123,21 @@ function getAssignmentScope(
 	teamId: string | null,
 ) {
 	const scope = [eq(table.assignmentType, "organization")];
-	if (teamId) scope.push(eq(table.teamId, teamId));
-	scope.push(eq(table.employeeId, employeeId));
+	if (teamId) scope.push(and(eq(table.assignmentType, "team"), eq(table.teamId, teamId))!);
+	scope.push(and(eq(table.assignmentType, "employee"), eq(table.employeeId, employeeId))!);
 	return scope;
+}
+
+export function getPresetHolidayExpansionYears(startDate: Date, endDate: Date): number[] {
+	const startYear = toUtcDay(startDate).year;
+	const endYear = toUtcDay(endDate).year;
+	if (!Number.isFinite(startYear) || !Number.isFinite(endYear) || endYear < startYear) return [];
+
+	const years: number[] = [];
+	for (let year = startYear - 1; year <= endYear; year++) {
+		years.push(year);
+	}
+	return years;
 }
 
 function expandPresetHolidayForYear(params: {
@@ -166,6 +180,16 @@ function overlapsRange(holiday: AssignedHolidayRange, startDate: Date, endDate: 
 	return holiday.startDate <= endDate && holiday.endDate >= startDate;
 }
 
+export function overlapsEffectiveWindow(
+	holiday: AssignedHolidayRange,
+	window: { effectiveFrom: Date | null; effectiveUntil: Date | null },
+): boolean {
+	return (
+		(!window.effectiveFrom || holiday.endDate >= window.effectiveFrom) &&
+		(!window.effectiveUntil || holiday.startDate <= window.effectiveUntil)
+	);
+}
+
 export async function getAssignedHolidaysForEmployee(params: {
 	organizationId: string;
 	employeeId: string;
@@ -205,6 +229,7 @@ export async function getAssignedHolidaysForEmployee(params: {
 	})) as unknown as HolidayAssignmentWithHoliday[];
 
 	const presetAssignments = (await db.query.holidayPresetAssignment.findMany({
+		columns: { effectiveFrom: true, effectiveUntil: true },
 		where: and(
 			eq(holidayPresetAssignment.organizationId, params.organizationId),
 			eq(holidayPresetAssignment.isActive, true),
@@ -262,13 +287,12 @@ export async function getAssignedHolidaysForEmployee(params: {
 		});
 	}
 
-	const startYear = toUtcDay(params.startDate).year;
-	const endYear = toUtcDay(params.endDate).year;
+	const expansionYears = getPresetHolidayExpansionYears(params.startDate, params.endDate);
 	for (const assignment of presetAssignments) {
 		const preset = assignment.preset;
 		if (!preset?.isActive || preset.organizationId !== params.organizationId) continue;
 
-		for (let year = startYear; year <= endYear; year++) {
+		for (const year of expansionYears) {
 			for (const presetHoliday of preset.holidays) {
 				if (!presetHoliday.isActive) continue;
 
@@ -279,7 +303,11 @@ export async function getAssignedHolidaysForEmployee(params: {
 					presetHoliday,
 					year,
 				});
-				if (!expandedHoliday || !overlapsRange(expandedHoliday, params.startDate, params.endDate))
+				if (
+					!expandedHoliday ||
+					!overlapsRange(expandedHoliday, params.startDate, params.endDate) ||
+					!overlapsEffectiveWindow(expandedHoliday, assignment)
+				)
 					continue;
 
 				holidaysById.set(expandedHoliday.id, expandedHoliday);

--- a/apps/webapp/src/lib/calendar/assigned-holidays.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.ts
@@ -1,0 +1,293 @@
+import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
+import { DateTime } from "luxon";
+import { db } from "@/db";
+import {
+	employee,
+	type holiday,
+	holidayAssignment,
+	type holidayPreset,
+	holidayPresetAssignment,
+	type holidayPresetHoliday,
+} from "@/db/schema";
+import type { DailyWorkRequirements, HolidayEvent } from "./types";
+
+export interface AssignedHolidayRange {
+	id: string;
+	name: string;
+	startDate: Date;
+	endDate: Date;
+	categoryId?: string | null;
+	color?: string | null;
+	description?: string | null;
+	metadata?: Partial<HolidayEvent["metadata"]>;
+}
+
+type HolidayAssignmentWithHoliday = {
+	holiday: Pick<
+		typeof holiday.$inferSelect,
+		| "id"
+		| "name"
+		| "organizationId"
+		| "startDate"
+		| "endDate"
+		| "categoryId"
+		| "description"
+		| "isActive"
+	> | null;
+};
+
+type HolidayPresetAssignmentWithPreset = {
+	preset:
+		| (Pick<
+				typeof holidayPreset.$inferSelect,
+				"id" | "name" | "organizationId" | "color" | "isActive"
+		  > & {
+				holidays: Pick<
+					typeof holidayPresetHoliday.$inferSelect,
+					| "id"
+					| "name"
+					| "description"
+					| "month"
+					| "day"
+					| "durationDays"
+					| "categoryId"
+					| "isActive"
+				>[];
+		  })
+		| null;
+};
+
+function toUtcDay(date: Date): DateTime {
+	return DateTime.fromJSDate(date, { zone: "utc" }).startOf("day");
+}
+
+export function getAssignedHolidayDateKeys(holidays: AssignedHolidayRange[]): Set<string> {
+	const dateKeys = new Set<string>();
+
+	for (const holiday of holidays) {
+		let cursor = toUtcDay(holiday.startDate);
+		const end = toUtcDay(holiday.endDate);
+		if (!cursor.isValid || !end.isValid || end < cursor) continue;
+
+		while (cursor <= end) {
+			const dateKey = cursor.toISODate();
+			if (dateKey) dateKeys.add(dateKey);
+			cursor = cursor.plus({ days: 1 });
+		}
+	}
+
+	return dateKeys;
+}
+
+export function applyAssignedHolidayAdjustmentsToRequirements(
+	requirements: DailyWorkRequirements,
+	holidays: AssignedHolidayRange[],
+): DailyWorkRequirements {
+	const holidayDateKeys = getAssignedHolidayDateKeys(holidays);
+	const adjusted: DailyWorkRequirements = {};
+
+	for (const [dateKey, requirement] of Object.entries(requirements)) {
+		adjusted[dateKey] = {
+			...requirement,
+			requiredMinutes: holidayDateKeys.has(dateKey) ? 0 : requirement.requiredMinutes,
+		};
+	}
+
+	return adjusted;
+}
+
+export function assignedHolidayToCalendarEvent(holiday: AssignedHolidayRange): HolidayEvent {
+	return {
+		id: holiday.id,
+		type: "holiday",
+		date: holiday.startDate,
+		endDate: holiday.endDate,
+		title: holiday.name,
+		description: holiday.description ?? undefined,
+		color: holiday.color ?? "#f59e0b",
+		metadata: {
+			categoryName: "Holiday",
+			categoryType: "public_holiday",
+			blocksTimeEntry: true,
+			isRecurring: false,
+			...holiday.metadata,
+		},
+	};
+}
+
+function getAssignmentScope(
+	table: typeof holidayAssignment | typeof holidayPresetAssignment,
+	employeeId: string,
+	teamId: string | null,
+) {
+	const scope = [eq(table.assignmentType, "organization")];
+	if (teamId) scope.push(eq(table.teamId, teamId));
+	scope.push(eq(table.employeeId, employeeId));
+	return scope;
+}
+
+function expandPresetHolidayForYear(params: {
+	presetId: string;
+	presetName: string;
+	presetColor: string | null;
+	presetHoliday: Pick<
+		typeof holidayPresetHoliday.$inferSelect,
+		"id" | "name" | "description" | "month" | "day" | "durationDays" | "categoryId"
+	>;
+	year: number;
+}): AssignedHolidayRange | null {
+	const start = DateTime.utc(
+		params.year,
+		params.presetHoliday.month,
+		params.presetHoliday.day,
+	).startOf("day");
+	if (!start.isValid) return null;
+
+	const durationDays = Math.max(1, params.presetHoliday.durationDays ?? 1);
+	const end = start.plus({ days: durationDays - 1 }).endOf("day");
+
+	return {
+		id: `preset-${params.presetId}-${params.presetHoliday.id}-${params.year}`,
+		name: params.presetHoliday.name,
+		startDate: start.toJSDate(),
+		endDate: end.toJSDate(),
+		categoryId: params.presetHoliday.categoryId,
+		color: params.presetColor,
+		description: params.presetHoliday.description,
+		metadata: {
+			isRecurring: true,
+			presetId: params.presetId,
+			presetName: params.presetName,
+		},
+	};
+}
+
+function overlapsRange(holiday: AssignedHolidayRange, startDate: Date, endDate: Date): boolean {
+	return holiday.startDate <= endDate && holiday.endDate >= startDate;
+}
+
+export async function getAssignedHolidaysForEmployee(params: {
+	organizationId: string;
+	employeeId: string;
+	startDate: Date;
+	endDate: Date;
+}): Promise<AssignedHolidayRange[]> {
+	const scopedEmployee = await db.query.employee.findFirst({
+		where: and(
+			eq(employee.id, params.employeeId),
+			eq(employee.organizationId, params.organizationId),
+		),
+		columns: { id: true, organizationId: true, teamId: true },
+	});
+
+	if (!scopedEmployee) return [];
+
+	const customAssignments = (await db.query.holidayAssignment.findMany({
+		where: and(
+			eq(holidayAssignment.organizationId, params.organizationId),
+			eq(holidayAssignment.isActive, true),
+			or(...getAssignmentScope(holidayAssignment, params.employeeId, scopedEmployee.teamId)),
+		),
+		with: {
+			holiday: {
+				columns: {
+					id: true,
+					name: true,
+					organizationId: true,
+					startDate: true,
+					endDate: true,
+					categoryId: true,
+					description: true,
+					isActive: true,
+				},
+			},
+		},
+	})) as unknown as HolidayAssignmentWithHoliday[];
+
+	const presetAssignments = (await db.query.holidayPresetAssignment.findMany({
+		where: and(
+			eq(holidayPresetAssignment.organizationId, params.organizationId),
+			eq(holidayPresetAssignment.isActive, true),
+			or(...getAssignmentScope(holidayPresetAssignment, params.employeeId, scopedEmployee.teamId)),
+			or(
+				isNull(holidayPresetAssignment.effectiveFrom),
+				lte(holidayPresetAssignment.effectiveFrom, params.endDate),
+			),
+			or(
+				isNull(holidayPresetAssignment.effectiveUntil),
+				gte(holidayPresetAssignment.effectiveUntil, params.startDate),
+			),
+		),
+		with: {
+			preset: {
+				columns: { id: true, name: true, organizationId: true, color: true, isActive: true },
+				with: {
+					holidays: {
+						columns: {
+							id: true,
+							name: true,
+							description: true,
+							month: true,
+							day: true,
+							durationDays: true,
+							categoryId: true,
+							isActive: true,
+						},
+					},
+				},
+			},
+		},
+	})) as unknown as HolidayPresetAssignmentWithPreset[];
+
+	const holidaysById = new Map<string, AssignedHolidayRange>();
+
+	for (const assignment of customAssignments) {
+		const assignedHoliday = assignment.holiday;
+		if (
+			!assignedHoliday?.isActive ||
+			assignedHoliday.organizationId !== params.organizationId ||
+			assignedHoliday.startDate > params.endDate ||
+			assignedHoliday.endDate < params.startDate
+		) {
+			continue;
+		}
+
+		holidaysById.set(`custom-${assignedHoliday.id}`, {
+			id: assignedHoliday.id,
+			name: assignedHoliday.name,
+			startDate: assignedHoliday.startDate,
+			endDate: assignedHoliday.endDate,
+			categoryId: assignedHoliday.categoryId,
+			description: assignedHoliday.description,
+		});
+	}
+
+	const startYear = toUtcDay(params.startDate).year;
+	const endYear = toUtcDay(params.endDate).year;
+	for (const assignment of presetAssignments) {
+		const preset = assignment.preset;
+		if (!preset?.isActive || preset.organizationId !== params.organizationId) continue;
+
+		for (let year = startYear; year <= endYear; year++) {
+			for (const presetHoliday of preset.holidays) {
+				if (!presetHoliday.isActive) continue;
+
+				const expandedHoliday = expandPresetHolidayForYear({
+					presetId: preset.id,
+					presetName: preset.name,
+					presetColor: preset.color,
+					presetHoliday,
+					year,
+				});
+				if (!expandedHoliday || !overlapsRange(expandedHoliday, params.startDate, params.endDate))
+					continue;
+
+				holidaysById.set(expandedHoliday.id, expandedHoliday);
+			}
+		}
+	}
+
+	return [...holidaysById.values()].sort(
+		(left, right) => left.startDate.getTime() - right.startDate.getTime(),
+	);
+}

--- a/apps/webapp/src/lib/calendar/assigned-holidays.ts
+++ b/apps/webapp/src/lib/calendar/assigned-holidays.ts
@@ -23,18 +23,25 @@ export interface AssignedHolidayRange {
 }
 
 type HolidayAssignmentWithHoliday = {
-	holiday: Pick<
-		typeof holiday.$inferSelect,
-		| "id"
-		| "name"
-		| "organizationId"
-		| "startDate"
-		| "endDate"
-		| "categoryId"
-		| "description"
-		| "isActive"
-	> | null;
+	holiday: CustomAssignedHoliday | null;
 };
+
+export type CustomAssignedHoliday = Pick<
+	typeof holiday.$inferSelect,
+	| "id"
+	| "name"
+	| "organizationId"
+	| "startDate"
+	| "endDate"
+	| "categoryId"
+	| "description"
+	| "isActive"
+	| "recurrenceType"
+	| "recurrenceRule"
+	| "recurrenceEndDate"
+>;
+
+export type RequestedDateRange = { startDate: Date; endDate: Date };
 
 type HolidayPresetAssignmentWithPreset = {
 	effectiveFrom: Date | null;
@@ -180,6 +187,98 @@ function overlapsRange(holiday: AssignedHolidayRange, startDate: Date, endDate: 
 	return holiday.startDate <= endDate && holiday.endDate >= startDate;
 }
 
+function toAssignedHolidayRange(
+	holiday: CustomAssignedHoliday,
+	dateRange: { startDate: Date; endDate: Date },
+): AssignedHolidayRange {
+	return {
+		id:
+			dateRange.startDate.getTime() === holiday.startDate.getTime()
+				? holiday.id
+				: `${holiday.id}-${toUtcDay(dateRange.startDate).year}`,
+		name: holiday.name,
+		startDate: dateRange.startDate,
+		endDate: dateRange.endDate,
+		categoryId: holiday.categoryId,
+		description: holiday.description,
+		metadata: {
+			isRecurring: holiday.recurrenceType !== "none",
+		},
+	};
+}
+
+function parseYearlyRecurrenceRule(rule: string | null): { month: number; day: number } | null {
+	if (!rule) return null;
+
+	try {
+		const parsed = JSON.parse(rule) as { month?: unknown; day?: unknown };
+		if (!Number.isInteger(parsed.month) || !Number.isInteger(parsed.day)) return null;
+		return { month: parsed.month, day: parsed.day };
+	} catch {
+		return null;
+	}
+}
+
+export function expandCustomAssignedHoliday(
+	holiday: CustomAssignedHoliday,
+	requestedRange: RequestedDateRange,
+): AssignedHolidayRange[] {
+	if (!holiday.isActive) return [];
+
+	const requestedStart = toUtcDay(requestedRange.startDate);
+	const requestedEnd = toUtcDay(requestedRange.endDate).endOf("day");
+	const originalStart = toUtcDay(holiday.startDate);
+	const originalEnd = toUtcDay(holiday.endDate);
+	if (
+		!requestedStart.isValid ||
+		!requestedEnd.isValid ||
+		requestedEnd < requestedStart ||
+		!originalStart.isValid ||
+		!originalEnd.isValid ||
+		originalEnd < originalStart
+	) {
+		return [];
+	}
+
+	if (holiday.recurrenceType === "none") {
+		const assignedHoliday = toAssignedHolidayRange(holiday, {
+			startDate: holiday.startDate,
+			endDate: holiday.endDate,
+		});
+		return overlapsRange(assignedHoliday, requestedRange.startDate, requestedRange.endDate)
+			? [assignedHoliday]
+			: [];
+	}
+
+	if (holiday.recurrenceType !== "yearly") return [];
+
+	const rule = parseYearlyRecurrenceRule(holiday.recurrenceRule);
+	if (!rule) return [];
+
+	const durationDays = Math.floor(originalEnd.diff(originalStart, "days").days) + 1;
+	const recurrenceEnd = holiday.recurrenceEndDate
+		? toUtcDay(holiday.recurrenceEndDate).endOf("day")
+		: null;
+	const expanded: AssignedHolidayRange[] = [];
+
+	for (let year = requestedStart.year - 1; year <= requestedEnd.year; year++) {
+		const start = DateTime.utc(year, rule.month, rule.day).startOf("day");
+		if (!start.isValid) continue;
+		if (recurrenceEnd && start > recurrenceEnd) continue;
+
+		const end = start.plus({ days: durationDays - 1 }).endOf("day");
+		const assignedHoliday = toAssignedHolidayRange(holiday, {
+			startDate: start.toJSDate(),
+			endDate: end.toJSDate(),
+		});
+		if (overlapsRange(assignedHoliday, requestedRange.startDate, requestedRange.endDate)) {
+			expanded.push(assignedHoliday);
+		}
+	}
+
+	return expanded;
+}
+
 export function overlapsEffectiveWindow(
 	holiday: AssignedHolidayRange,
 	window: { effectiveFrom: Date | null; effectiveUntil: Date | null },
@@ -223,6 +322,9 @@ export async function getAssignedHolidaysForEmployee(params: {
 					categoryId: true,
 					description: true,
 					isActive: true,
+					recurrenceType: true,
+					recurrenceRule: true,
+					recurrenceEndDate: true,
 				},
 			},
 		},
@@ -268,23 +370,13 @@ export async function getAssignedHolidaysForEmployee(params: {
 
 	for (const assignment of customAssignments) {
 		const assignedHoliday = assignment.holiday;
-		if (
-			!assignedHoliday?.isActive ||
-			assignedHoliday.organizationId !== params.organizationId ||
-			assignedHoliday.startDate > params.endDate ||
-			assignedHoliday.endDate < params.startDate
-		) {
+		if (!assignedHoliday || assignedHoliday.organizationId !== params.organizationId) {
 			continue;
 		}
 
-		holidaysById.set(`custom-${assignedHoliday.id}`, {
-			id: assignedHoliday.id,
-			name: assignedHoliday.name,
-			startDate: assignedHoliday.startDate,
-			endDate: assignedHoliday.endDate,
-			categoryId: assignedHoliday.categoryId,
-			description: assignedHoliday.description,
-		});
+		for (const expandedHoliday of expandCustomAssignedHoliday(assignedHoliday, params)) {
+			holidaysById.set(`custom-${expandedHoliday.id}`, expandedHoliday);
+		}
 	}
 
 	const expansionYears = getPresetHolidayExpansionYears(params.startDate, params.endDate);

--- a/apps/webapp/src/lib/calendar/work-policy-requirements.test.ts
+++ b/apps/webapp/src/lib/calendar/work-policy-requirements.test.ts
@@ -174,10 +174,12 @@ describe("buildDailyWorkRequirements", () => {
 });
 
 describe("getDailyWorkRequirementsForEmployee", () => {
-	it("clamps generated requirements to the employee start date", () => {
+	it("clamps generated requirements to account creation unless imported work predates it", () => {
 		expect(source).toContain("columns: { id: true, startDate: true }");
+		expect(source).toContain("user: { columns: { createdAt: true } }");
+		expect(source).toContain("getFirstCompletedWorkPeriodBeforeAccount");
+		expect(source).toContain("scopedEmployee.user.createdAt");
 		expect(source).toContain("const effectiveStartDate");
-		expect(source).toContain("scopedEmployee.startDate");
 		expect(source).toContain("if (effectiveStartDate > params.endDate) return {};");
 		expect(source).toContain("startDate: effectiveStartDate");
 	});

--- a/apps/webapp/src/lib/calendar/work-policy-requirements.test.ts
+++ b/apps/webapp/src/lib/calendar/work-policy-requirements.test.ts
@@ -7,7 +7,10 @@ import {
 	buildDailyWorkRequirements,
 } from "./work-policy-requirements";
 
-const source = readFileSync(fileURLToPath(new URL("./work-policy-requirements.ts", import.meta.url)), "utf8");
+const source = readFileSync(
+	fileURLToPath(new URL("./work-policy-requirements.ts", import.meta.url)),
+	"utf8",
+);
 
 function basePolicy(schedule: EffectiveWorkPolicy["schedule"]): EffectiveWorkPolicy {
 	return {
@@ -174,6 +177,17 @@ describe("buildDailyWorkRequirements", () => {
 });
 
 describe("getDailyWorkRequirementsForEmployee", () => {
+	it("applies assigned holiday adjustments after absence adjustments", () => {
+		expect(source).toContain("getAssignedHolidaysForEmployee");
+		expect(source).toContain("applyAssignedHolidayAdjustmentsToRequirements");
+		expect(source).toContain(
+			"const absenceAdjustedRequirements = applyApprovedAbsencesToDailyRequirements",
+		);
+		expect(source).toContain(
+			"return applyAssignedHolidayAdjustmentsToRequirements(absenceAdjustedRequirements, assignedHolidays)",
+		);
+	});
+
 	it("clamps generated requirements to account creation unless imported work predates it", () => {
 		expect(source).toContain("columns: { id: true, startDate: true }");
 		expect(source).toContain("user: { columns: { createdAt: true } }");

--- a/apps/webapp/src/lib/calendar/work-policy-requirements.ts
+++ b/apps/webapp/src/lib/calendar/work-policy-requirements.ts
@@ -12,6 +12,10 @@ import {
 	type ApprovedAbsenceRange,
 	applyAbsenceAdjustmentsToRequirements,
 } from "./absence-adjusted-requirements";
+import {
+	applyAssignedHolidayAdjustmentsToRequirements,
+	getAssignedHolidaysForEmployee,
+} from "./assigned-holidays";
 import type { DailyWorkRequirements } from "./types";
 
 type EffectiveWorkPolicyScheduleDayName = NonNullable<
@@ -204,7 +208,9 @@ export async function getDailyWorkRequirementsForEmployee(params: {
 			if (!scopedEmployee) return {};
 
 			const requestedStartDate = DateTime.fromJSDate(params.startDate, { zone: "utc" });
-			const accountCreatedDate = DateTime.fromJSDate(scopedEmployee.user.createdAt, { zone: "utc" });
+			const accountCreatedDate = DateTime.fromJSDate(scopedEmployee.user.createdAt, {
+				zone: "utc",
+			});
 			const firstCompletedWorkPeriodBeforeAccount = yield* _(
 				Effect.promise(() =>
 					getFirstCompletedWorkPeriodBeforeAccount({
@@ -247,7 +253,23 @@ export async function getDailyWorkRequirementsForEmployee(params: {
 				),
 			);
 
-			return applyApprovedAbsencesToDailyRequirements(requirements, approvedAbsences);
+			const absenceAdjustedRequirements = applyApprovedAbsencesToDailyRequirements(
+				requirements,
+				approvedAbsences,
+			);
+			const assignedHolidays = yield* _(
+				Effect.promise(() =>
+					getAssignedHolidaysForEmployee({
+						organizationId: params.organizationId,
+						employeeId: params.employeeId,
+						startDate: effectiveStartDate,
+						endDate: params.endDate,
+					}),
+				),
+			);
+
+			// biome-ignore format: source-level regression test asserts this call order.
+			return applyAssignedHolidayAdjustmentsToRequirements(absenceAdjustedRequirements, assignedHolidays);
 		}).pipe(Effect.provide(WorkPolicyServiceLive), Effect.provide(DatabaseServiceLive)),
 	);
 }

--- a/apps/webapp/src/lib/calendar/work-policy-requirements.ts
+++ b/apps/webapp/src/lib/calendar/work-policy-requirements.ts
@@ -1,7 +1,7 @@
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, isNotNull, lt, lte, min } from "drizzle-orm";
 import { Effect } from "effect";
 import { DateTime } from "luxon";
-import { absenceCategory, absenceEntry, employee } from "@/db/schema";
+import { absenceCategory, absenceEntry, employee, workPeriod } from "@/db/schema";
 import { DatabaseService, DatabaseServiceLive } from "@/lib/effect/services/database.service";
 import {
 	type EffectiveWorkPolicy,
@@ -154,6 +154,32 @@ async function getApprovedAbsenceRanges(params: {
 	);
 }
 
+async function getFirstCompletedWorkPeriodBeforeAccount(params: {
+	database: typeof DatabaseService.Service;
+	organizationId: string;
+	employeeId: string;
+	accountCreatedAt: Date;
+}): Promise<Date | null> {
+	const [row] = await Effect.runPromise(
+		params.database.query("getFirstCompletedWorkPeriodBeforeAccount", async () => {
+			return params.database.db
+				.select({ value: min(workPeriod.startTime) })
+				.from(workPeriod)
+				.where(
+					and(
+						eq(workPeriod.employeeId, params.employeeId),
+						eq(workPeriod.organizationId, params.organizationId),
+						isNotNull(workPeriod.endTime),
+						isNotNull(workPeriod.durationMinutes),
+						lt(workPeriod.startTime, params.accountCreatedAt),
+					),
+				);
+		}),
+	);
+
+	return row?.value ?? null;
+}
+
 export async function getDailyWorkRequirementsForEmployee(params: {
 	organizationId: string;
 	employeeId: string;
@@ -171,16 +197,35 @@ export async function getDailyWorkRequirementsForEmployee(params: {
 							eq(employee.organizationId, params.organizationId),
 						),
 						columns: { id: true, startDate: true },
+						with: { user: { columns: { createdAt: true } } },
 					});
 				}),
 			);
 			if (!scopedEmployee) return {};
 
 			const requestedStartDate = DateTime.fromJSDate(params.startDate, { zone: "utc" });
+			const accountCreatedDate = DateTime.fromJSDate(scopedEmployee.user.createdAt, { zone: "utc" });
+			const firstCompletedWorkPeriodBeforeAccount = yield* _(
+				Effect.promise(() =>
+					getFirstCompletedWorkPeriodBeforeAccount({
+						database,
+						organizationId: params.organizationId,
+						employeeId: params.employeeId,
+						accountCreatedAt: scopedEmployee.user.createdAt,
+					}),
+				),
+			);
 			const employeeStartDate = scopedEmployee.startDate
 				? DateTime.fromJSDate(scopedEmployee.startDate, { zone: "utc" })
-				: requestedStartDate;
-			const effectiveStartDate = DateTime.max(requestedStartDate, employeeStartDate).toJSDate();
+				: accountCreatedDate;
+			const normalStartDate = DateTime.max(accountCreatedDate, employeeStartDate);
+			const lowerBoundDate = firstCompletedWorkPeriodBeforeAccount
+				? DateTime.min(
+						DateTime.fromJSDate(firstCompletedWorkPeriodBeforeAccount, { zone: "utc" }),
+						normalStartDate,
+					)
+				: normalStartDate;
+			const effectiveStartDate = DateTime.max(requestedStartDate, lowerBoundDate).toJSDate();
 			if (effectiveStartDate > params.endDate) return {};
 
 			const service = yield* _(WorkPolicyService);

--- a/apps/webapp/src/lib/work-balance/service.test.ts
+++ b/apps/webapp/src/lib/work-balance/service.test.ts
@@ -6,6 +6,9 @@ import { formatSignedWorkBalance, getWorkBalanceStatus } from "./format";
 const mockState = vi.hoisted(() => ({
 	db: {
 		query: {
+			employee: {
+				findFirst: vi.fn(),
+			},
 			employeeWorkBalance: {
 				findFirst: vi.fn(),
 			},
@@ -72,6 +75,12 @@ describe("work balance helpers", () => {
 		mockState.db.insert.mockReturnValue({ values: mockState.insertValues });
 		mockState.insertValues.mockReturnValue({ onConflictDoUpdate: mockState.onConflictDoUpdate });
 		mockState.getDailyWorkRequirementsForEmployee.mockResolvedValue({});
+		mockState.db.query.employee.findFirst.mockReset();
+		mockState.db.query.employee.findFirst.mockResolvedValue({
+			id: "employee-1",
+			startDate: null,
+			user: { createdAt: new Date("2026-05-01T00:00:00.000Z") },
+		});
 	});
 
 	it("builds all-time work balance values", () => {
@@ -253,17 +262,15 @@ describe("work balance helpers", () => {
 		);
 	});
 
-	it("uses the employee start date as the all-time balance start when it predates work and absences", async () => {
+	it("uses the account creation date as the all-time balance start when it predates work and absences", async () => {
 		mockState.db.select.mockReturnValue({ from: mockState.selectFrom });
 		mockState.selectFrom
-			.mockReturnValueOnce({ where: mockState.selectWhere })
 			.mockReturnValueOnce({ where: mockState.selectWhere })
 			.mockReturnValueOnce({ where: mockState.selectWhere })
 			.mockReturnValueOnce({ where: mockState.selectWhere });
 		mockState.selectWhere
 			.mockResolvedValueOnce([{ value: new Date("2026-05-10T09:00:00.000Z") }])
 			.mockResolvedValueOnce([{ value: "2026-05-08" }])
-			.mockResolvedValueOnce([{ value: new Date("2026-05-01T00:00:00.000Z") }])
 			.mockResolvedValueOnce([{ totalMinutes: 480 }]);
 		mockState.getDailyWorkRequirementsForEmployee.mockResolvedValue({
 			"2026-05-01": { requiredMinutes: 480 },
@@ -293,18 +300,96 @@ describe("work balance helpers", () => {
 		);
 	});
 
-	it("includes completed legacy periods even when isActive is stale", async () => {
+	it("uses the account creation date when no completed work predates the account", async () => {
 		mockState.db.select.mockReturnValue({ from: mockState.selectFrom });
 		mockState.selectFrom
 			.mockReturnValueOnce({ where: mockState.selectWhere })
+			.mockReturnValueOnce({ where: mockState.selectWhere })
+			.mockReturnValueOnce({ where: mockState.selectWhere });
+		mockState.selectWhere
+			.mockResolvedValueOnce([{ value: new Date("2026-05-20T09:00:00.000Z") }])
+			.mockResolvedValueOnce([{ value: "2026-05-08" }])
+			.mockResolvedValueOnce([{ totalMinutes: 480 }]);
+		mockState.db.query.employee.findFirst.mockResolvedValueOnce({
+			id: "employee-1",
+			startDate: new Date("2026-05-01T00:00:00.000Z"),
+			user: { createdAt: new Date("2026-05-15T10:30:00.000Z") },
+		});
+		mockState.getDailyWorkRequirementsForEmployee.mockResolvedValue({
+			"2026-05-15": { requiredMinutes: 480 },
+		});
+
+		const result = await computeEmployeeWorkBalance({
+			employeeId: "employee-1",
+			organizationId: "org-1",
+			now: new Date("2026-05-22T12:00:00.000Z"),
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				computedFromDate: "2026-05-15",
+				actualMinutes: 480,
+				requiredMinutes: 480,
+				balanceMinutes: 0,
+			}),
+		);
+		expect(mockState.getDailyWorkRequirementsForEmployee).toHaveBeenCalledWith(
+			expect.objectContaining({
+				startDate: new Date("2026-05-15T00:00:00.000Z"),
+			}),
+		);
+	});
+
+	it("uses the first completed work period when imported work predates the account", async () => {
+		mockState.db.select.mockReturnValue({ from: mockState.selectFrom });
+		mockState.selectFrom
+			.mockReturnValueOnce({ where: mockState.selectWhere })
+			.mockReturnValueOnce({ where: mockState.selectWhere })
+			.mockReturnValueOnce({ where: mockState.selectWhere });
+		mockState.selectWhere
+			.mockResolvedValueOnce([{ value: new Date("2026-05-10T09:00:00.000Z") }])
+			.mockResolvedValueOnce([{ value: null }])
+			.mockResolvedValueOnce([{ totalMinutes: 480 }]);
+		mockState.db.query.employee.findFirst.mockResolvedValueOnce({
+			id: "employee-1",
+			startDate: null,
+			user: { createdAt: new Date("2026-05-15T10:30:00.000Z") },
+		});
+
+		const result = await computeEmployeeWorkBalance({
+			employeeId: "employee-1",
+			organizationId: "org-1",
+			now: new Date("2026-05-22T12:00:00.000Z"),
+		});
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				computedFromDate: "2026-05-10",
+				actualMinutes: 480,
+			}),
+		);
+		expect(mockState.getDailyWorkRequirementsForEmployee).toHaveBeenCalledWith(
+			expect.objectContaining({
+				startDate: new Date("2026-05-10T00:00:00.000Z"),
+			}),
+		);
+	});
+
+	it("includes completed legacy periods even when isActive is stale", async () => {
+		mockState.db.select.mockReturnValue({ from: mockState.selectFrom });
+		mockState.selectFrom
 			.mockReturnValueOnce({ where: mockState.selectWhere })
 			.mockReturnValueOnce({ where: mockState.selectWhere })
 			.mockReturnValueOnce({ where: mockState.selectWhere });
 		mockState.selectWhere
 			.mockResolvedValueOnce([{ value: new Date("2026-05-03T09:00:00.000Z") }])
 			.mockResolvedValueOnce([{ value: null }])
-			.mockResolvedValueOnce([{ value: null }])
 			.mockResolvedValueOnce([{ totalMinutes: 450 }]);
+		mockState.db.query.employee.findFirst.mockResolvedValueOnce({
+			id: "employee-1",
+			startDate: null,
+			user: { createdAt: new Date("2026-05-03T00:00:00.000Z") },
+		});
 		mockState.getDailyWorkRequirementsForEmployee.mockResolvedValue({});
 
 		const result = await computeEmployeeWorkBalance({

--- a/apps/webapp/src/lib/work-balance/service.ts
+++ b/apps/webapp/src/lib/work-balance/service.ts
@@ -89,6 +89,13 @@ async function getFirstRelevantDate(input: {
 	employeeId: string;
 	organizationId: string;
 }): Promise<string | null> {
+	const scopedEmployee = await db.query.employee.findFirst({
+		where: and(eq(employee.id, input.employeeId), eq(employee.organizationId, input.organizationId)),
+		columns: { id: true, startDate: true },
+		with: { user: { columns: { createdAt: true } } },
+	});
+	if (!scopedEmployee) return null;
+
 	const [firstWorkPeriod] = await db
 		.select({ value: min(workPeriod.startTime) })
 		.from(workPeriod)
@@ -112,29 +119,23 @@ async function getFirstRelevantDate(input: {
 			),
 		);
 
-	const [employeeStart] = await db
-		.select({ value: min(employee.startDate) })
-		.from(employee)
-		.where(
-			and(
-				eq(employee.id, input.employeeId),
-				eq(employee.organizationId, input.organizationId),
-				isNotNull(employee.startDate),
-			),
-		);
-
 	const workDate = firstWorkPeriod?.value
 		? DateTime.fromJSDate(firstWorkPeriod.value, { zone: "utc" }).toISODate()
 		: null;
-	const absenceDate = firstAbsence?.value ?? null;
-	const employeeStartDate = employeeStart?.value
-		? DateTime.fromJSDate(employeeStart.value, { zone: "utc" }).toISODate()
-		: null;
-	const dates = [workDate, absenceDate, employeeStartDate].filter((value): value is string =>
-		Boolean(value),
-	);
-	if (dates.length === 0) return null;
-	return dates.sort()[0]!;
+	const accountCreatedDate = DateTime.fromJSDate(scopedEmployee.user.createdAt, {
+		zone: "utc",
+	}).toISODate();
+	if (!accountCreatedDate) return null;
+
+	if (workDate && workDate < accountCreatedDate) {
+		const absenceDate = firstAbsence?.value ?? null;
+		const dates = [workDate, absenceDate, accountCreatedDate].filter(
+			(value): value is string => Boolean(value),
+		);
+		return dates.sort()[0]!;
+	}
+
+	return accountCreatedDate;
 }
 
 async function getActualMinutes(input: {

--- a/docs/superpowers/plans/2026-05-23-calendar-assigned-holidays-work-targets.md
+++ b/docs/superpowers/plans/2026-05-23-calendar-assigned-holidays-work-targets.md
@@ -1,0 +1,624 @@
+# Calendar Assigned Holidays Work Targets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display employee-assigned holidays on `/calendar` and set policy-required minutes to `0` on assigned holiday dates.
+
+**Architecture:** Add one focused employee-assigned holiday service in `apps/webapp/src/lib/calendar`, then call it from both `/api/calendar/events` and `getDailyWorkRequirementsForEmployee`. This keeps the work-balance worker correct automatically because it already uses the shared requirement function.
+
+**Tech Stack:** Next.js route handlers, Drizzle ORM, Luxon, Vitest, pnpm.
+
+---
+
+## File Structure
+
+- Create `apps/webapp/src/lib/calendar/assigned-holidays.ts`: employee-scoped assigned holiday resolver, event conversion, holiday date expansion, and pure requirement adjustment helper.
+- Create `apps/webapp/src/lib/calendar/assigned-holidays.test.ts`: pure helper tests for date expansion and requirement zeroing.
+- Modify `apps/webapp/src/app/api/calendar/events/route.ts`: use assigned holidays when an authorized employee is scoped; keep org-wide fallback when no employee is scoped.
+- Modify `apps/webapp/src/app/api/calendar/events/route.test.ts`: mock and assert employee-scoped holiday loading.
+- Modify `apps/webapp/src/lib/calendar/work-policy-requirements.ts`: fetch assigned holidays after absence adjustment and zero required minutes.
+- Modify `apps/webapp/src/lib/calendar/work-policy-requirements.test.ts`: add source-level guard that requirement calculation calls the holiday adjuster after absence adjustment.
+
+## Task 1: Shared Assigned Holiday Service
+
+**Files:**
+- Create: `apps/webapp/src/lib/calendar/assigned-holidays.ts`
+- Create: `apps/webapp/src/lib/calendar/assigned-holidays.test.ts`
+
+- [ ] **Step 1: Write failing pure helper tests**
+
+Create `apps/webapp/src/lib/calendar/assigned-holidays.test.ts` with:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	applyAssignedHolidayAdjustmentsToRequirements,
+	getAssignedHolidayDateKeys,
+	type AssignedHolidayRange,
+} from "./assigned-holidays";
+
+const singleDayHoliday: AssignedHolidayRange = {
+	id: "holiday-1",
+	name: "Labor Day",
+	startDate: new Date("2026-05-01T00:00:00.000Z"),
+	endDate: new Date("2026-05-01T23:59:59.999Z"),
+};
+
+describe("assigned holiday requirement adjustments", () => {
+	it("sets required minutes to zero on an assigned holiday", () => {
+		expect(
+			applyAssignedHolidayAdjustmentsToRequirements(
+				{
+					"2026-05-01": {
+						requiredMinutes: 480,
+						policyId: "policy-1",
+						policyName: "Standard Hours",
+					},
+				},
+				[singleDayHoliday],
+			),
+		).toEqual({
+			"2026-05-01": {
+				requiredMinutes: 0,
+				policyId: "policy-1",
+				policyName: "Standard Hours",
+			},
+		});
+	});
+
+	it("zeros every overlapping required date for a multi-day holiday", () => {
+		const adjusted = applyAssignedHolidayAdjustmentsToRequirements(
+			{
+				"2026-05-04": { requiredMinutes: 480, policyId: "policy-1", policyName: "Standard Hours" },
+				"2026-05-05": { requiredMinutes: 360, policyId: "policy-1", policyName: "Standard Hours" },
+				"2026-05-06": { requiredMinutes: 480, policyId: "policy-1", policyName: "Standard Hours" },
+			},
+			[
+				{
+					id: "holiday-2",
+					name: "Company Shutdown",
+					startDate: new Date("2026-05-04T00:00:00.000Z"),
+					endDate: new Date("2026-05-05T23:59:59.999Z"),
+				},
+			],
+		);
+
+		expect(adjusted["2026-05-04"]?.requiredMinutes).toBe(0);
+		expect(adjusted["2026-05-05"]?.requiredMinutes).toBe(0);
+		expect(adjusted["2026-05-06"]?.requiredMinutes).toBe(480);
+	});
+
+	it("does not create requirement entries for holiday dates without policy requirements", () => {
+		expect(applyAssignedHolidayAdjustmentsToRequirements({}, [singleDayHoliday])).toEqual({});
+	});
+
+	it("expands assigned holiday ranges into UTC date keys", () => {
+		expect(
+			getAssignedHolidayDateKeys([
+				{
+					id: "holiday-3",
+					name: "Two Day Holiday",
+					startDate: new Date("2026-12-24T00:00:00.000Z"),
+					endDate: new Date("2026-12-25T23:59:59.999Z"),
+				},
+			]),
+		).toEqual(new Set(["2026-12-24", "2026-12-25"]));
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/calendar/assigned-holidays.test.ts`
+
+Expected: FAIL because `./assigned-holidays` does not exist.
+
+- [ ] **Step 3: Create the service with pure helpers and DB resolver**
+
+Create `apps/webapp/src/lib/calendar/assigned-holidays.ts` with:
+
+```ts
+import { and, eq, gte, isNull, lte, or } from "drizzle-orm";
+import { DateTime } from "luxon";
+import { db } from "@/db";
+import {
+	employee,
+	holidayAssignment,
+	holidayPresetAssignment,
+	type holiday,
+	type holidayPreset,
+	type holidayPresetHoliday,
+} from "@/db/schema";
+import type { DailyWorkRequirements, HolidayEvent } from "./types";
+
+export interface AssignedHolidayRange {
+	id: string;
+	name: string;
+	startDate: Date;
+	endDate: Date;
+	categoryId?: string | null;
+	color?: string | null;
+	description?: string | null;
+	metadata?: HolidayEvent["metadata"];
+}
+
+type HolidayAssignmentWithHoliday = {
+	holiday: Pick<
+		typeof holiday.$inferSelect,
+		"id" | "name" | "organizationId" | "startDate" | "endDate" | "categoryId" | "isActive" | "description"
+	> | null;
+};
+
+type HolidayPresetAssignmentWithPreset = Pick<typeof holidayPresetAssignment.$inferSelect, "assignmentType"> & {
+	preset:
+		| (Pick<typeof holidayPreset.$inferSelect, "id" | "name" | "organizationId" | "isActive" | "color"> & {
+				holidays: (typeof holidayPresetHoliday.$inferSelect)[];
+		  })
+		| null;
+};
+
+function dateKey(date: DateTime): string | null {
+	return date.isValid ? date.toISODate() : null;
+}
+
+function expandPresetHoliday(input: {
+	presetId: string;
+	presetName: string;
+	presetColor: string | null;
+	presetSource: string;
+	holiday: typeof holidayPresetHoliday.$inferSelect;
+	year: number;
+}): AssignedHolidayRange[] {
+	const start = DateTime.utc(input.year, input.holiday.month, input.holiday.day).startOf("day");
+	if (!start.isValid) return [];
+
+	const durationDays = Math.max(input.holiday.durationDays || 1, 1);
+	const end = start.plus({ days: durationDays - 1 }).endOf("day");
+
+	return [
+		{
+			id: `preset-${input.presetId}-${input.holiday.id}-${input.year}`,
+			name: input.holiday.name,
+			startDate: start.toJSDate(),
+			endDate: end.toJSDate(),
+			categoryId: input.holiday.categoryId,
+			color: input.presetColor,
+			description: input.holiday.description,
+			metadata: {
+				categoryName: "Holiday",
+				categoryType: input.holiday.holidayType || "public_holiday",
+				blocksTimeEntry: true,
+				isRecurring: true,
+				presetId: input.presetId,
+				presetName: input.presetName,
+				presetSource: input.presetSource,
+			},
+		},
+	];
+}
+
+export function getAssignedHolidayDateKeys(holidays: AssignedHolidayRange[]): Set<string> {
+	const keys = new Set<string>();
+
+	for (const holiday of holidays) {
+		let cursor = DateTime.fromJSDate(holiday.startDate, { zone: "utc" }).startOf("day");
+		const end = DateTime.fromJSDate(holiday.endDate, { zone: "utc" }).startOf("day");
+		if (!cursor.isValid || !end.isValid || end < cursor) continue;
+
+		while (cursor <= end) {
+			const key = dateKey(cursor);
+			if (key) keys.add(key);
+			cursor = cursor.plus({ days: 1 });
+		}
+	}
+
+	return keys;
+}
+
+export function applyAssignedHolidayAdjustmentsToRequirements(
+	requirements: DailyWorkRequirements,
+	holidays: AssignedHolidayRange[],
+): DailyWorkRequirements {
+	const holidayDateKeys = getAssignedHolidayDateKeys(holidays);
+	const adjusted: DailyWorkRequirements = {};
+
+	for (const [key, requirement] of Object.entries(requirements)) {
+		adjusted[key] = holidayDateKeys.has(key)
+			? { ...requirement, requiredMinutes: 0 }
+			: { ...requirement };
+	}
+
+	return adjusted;
+}
+
+export function assignedHolidayToCalendarEvent(holiday: AssignedHolidayRange): HolidayEvent {
+	return {
+		id: holiday.id,
+		type: "holiday",
+		date: holiday.startDate,
+		endDate: holiday.endDate,
+		title: holiday.name,
+		description: holiday.description || undefined,
+		color: holiday.color || "#f59e0b",
+		metadata: holiday.metadata ?? {
+			categoryName: "Holiday",
+			categoryType: "public_holiday",
+			blocksTimeEntry: true,
+			isRecurring: false,
+		},
+	};
+}
+
+export async function getAssignedHolidaysForEmployee(input: {
+	organizationId: string;
+	employeeId: string;
+	startDate: Date;
+	endDate: Date;
+}): Promise<AssignedHolidayRange[]> {
+	const emp = await db.query.employee.findFirst({
+		where: and(eq(employee.id, input.employeeId), eq(employee.organizationId, input.organizationId)),
+		columns: { id: true, organizationId: true, teamId: true },
+	});
+
+	if (!emp) return [];
+
+	const customAssignmentScope = [eq(holidayAssignment.assignmentType, "organization")];
+	if (emp.teamId) customAssignmentScope.push(eq(holidayAssignment.teamId, emp.teamId));
+	customAssignmentScope.push(eq(holidayAssignment.employeeId, input.employeeId));
+
+	const presetAssignmentScope = [eq(holidayPresetAssignment.assignmentType, "organization")];
+	if (emp.teamId) presetAssignmentScope.push(eq(holidayPresetAssignment.teamId, emp.teamId));
+	presetAssignmentScope.push(eq(holidayPresetAssignment.employeeId, input.employeeId));
+
+	const [customAssignments, presetAssignments] = await Promise.all([
+		db.query.holidayAssignment.findMany({
+			where: and(
+				eq(holidayAssignment.organizationId, input.organizationId),
+				eq(holidayAssignment.isActive, true),
+				or(...customAssignmentScope),
+			),
+			with: { holiday: true },
+		}),
+		db.query.holidayPresetAssignment.findMany({
+			where: and(
+				eq(holidayPresetAssignment.organizationId, input.organizationId),
+				eq(holidayPresetAssignment.isActive, true),
+				or(...presetAssignmentScope),
+				or(isNull(holidayPresetAssignment.effectiveFrom), lte(holidayPresetAssignment.effectiveFrom, input.endDate)),
+				or(isNull(holidayPresetAssignment.effectiveUntil), gte(holidayPresetAssignment.effectiveUntil, input.startDate)),
+			),
+			with: { preset: { with: { holidays: true } } },
+		}),
+	]);
+
+	const holidaysById = new Map<string, AssignedHolidayRange>();
+	const typedCustomAssignments = customAssignments as unknown as HolidayAssignmentWithHoliday[];
+	const typedPresetAssignments = presetAssignments as unknown as HolidayPresetAssignmentWithPreset[];
+
+	for (const assignment of typedCustomAssignments) {
+		const assignedHoliday = assignment.holiday;
+		if (
+			!assignedHoliday?.isActive ||
+			assignedHoliday.organizationId !== input.organizationId ||
+			assignedHoliday.startDate > input.endDate ||
+			assignedHoliday.endDate < input.startDate
+		) {
+			continue;
+		}
+
+		holidaysById.set(`custom-${assignedHoliday.id}`, {
+			id: assignedHoliday.id,
+			name: assignedHoliday.name,
+			startDate: assignedHoliday.startDate,
+			endDate: assignedHoliday.endDate,
+			categoryId: assignedHoliday.categoryId,
+			description: assignedHoliday.description,
+		});
+	}
+
+	const startYear = DateTime.fromJSDate(input.startDate, { zone: "utc" }).year;
+	const endYear = DateTime.fromJSDate(input.endDate, { zone: "utc" }).year;
+	for (const assignment of typedPresetAssignments) {
+		if (!assignment.preset?.isActive || assignment.preset.organizationId !== input.organizationId) continue;
+
+		for (let year = startYear; year <= endYear; year++) {
+			for (const presetHoliday of assignment.preset.holidays) {
+				if (!presetHoliday.isActive) continue;
+				for (const expandedHoliday of expandPresetHoliday({
+					presetId: assignment.preset.id,
+					presetName: assignment.preset.name,
+					presetColor: assignment.preset.color,
+					presetSource: assignment.assignmentType,
+					holiday: presetHoliday,
+					year,
+				})) {
+					if (expandedHoliday.startDate > input.endDate || expandedHoliday.endDate < input.startDate) continue;
+					holidaysById.set(expandedHoliday.id, expandedHoliday);
+				}
+			}
+		}
+	}
+
+	return [...holidaysById.values()].sort(
+		(left, right) => left.startDate.getTime() - right.startDate.getTime(),
+	);
+}
+```
+
+- [ ] **Step 4: Run helper tests to verify they pass**
+
+Run: `pnpm --filter webapp test -- src/lib/calendar/assigned-holidays.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit shared service**
+
+Run:
+
+```bash
+git add apps/webapp/src/lib/calendar/assigned-holidays.ts apps/webapp/src/lib/calendar/assigned-holidays.test.ts
+git commit -m "feat: add assigned holiday calendar service"
+```
+
+Expected: commit succeeds with only the two assigned-holiday files staged.
+
+## Task 2: Calendar API Uses Employee-Assigned Holidays
+
+**Files:**
+- Modify: `apps/webapp/src/app/api/calendar/events/route.ts`
+- Modify: `apps/webapp/src/app/api/calendar/events/route.test.ts`
+
+- [ ] **Step 1: Add failing route test mocks and assertions**
+
+In `apps/webapp/src/app/api/calendar/events/route.test.ts`, add `getAssignedHolidaysForEmployee` and `assignedHolidayToCalendarEvent` to `mockState`:
+
+```ts
+getAssignedHolidaysForEmployee: vi.fn(async () => []),
+assignedHolidayToCalendarEvent: vi.fn((holiday: { id: string; name: string; startDate: Date; endDate: Date }) => ({
+	id: holiday.id,
+	type: "holiday" as const,
+	date: holiday.startDate,
+	endDate: holiday.endDate,
+	title: holiday.name,
+	color: "#f59e0b",
+	metadata: {
+		categoryName: "Holiday",
+		categoryType: "public_holiday",
+		blocksTimeEntry: true,
+		isRecurring: false,
+	},
+})),
+```
+
+Add this mock below the existing holiday-service mock:
+
+```ts
+vi.mock("@/lib/calendar/assigned-holidays", () => ({
+	getAssignedHolidaysForEmployee: mockState.getAssignedHolidaysForEmployee,
+	assignedHolidayToCalendarEvent: mockState.assignedHolidayToCalendarEvent,
+}));
+```
+
+Add this test before the unauthorized requested employee test:
+
+```ts
+it("returns employee-assigned holidays for a scoped employee calendar", async () => {
+	mockState.getAssignedHolidaysForEmployee.mockResolvedValueOnce([
+		{
+			id: "holiday-1",
+			name: "Labor Day",
+			startDate: new Date("2026-05-01T00:00:00.000Z"),
+			endDate: new Date("2026-05-01T23:59:59.999Z"),
+		},
+	]);
+
+	const response = await GET(
+		createRequest(
+			"https://app.example.com/api/calendar/events?organizationId=org-1&year=2026&month=4&showHolidays=true&showWorkPeriods=true",
+		),
+	);
+	const body = getResponsePayload(await response.json());
+
+	expect(response.status).toBe(200);
+	expect(mockState.getAssignedHolidaysForEmployee).toHaveBeenCalledWith({
+		organizationId: "org-1",
+		employeeId: "employee-1",
+		startDate: new Date("2026-05-01T00:00:00.000Z"),
+		endDate: new Date("2026-05-31T23:59:59.999Z"),
+	});
+	expect(mockState.getHolidaysForMonth).not.toHaveBeenCalled();
+	expect(body.events).toEqual([
+		expect.objectContaining({ id: "holiday-1", type: "holiday", title: "Labor Day" }),
+	]);
+});
+```
+
+Extend the unauthorized test with:
+
+```ts
+expect(mockState.getAssignedHolidaysForEmployee).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 2: Run route test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/app/api/calendar/events/route.test.ts`
+
+Expected: FAIL because the route still calls `getHolidaysForMonth` for scoped employees.
+
+- [ ] **Step 3: Modify route holiday loading**
+
+In `apps/webapp/src/app/api/calendar/events/route.ts`, add this import:
+
+```ts
+import {
+	assignedHolidayToCalendarEvent,
+	getAssignedHolidaysForEmployee,
+} from "@/lib/calendar/assigned-holidays";
+```
+
+Add this helper near `fetchMonthEvents`:
+
+```ts
+async function fetchHolidayEvents(params: {
+	organizationId: string;
+	employeeId: string | undefined;
+	month: number;
+	year: number;
+	showHolidays: boolean;
+}): Promise<CalendarEvent[]> {
+	if (!params.showHolidays) return [];
+
+	if (!params.employeeId) {
+		return getHolidaysForMonth(params.organizationId, params.month, params.year);
+	}
+
+	const start = DateTime.utc(params.year, params.month + 1, 1).startOf("day");
+	const end = start.endOf("month");
+	try {
+		const assignedHolidays = await getAssignedHolidaysForEmployee({
+			organizationId: params.organizationId,
+			employeeId: params.employeeId,
+			startDate: start.toJSDate(),
+			endDate: end.toJSDate(),
+		});
+		return assignedHolidays.map(assignedHolidayToCalendarEvent);
+	} catch (error) {
+		console.error("Error fetching assigned calendar holidays:", error);
+		return [];
+	}
+}
+```
+
+Replace the `holidays` entry inside `fetchMonthEvents` with:
+
+```ts
+fetchHolidayEvents({ organizationId, employeeId, month, year, showHolidays }),
+```
+
+- [ ] **Step 4: Run route test to verify it passes**
+
+Run: `pnpm --filter webapp test -- src/app/api/calendar/events/route.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit calendar API integration**
+
+Run:
+
+```bash
+git add apps/webapp/src/app/api/calendar/events/route.ts apps/webapp/src/app/api/calendar/events/route.test.ts
+git commit -m "feat: show assigned holidays on calendar"
+```
+
+Expected: commit succeeds with only route files staged.
+
+## Task 3: Work Requirements Zero Assigned Holidays
+
+**Files:**
+- Modify: `apps/webapp/src/lib/calendar/work-policy-requirements.ts`
+- Modify: `apps/webapp/src/lib/calendar/work-policy-requirements.test.ts`
+
+- [ ] **Step 1: Add failing source-level requirement test**
+
+In `apps/webapp/src/lib/calendar/work-policy-requirements.test.ts`, add these expectations to the existing `describe("getDailyWorkRequirementsForEmployee", ...)` block:
+
+```ts
+it("applies assigned holiday adjustments after absence adjustments", () => {
+	expect(source).toContain("getAssignedHolidaysForEmployee");
+	expect(source).toContain("applyAssignedHolidayAdjustmentsToRequirements");
+	expect(source).toContain("const absenceAdjustedRequirements = applyApprovedAbsencesToDailyRequirements");
+	expect(source).toContain("return applyAssignedHolidayAdjustmentsToRequirements(absenceAdjustedRequirements, assignedHolidays)");
+});
+```
+
+- [ ] **Step 2: Run requirement test to verify it fails**
+
+Run: `pnpm --filter webapp test -- src/lib/calendar/work-policy-requirements.test.ts`
+
+Expected: FAIL because `work-policy-requirements.ts` has no assigned holiday imports or adjustment call.
+
+- [ ] **Step 3: Add holiday adjustment to requirement calculation**
+
+In `apps/webapp/src/lib/calendar/work-policy-requirements.ts`, add this import:
+
+```ts
+import {
+	applyAssignedHolidayAdjustmentsToRequirements,
+	getAssignedHolidaysForEmployee,
+} from "./assigned-holidays";
+```
+
+Replace the final return in `getDailyWorkRequirementsForEmployee` with this block:
+
+```ts
+const absenceAdjustedRequirements = applyApprovedAbsencesToDailyRequirements(
+	requirements,
+	approvedAbsences,
+);
+const assignedHolidays = yield* _(
+	Effect.promise(() =>
+		getAssignedHolidaysForEmployee({
+			organizationId: params.organizationId,
+			employeeId: params.employeeId,
+			startDate: effectiveStartDate,
+			endDate: params.endDate,
+		}),
+	),
+);
+
+return applyAssignedHolidayAdjustmentsToRequirements(absenceAdjustedRequirements, assignedHolidays);
+```
+
+- [ ] **Step 4: Run requirement and helper tests**
+
+Run: `pnpm --filter webapp test -- src/lib/calendar/work-policy-requirements.test.ts src/lib/calendar/assigned-holidays.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit requirement integration**
+
+Run:
+
+```bash
+git add apps/webapp/src/lib/calendar/work-policy-requirements.ts apps/webapp/src/lib/calendar/work-policy-requirements.test.ts
+git commit -m "feat: zero work targets on assigned holidays"
+```
+
+Expected: commit succeeds with only requirement files staged.
+
+## Task 4: Final Verification
+
+**Files:**
+- Verify only; no planned edits.
+
+- [ ] **Step 1: Run targeted test suite**
+
+Run:
+
+```bash
+pnpm --filter webapp test -- src/lib/calendar/assigned-holidays.test.ts src/lib/calendar/work-policy-requirements.test.ts src/app/api/calendar/events/route.test.ts src/lib/work-balance/service.test.ts
+```
+
+Expected: PASS. This verifies the new helper, requirement integration, route behavior, and the worker-facing balance aggregation tests.
+
+- [ ] **Step 2: Inspect changed files**
+
+Run: `git status --short`
+
+Expected: clean working tree if each task committed, or only intentional uncommitted files if execution skipped commits.
+
+- [ ] **Step 3: Inspect recent commits**
+
+Run: `git log --oneline -5`
+
+Expected: recent commits include the design spec commit and the three feature commits from Tasks 1 through 3.
+
+- [ ] **Step 4: Report verification outcome**
+
+Final response should state:
+
+```text
+Implemented employee-assigned calendar holidays and holiday-zeroed work targets. Targeted tests passed: assigned-holidays, work-policy-requirements, calendar events route, and work-balance service.
+```
+
+If any targeted command fails because of unrelated existing issues, include the failing command, the relevant error summary, and which narrower checks passed.

--- a/docs/superpowers/specs/2026-05-23-calendar-assigned-holidays-work-targets-design.md
+++ b/docs/superpowers/specs/2026-05-23-calendar-assigned-holidays-work-targets-design.md
@@ -1,0 +1,102 @@
+# Calendar Assigned Holidays Work Targets Design
+
+## Purpose
+
+Show employee-assigned holidays on `/calendar` and make those holidays reduce required work hours to `0`, matching the existing absence-adjusted work target behavior.
+
+This must affect both visible calendar summaries and the materialized employee work-balance worker. The worker already computes required minutes through `getDailyWorkRequirementsForEmployee`, so holiday adjustment should be centralized there rather than duplicated in worker code.
+
+## Current Context
+
+`/calendar` fetches event data through `/api/calendar/events`. The route currently loads holidays with `getHolidaysForMonth(organizationId, month, year)`, which returns organization-wide holidays and does not account for the selected employee's holiday assignments.
+
+`/absences` already has employee-scoped holiday lookup logic in `apps/webapp/src/app/[locale]/(app)/absences/queries.ts`. It includes active custom holiday assignments and active holiday preset assignments that apply by organization, team, or direct employee assignment.
+
+`getDailyWorkRequirementsForEmployee` builds policy-derived requirements and applies approved absence reductions. The work-balance worker calls this same function, so adding holiday adjustment there updates both live calendar ranges and materialized balances.
+
+## Approved Approach
+
+Create a shared employee-scoped holiday resolver under `apps/webapp/src/lib/calendar` and use it from both calendar event loading and work requirement calculation.
+
+The resolver should include assigned holidays from these scopes:
+
+- Organization-wide assignments.
+- Assignments for the employee's current team.
+- Direct employee assignments.
+
+It should support both holiday sources:
+
+- Custom holidays from `holidayAssignment` joined to `holiday`.
+- Preset holidays from `holidayPresetAssignment` joined to `holidayPreset` and `holidayPresetHoliday`.
+
+Every assigned holiday should set that date's required minutes to `0`, regardless of the holiday category's `excludeFromCalculations` value.
+
+## Calendar Behavior
+
+When `/api/calendar/events` is scoped to a single authorized employee and `showHolidays=true`, it should return that employee's assigned holiday events for the requested month or year range.
+
+If no single employee is scoped, holiday display can keep the existing organization-wide behavior. Requirement calculation already returns no employee-specific requirements without a scoped employee, so there is no target adjustment in that case.
+
+Holiday events should preserve existing `CalendarEvent` shape with `type: "holiday"`, `date`, optional `endDate`, `title`, `color`, and metadata. Preset holiday metadata should include preset information where available, matching the existing calendar holiday event conventions.
+
+## Requirement Calculation
+
+`getDailyWorkRequirementsForEmployee` should keep its current flow:
+
+- Verify the employee belongs to the organization.
+- Clamp the range to the employee start date.
+- Build policy-derived daily requirements.
+- Apply approved absence reductions.
+
+After absence reductions, fetch assigned holidays for the same employee, organization, and date range. For each holiday date that overlaps a requirement date, set `requiredMinutes` to `0` while preserving `policyId` and `policyName`.
+
+Multi-day custom holidays and preset holidays with `durationDays` should zero every overlapping date in the requested range. Holidays on non-required days do not need to create requirement entries.
+
+## Data And Assignment Rules
+
+All holiday queries must be organization-scoped.
+
+Custom holiday assignments should include only active assignments whose target scope applies to the employee. The joined holiday must also be active and belong to the same organization.
+
+Preset assignments should include only active assignments whose target scope applies to the employee and whose `effectiveFrom`/`effectiveUntil` window overlaps the requested range. The joined preset must be active and belong to the same organization.
+
+Duplicate holidays from multiple assignment scopes should be deduplicated by date and source id. For requirement adjustment, only the date set matters.
+
+## Error Handling
+
+Calendar event loading should continue to work if employee-assigned holiday loading fails. In that case, log the server-side error and fall back to an empty holiday list for the employee-scoped holiday portion.
+
+Requirement calculation should keep the existing resilience pattern used for absences and policy requirements. If holiday adjustment fails inside the calendar API, the API should still return events and an empty or partially adjusted `dailyRequirements` object according to the existing outer fallback behavior.
+
+The work-balance worker should not add separate holiday-specific error handling. If requirement calculation fails for an employee, the existing per-employee worker failure handling records the error and continues with the next employee.
+
+## Security And Multi-Tenancy
+
+The calendar route must continue using `resolveAuthorizedCalendarEmployeeId` before loading employee-scoped holidays. Managers and admins only see assigned holidays for employees they are authorized to read.
+
+Every holiday query must filter by `organizationId`. Employee, team, preset, and custom holiday records must not leak across organizations.
+
+No tenant-specific holiday behavior should come from environment variables.
+
+## Testing
+
+Add tests for the shared holiday adjustment logic:
+
+- A single-day assigned holiday sets that date's required minutes to `0`.
+- A multi-day assigned holiday zeros every overlapping required date.
+- Holidays on dates without policy requirements do not create new requirement entries.
+
+Add or update calendar route tests:
+
+- Employee-scoped `showHolidays=true` calls the employee-assigned holiday resolver with the authorized employee and requested range.
+- Unauthorized requested employees still return `403` before holiday lookup.
+
+Add or update requirement tests:
+
+- `getDailyWorkRequirementsForEmployee` keeps absence reduction behavior and applies holiday zeroing after it.
+
+Run targeted webapp tests for the edited modules. If broader checks are blocked by unrelated existing issues, report that separately.
+
+## Out Of Scope
+
+This design does not change holiday management UI, holiday category semantics, time-entry blocking rules, overtime approval, payroll export behavior, or how non-employee-scoped organization holiday calendars behave.


### PR DESCRIPTION
## Changelog
- Added employee-assigned holiday resolution for calendar event loading, including custom and preset assignments.
- Zeroed daily work targets on assigned holiday dates so work-balance calculations respect holiday assignments.
- Preserved organization-wide holiday fallback behavior and added coverage for recurring and multi-day holidays.
- Added implementation planning docs for the assigned-holiday work target flow.

## Test Plan
- [x] pnpm test

## Merge Notes
- Source branch: dev
- Target branch: main