### PR TITLE
Seal the Footer Env Boundary

### DIFF
--- a/apps/webapp/src/app/[locale]/(auth)/layout.tsx
+++ b/apps/webapp/src/app/[locale]/(auth)/layout.tsx
@@ -40,6 +40,7 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
 	let domainContext: DomainAuthContext | null = null;
 	const platformDomainContext = await getPlatformDomainConfig(host ?? "");
 	const globalTurnstileSiteKey = env.TURNSTILE_SITE_KEY ?? null;
+	const buildHash = env.NEXT_PUBLIC_BUILD_HASH;
 	if (platformDomainContext) {
 		domainContext = {
 			...platformDomainContext,
@@ -119,7 +120,7 @@ export default async function AuthLayout({ children }: { children: React.ReactNo
 					</main>
 
 					<div className="pt-2">
-						<InfoFooter />
+						<InfoFooter buildHash={buildHash} />
 					</div>
 				</section>
 

--- a/apps/webapp/src/app/[locale]/onboarding/layout.tsx
+++ b/apps/webapp/src/app/[locale]/onboarding/layout.tsx
@@ -1,7 +1,10 @@
 import { InfoFooter } from "@/components/info-footer";
 import { LanguageSwitcher } from "@/components/language-switcher";
+import { env } from "@/env";
 
 export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
+	const buildHash = env.NEXT_PUBLIC_BUILD_HASH;
+
 	return (
 		<div className="flex min-h-svh flex-col bg-background">
 			<div className="container mx-auto px-6 py-8">
@@ -15,7 +18,7 @@ export default function OnboardingLayout({ children }: { children: React.ReactNo
 
 				{/* Footer */}
 				<div className="mt-12">
-					<InfoFooter />
+					<InfoFooter buildHash={buildHash} />
 				</div>
 			</div>
 		</div>

--- a/apps/webapp/src/components/info-footer.test.tsx
+++ b/apps/webapp/src/components/info-footer.test.tsx
@@ -1,0 +1,29 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({ t: (_key: string, defaultValue?: string) => defaultValue ?? _key }),
+}));
+
+vi.mock("@/navigation", () => ({
+	Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+		<a href={href}>{children}</a>
+	),
+}));
+
+vi.mock("@/env", () => {
+	throw new Error("client component imported server env");
+});
+
+describe("InfoFooter", () => {
+	test("renders without importing server environment config", async () => {
+		const { InfoFooter } = await import("./info-footer");
+
+		render(<InfoFooter buildHash="build-123" />);
+
+		expect(screen.getByText("Terms of Service")).toBeTruthy();
+		expect(screen.getByText("Version build-123")).toBeTruthy();
+	});
+});

--- a/apps/webapp/src/components/info-footer.tsx
+++ b/apps/webapp/src/components/info-footer.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useTranslate } from "@tolgee/react";
-import { env } from "@/env";
 import { Link } from "@/navigation";
 
-export function InfoFooter() {
+export function InfoFooter({ buildHash }: { buildHash?: string }) {
 	const { t } = useTranslate();
-	const buildHash = env.NEXT_PUBLIC_BUILD_HASH;
 
 	return (
 		<div className="space-y-1 text-balance text-center text-muted-foreground text-xs">


### PR DESCRIPTION
## Changelog
- Moved the footer build hash lookup out of the client component and into server layouts.
- Prevented `@/env` from entering the `InfoFooter` browser bundle.
- Added a regression test that fails if the client footer imports server environment config again.

## Verification
- `pnpm exec biome check \"src/components/info-footer.tsx\" \"src/components/info-footer.test.tsx\" \"src/app/[locale]/(auth)/layout.tsx\" \"src/app/[locale]/onboarding/layout.tsx\"`
- `pnpm test`
- `CI=true pnpm build`