### PR TITLE
Redis by One Name: managed cache env cleanup

### DIFF
--- a/apps/webapp/src/env.test.ts
+++ b/apps/webapp/src/env.test.ts
@@ -62,4 +62,18 @@ describe("env", () => {
 		expect(env.SCALEWAY_REGION).toBe("fr-par");
 		expect(env.SCALEWAY_KEY_MANAGER_API_URL).toBe("https://api.scaleway.com");
 	});
+
+	test("accepts managed Redis TLS configuration", async () => {
+		const { env } = await importEnv({
+			REDIS_HOST: "managed-redis.example.com",
+			REDIS_PORT: "6380",
+			REDIS_PASSWORD: "redis-password",
+			REDIS_TLS: "true",
+		});
+
+		expect(env.REDIS_HOST).toBe("managed-redis.example.com");
+		expect(env.REDIS_PORT).toBe("6380");
+		expect(env.REDIS_PASSWORD).toBe("redis-password");
+		expect(env.REDIS_TLS).toBe("true");
+	});
 });

--- a/apps/webapp/src/env.ts
+++ b/apps/webapp/src/env.ts
@@ -28,13 +28,11 @@ const parsedEnv = createEnv({
 		POSTGRES_SSL_CA_CERT: z.string().optional(),
 		POSTGRES_SSL_ROOT_CERT_PATH: z.string().optional(),
 
-		// Valkey / Redis
-		VALKEY_HOST: z.string().optional(),
-		VALKEY_PORT: z.string().optional(),
-		VALKEY_PASSWORD: z.string().optional(),
+		// Redis-compatible cache and queue backend
 		REDIS_HOST: z.string().optional(),
 		REDIS_PORT: z.string().optional(),
 		REDIS_PASSWORD: z.string().optional(),
+		REDIS_TLS: z.enum(["true", "false"]).default("false"),
 
 		// Public AWS S3 / Object Storage (REQUIRED)
 		// S3-compatible storage is required for public file uploads
@@ -155,12 +153,10 @@ const parsedEnv = createEnv({
 		BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
 		BETTER_AUTH_SECRETS: process.env.BETTER_AUTH_SECRETS,
 		SECRET_STORE_PROVIDER: process.env.SECRET_STORE_PROVIDER ?? "vault",
-		VALKEY_HOST: process.env.VALKEY_HOST,
-		VALKEY_PORT: process.env.VALKEY_PORT,
-		VALKEY_PASSWORD: process.env.VALKEY_PASSWORD,
 		REDIS_HOST: process.env.REDIS_HOST,
 		REDIS_PORT: process.env.REDIS_PORT,
 		REDIS_PASSWORD: process.env.REDIS_PASSWORD,
+		REDIS_TLS: process.env.REDIS_TLS ?? "false",
 
 		S3_PUBLIC_BUCKET: process.env.S3_PUBLIC_BUCKET,
 		S3_PUBLIC_ACCESS_KEY_ID: process.env.S3_PUBLIC_ACCESS_KEY_ID,

--- a/apps/webapp/src/lib/health.ts
+++ b/apps/webapp/src/lib/health.ts
@@ -174,7 +174,7 @@ export async function runStartupChecks(): Promise<boolean> {
 			buildHash: env.NEXT_PUBLIC_BUILD_HASH ?? "unknown",
 			appUrlConfigured: Boolean(env.APP_URL || env.NEXT_PUBLIC_APP_URL),
 			mainDomainConfigured: Boolean(env.MAIN_DOMAIN),
-			valkeyConfigured: Boolean(env.VALKEY_HOST || env.REDIS_HOST),
+			redisConfigured: Boolean(env.REDIS_HOST),
 			turnstileConfigured: Boolean(env.TURNSTILE_SITE_KEY),
 			billingEnabled: env.BILLING_ENABLED === "true",
 		},

--- a/apps/webapp/src/lib/queue/index.ts
+++ b/apps/webapp/src/lib/queue/index.ts
@@ -21,9 +21,10 @@ const logger = createLogger("JobQueue");
 
 // Connection configuration for Valkey/Redis
 const connection: ConnectionOptions = {
-	host: env.VALKEY_HOST || env.REDIS_HOST || "localhost",
-	port: Number(env.VALKEY_PORT || env.REDIS_PORT || 6379),
-	password: env.VALKEY_PASSWORD || env.REDIS_PASSWORD || undefined,
+	host: env.REDIS_HOST || "localhost",
+	port: Number(env.REDIS_PORT || 6379),
+	password: env.REDIS_PASSWORD || undefined,
+	tls: env.REDIS_TLS === "true" ? {} : undefined,
 	maxRetriesPerRequest: null, // Required for BullMQ
 };
 

--- a/apps/webapp/src/lib/valkey.ts
+++ b/apps/webapp/src/lib/valkey.ts
@@ -3,7 +3,7 @@ import { createLogger } from "@/lib/logger";
 import { env } from "@/env";
 
 const logger = createLogger("Valkey");
-const hasValkeyConfig = Boolean(env.VALKEY_HOST || env.REDIS_HOST);
+const hasValkeyConfig = Boolean(env.REDIS_HOST);
 const shouldDisableValkeyDuringBuild =
 	(!hasValkeyConfig && env.NODE_ENV === "production") ||
 	process.env.NEXT_PHASE === "phase-production-build" ||
@@ -41,14 +41,15 @@ function isAlreadyConnectingError(error: unknown): boolean {
 }
 
 function createValkeyClient(): Redis {
-	const host = env.VALKEY_HOST || env.REDIS_HOST || "localhost";
-	const port = Number(env.VALKEY_PORT || env.REDIS_PORT || 6379);
-	const password = env.VALKEY_PASSWORD || env.REDIS_PASSWORD;
+	const host = env.REDIS_HOST || "localhost";
+	const port = Number(env.REDIS_PORT || 6379);
+	const password = env.REDIS_PASSWORD;
 
 	const client = new Redis({
 		host,
 		port,
 		password: password || undefined,
+		tls: env.REDIS_TLS === "true" ? {} : undefined,
 		maxRetriesPerRequest: 20,
 		retryStrategy(times) {
 			// Exponential backoff: 50ms, 100ms, 200ms... capped at 2s

--- a/apps/webapp/src/worker.ts
+++ b/apps/webapp/src/worker.ts
@@ -12,9 +12,10 @@
  * - Health checks via Valkey connection
  *
  * Environment variables:
- * - VALKEY_HOST: Redis/Valkey host (default: localhost)
- * - VALKEY_PORT: Redis/Valkey port (default: 6379)
- * - VALKEY_PASSWORD: Redis/Valkey password (optional)
+ * - REDIS_HOST: Redis-compatible host (default: localhost)
+ * - REDIS_PORT: Redis-compatible port (default: 6379)
+ * - REDIS_PASSWORD: Redis-compatible password (optional)
+ * - REDIS_TLS: Enable TLS for managed Redis providers (default: false)
  * - WORKER_CONCURRENCY: Number of concurrent jobs (default: 5)
  * - ENABLE_CRON_JOBS: Enable repeatable cron jobs (default: true)
  */
@@ -299,8 +300,9 @@ async function main(): Promise<void> {
 	logger.info(
 		{
 			concurrency,
-			valkeyHost: env.VALKEY_HOST || "localhost",
-			valkeyPort: env.VALKEY_PORT || 6379,
+			redisHost: env.REDIS_HOST || "localhost",
+			redisPort: env.REDIS_PORT || 6379,
+			redisTls: env.REDIS_TLS === "true",
 			nodeEnv: env.NODE_ENV,
 		},
 		"Starting worker process",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -281,7 +281,10 @@ See `deploy/.env.template` for the full list. Key variables:
 | `POSTGRES_SSL_CA_CERT` | No | Inline CA certificate content when mounting a file is not practical |
 | `BETTER_AUTH_SECRET` | Yes | Session encryption key |
 | `NEXT_PUBLIC_APP_URL` | Yes | Public URL of the application |
-| `VALKEY_HOST` | No | Cache host (default: localhost) |
+| `REDIS_HOST` | No | Redis-compatible cache host (default: localhost) |
+| `REDIS_PORT` | No | Redis-compatible cache port (default: 6379) |
+| `REDIS_PASSWORD` | No | Redis-compatible cache password |
+| `REDIS_TLS` | No | Enable TLS for managed Redis providers (`true` or `false`, default: `false`) |
 | `WORKER_CONCURRENCY` | No | Worker parallel jobs (default: 5) |
 | `ENABLE_CRON_JOBS` | No | Enable repeatable cron (default: true) |
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       --loglevel warning
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru
-      ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}
+      ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}
     volumes:
       - valkey_data:/data
     ports:
@@ -122,8 +122,8 @@ services:
     environment:
       REDIS_HOST: valkey
       REDIS_PORT: 6379
-      REDIS_PASSWORD: ${VALKEY_PASSWORD:-}
-      REDIS_USE_TLS: "false"
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_USE_TLS: ${REDIS_TLS:-false}
       BULL_PREFIX: bull
       USER_LOGIN: ${BULL_BOARD_USER:-admin}
       USER_PASSWORD: ${BULL_BOARD_PASSWORD:?BULL_BOARD_PASSWORD is required}
@@ -233,9 +233,10 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-z8}
       POSTGRES_USER: ${POSTGRES_USER:-z8}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
-      VALKEY_HOST: valkey
-      VALKEY_PORT: 6379
-      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-}
+      REDIS_HOST: ${REDIS_HOST:-valkey}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_TLS: ${REDIS_TLS:-false}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:?BETTER_AUTH_URL is required}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:?NEXT_PUBLIC_APP_URL is required}
@@ -325,9 +326,10 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-z8}
       POSTGRES_USER: ${POSTGRES_USER:-z8}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
-      VALKEY_HOST: valkey
-      VALKEY_PORT: 6379
-      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-}
+      REDIS_HOST: ${REDIS_HOST:-valkey}
+      REDIS_PORT: ${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_TLS: ${REDIS_TLS:-false}
       WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-5}
       ENABLE_CRON_JOBS: ${ENABLE_CRON_JOBS:-true}
       NODE_ENV: production

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -16,8 +16,9 @@ data:
   postgres-db: "z8"
 
   # Cache
-  valkey-host: "z8-valkey"
-  valkey-port: "6379"
+  redis-host: "z8-valkey"
+  redis-port: "6379"
+  redis-tls: "false"
 
   # Worker configuration
   worker-concurrency: "5"

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -10,7 +10,7 @@
 #     --from-literal=postgres-password=<your-password> \
 #     --from-literal=auth-secret=<generate-with-openssl-rand-base64-32> \
 #     --from-literal=resend-api-key=<optional> \
-#     --from-literal=valkey-password=<optional>
+#     --from-literal=redis-password=<optional>
 #
 # Option 2: Use external secrets (Vault, AWS Secrets Manager, etc.)
 #
@@ -37,7 +37,7 @@ stringData:
   resend-api-key: ""
 
   # Optional: Cache password
-  valkey-password: ""
+  redis-password: ""
 
   # Optional: Cron secret for HTTP-based cron (legacy)
   cron-secret: ""

--- a/deploy/k8s/webapp.yaml
+++ b/deploy/k8s/webapp.yaml
@@ -70,21 +70,27 @@ spec:
                   name: z8-secrets
                   key: postgres-password
             # Cache
-            - name: VALKEY_HOST
+            - name: REDIS_HOST
               valueFrom:
                 configMapKeyRef:
                   name: z8-config
-                  key: valkey-host
-            - name: VALKEY_PORT
+                  key: redis-host
+            - name: REDIS_PORT
               valueFrom:
                 configMapKeyRef:
                   name: z8-config
-                  key: valkey-port
-            - name: VALKEY_PASSWORD
+                  key: redis-port
+            - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: z8-secrets
-                  key: valkey-password
+                  key: redis-password
+                  optional: true
+            - name: REDIS_TLS
+              valueFrom:
+                configMapKeyRef:
+                  name: z8-config
+                  key: redis-tls
                   optional: true
             # Auth
             - name: BETTER_AUTH_SECRET

--- a/deploy/k8s/worker.yaml
+++ b/deploy/k8s/worker.yaml
@@ -68,21 +68,27 @@ spec:
                   name: z8-secrets
                   key: postgres-password
             # Cache/Queue
-            - name: VALKEY_HOST
+            - name: REDIS_HOST
               valueFrom:
                 configMapKeyRef:
                   name: z8-config
-                  key: valkey-host
-            - name: VALKEY_PORT
+                  key: redis-host
+            - name: REDIS_PORT
               valueFrom:
                 configMapKeyRef:
                   name: z8-config
-                  key: valkey-port
-            - name: VALKEY_PASSWORD
+                  key: redis-port
+            - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: z8-secrets
-                  key: valkey-password
+                  key: redis-password
+                  optional: true
+            - name: REDIS_TLS
+              valueFrom:
+                configMapKeyRef:
+                  name: z8-config
+                  key: redis-tls
                   optional: true
             # Worker config
             - name: WORKER_CONCURRENCY
@@ -123,9 +129,10 @@ spec:
                 - |
                   const Redis = require('ioredis');
                   const r = new Redis({
-                    host: process.env.VALKEY_HOST,
-                    port: process.env.VALKEY_PORT,
-                    password: process.env.VALKEY_PASSWORD,
+                    host: process.env.REDIS_HOST,
+                    port: process.env.REDIS_PORT,
+                    password: process.env.REDIS_PASSWORD,
+                    tls: process.env.REDIS_TLS === 'true' ? {} : undefined,
                     lazyConnect: false
                   });
                   r.ping().then(() => process.exit(0)).catch(() => process.exit(1));

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -79,7 +79,7 @@ services:
       --loglevel warning
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru
-      ${VALKEY_PASSWORD:+--requirepass ${VALKEY_PASSWORD}}
+      ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}
     volumes:
       - valkey_data:/data
     ports:
@@ -110,8 +110,8 @@ services:
     environment:
       REDIS_HOST: valkey
       REDIS_PORT: 6379
-      REDIS_PASSWORD: ${VALKEY_PASSWORD:-}
-      REDIS_USE_TLS: "false"
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_USE_TLS: ${REDIS_TLS:-false}
       BULL_PREFIX: bull
       USER_LOGIN: ${BULL_BOARD_USER:-admin}
       USER_PASSWORD: ${BULL_BOARD_PASSWORD:-admin}

--- a/docs/superpowers/plans/2026-04-11-separate-image-dockerfiles.md
+++ b/docs/superpowers/plans/2026-04-11-separate-image-dockerfiles.md
@@ -185,7 +185,7 @@ WORKDIR /app/apps/webapp
 USER app
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["tsx", "src/worker.ts"]
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.VALKEY_HOST||'localhost',port:process.env.VALKEY_PORT||6379,password:process.env.VALKEY_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.REDIS_HOST||'localhost',port:process.env.REDIS_PORT||6379,password:process.env.REDIS_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
 ```
 
 - [ ] **Step 4: Create `Dockerfile.migration` by extracting only the migration path**

--- a/docs/superpowers/plans/2026-04-12-non-web-image-trimming.md
+++ b/docs/superpowers/plans/2026-04-12-non-web-image-trimming.md
@@ -446,7 +446,7 @@ ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["pnpm", "exec", "tsx", "src/worker.ts"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-    CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.VALKEY_HOST||'localhost',port:process.env.VALKEY_PORT||6379,password:process.env.VALKEY_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
+    CMD node -e "const Redis=require('ioredis');const r=new Redis({host:process.env.REDIS_HOST||'localhost',port:process.env.REDIS_PORT||6379,password:process.env.REDIS_PASSWORD,lazyConnect:false});r.ping().then(()=>process.exit(0)).catch(()=>process.exit(1))"
 ```
 
 - [ ] **Step 4: Build the worker image and verify the runtime no longer contains `.next`**

--- a/infra/hetzner-k8s/README.md
+++ b/infra/hetzner-k8s/README.md
@@ -85,7 +85,10 @@ These keys must exist in Phase and be synced into the `app-secrets` Kubernetes S
 - `POSTGRES_SSL_MODE` — one of `disable`, `prefer`, `require`, `verify-ca`, `verify-full`
 - `POSTGRES_SSL_ROOT_CERT_PATH` — optional path to a mounted CA file for managed Postgres TLS
 - `POSTGRES_SSL_CA_CERT` — optional inline CA certificate when mounting a file is not practical
-- `VALKEY_URL` — use the in-cluster service URL: `redis://valkey.app-prod.svc.cluster.local:6379`
+- `REDIS_HOST` — Redis-compatible cache host, use `valkey` for the in-cluster service
+- `REDIS_PORT` — Redis-compatible cache port, usually `6379`
+- `REDIS_PASSWORD` — optional Redis-compatible cache password
+- `REDIS_TLS` — set to `true` for managed Redis providers that require TLS
 
 ## Postgres VM (outside the cluster)
 

--- a/infra/hetzner-k8s/k8s/app/migration-job.yaml
+++ b/infra/hetzner-k8s/k8s/app/migration-job.yaml
@@ -17,10 +17,10 @@ spec:
           image: ghcr.io/umami-creative-gmbh/z8-migration:latest
           imagePullPolicy: Always
           env:
-            - name: VALKEY_HOST
-              value: valkey
-            - name: VALKEY_PORT
-              value: "6379"
+	            - name: REDIS_HOST
+	              value: valkey
+	            - name: REDIS_PORT
+	              value: "6379"
             - name: DB_MIGRATION_LOCK_ID
               value: "74382643"
             - name: DRIZZLE_MIGRATE_COMMAND

--- a/infra/hetzner-k8s/k8s/app/web-deployment.yaml
+++ b/infra/hetzner-k8s/k8s/app/web-deployment.yaml
@@ -28,10 +28,12 @@ spec:
           image: ghcr.io/umami-creative-gmbh/z8-webapp:latest
           imagePullPolicy: Always
           env:
-            - name: VALKEY_HOST
+            - name: REDIS_HOST
               value: valkey
-            - name: VALKEY_PORT
+            - name: REDIS_PORT
               value: "6379"
+            - name: REDIS_TLS
+              value: "false"
           ports:
             - containerPort: 3000
               name: http

--- a/infra/hetzner-k8s/k8s/app/worker-deployment.yaml
+++ b/infra/hetzner-k8s/k8s/app/worker-deployment.yaml
@@ -23,10 +23,12 @@ spec:
           workingDir: /app
           command: ["tsx", "src/worker.ts"]
           env:
-            - name: VALKEY_HOST
+            - name: REDIS_HOST
               value: valkey
-            - name: VALKEY_PORT
+            - name: REDIS_PORT
               value: "6379"
+            - name: REDIS_TLS
+              value: "false"
           envFrom:
             - secretRef:
                 name: app-secrets


### PR DESCRIPTION
## Changelog
- Unified cache and queue configuration on generic `REDIS_*` environment variables.
- Added optional `REDIS_TLS` support for managed Redis providers.
- Updated Docker Compose, Kubernetes manifests, deployment docs, and legacy plan references away from `VALKEY_*` env names.

## Verification
- `pnpm --dir apps/webapp test`
- `pnpm --dir apps/webapp exec tsc --noEmit`
- Search confirmed no remaining `VALKEY_HOST`, `VALKEY_PORT`, `VALKEY_PASSWORD`, or old k8s `valkey-*` keys in TS/YAML/MD files.