### PR TITLE
Promote Dev: Organization Logo Reliability Sweep

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/settings/organizations/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/settings/organizations/actions.ts
@@ -797,6 +797,105 @@ export async function updateOrganizationDetails(
 	return runServerActionSafe(effect);
 }
 
+/**
+ * Clear organization logo
+ * Requires owner role. Does not delete the underlying storage object.
+ */
+export async function removeOrganizationLogo(
+	organizationId: string,
+): Promise<ServerActionResult<void>> {
+	const tracer = trace.getTracer("organizations");
+
+	const effect = tracer.startActiveSpan(
+		"removeOrganizationLogo",
+		{
+			attributes: {
+				"organization.id": organizationId,
+			},
+		},
+		(span) => {
+			return Effect.gen(function* (_) {
+				const authService = yield* _(AuthService);
+				const session = yield* _(authService.getSession());
+				const dbService = yield* _(DatabaseService);
+
+				const memberRecord = yield* _(
+					dbService.query("getCurrentMemberForLogoRemoval", async () => {
+						return await db.query.member.findFirst({
+							where: and(
+								eq(authSchema.member.userId, session.user.id),
+								eq(authSchema.member.organizationId, organizationId),
+							),
+						});
+					}),
+					Effect.flatMap((member) =>
+						member
+							? Effect.succeed(member)
+							: Effect.fail(
+									new NotFoundError({
+										message: "You are not a member of this organization",
+										entityType: "member",
+									}),
+								),
+					),
+				);
+
+				if (memberRecord.role !== "owner") {
+					yield* _(
+						Effect.fail(
+							new AuthorizationError({
+								message: "Only owners can update organization details",
+								userId: session.user.id,
+								resource: "organization",
+								action: "update",
+							}),
+						),
+					);
+				}
+
+				yield* _(
+					Effect.tryPromise({
+						try: async () => {
+							await auth.api.updateOrganization({
+								body: {
+									organizationId,
+									data: { logo: null },
+								},
+								headers: await headers(),
+							});
+						},
+						catch: (error) => {
+							return new ValidationError({
+								message: error instanceof Error ? error.message : "Failed to remove organization logo",
+								field: "logo",
+							});
+						},
+					}),
+				);
+
+				logger.info({ organizationId }, "Organization logo removed successfully");
+				span.setStatus({ code: SpanStatusCode.OK });
+			}).pipe(
+				Effect.catchAll((error) =>
+					Effect.gen(function* (_) {
+						span.recordException(error as Error);
+						span.setStatus({
+							code: SpanStatusCode.ERROR,
+							message: String(error),
+						});
+						logger.error({ error, organizationId }, "Failed to remove organization logo");
+						return yield* _(Effect.fail(error as AnyAppError));
+					}),
+				),
+				Effect.onExit(() => Effect.sync(() => span.end())),
+				Effect.provide(AppLayer),
+			);
+		},
+	);
+
+	return runServerActionSafe(effect);
+}
+
 // =============================================================================
 // Organization Features Actions
 // =============================================================================

--- a/apps/webapp/src/app/api/upload/process/route.test.ts
+++ b/apps/webapp/src/app/api/upload/process/route.test.ts
@@ -102,6 +102,7 @@ vi.mock("@/lib/upload/tus-ownership", () => ({
 
 vi.mock("@/lib/storage/avatar-storage", () => ({
 	createAvatarStorageKey: vi.fn(() => "avatars/user_1/avatar.webp"),
+	createOrganizationLogoStorageKey: vi.fn(() => "org-logos/org_1/logo-id.webp"),
 }));
 
 vi.mock("file-type", () => ({
@@ -153,7 +154,9 @@ describe("image upload processing", () => {
 			body: {
 				organizationId: "org_1",
 				data: {
-					logo: expect.stringMatching(/^https:\/\/cdn\.example\.com\/org-logos\/org_1-\d+\.webp$/),
+					logo: expect.stringMatching(
+						/^https:\/\/cdn\.example\.com\/org-logos\/org_1\/[A-Za-z0-9_-]+\.webp$/,
+					),
 				},
 			},
 		});

--- a/apps/webapp/src/app/api/upload/process/route.ts
+++ b/apps/webapp/src/app/api/upload/process/route.ts
@@ -6,7 +6,7 @@ import { connection, type NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import * as authSchema from "@/db/auth-schema";
 import { auth } from "@/lib/auth";
-import { createAvatarStorageKey } from "@/lib/storage/avatar-storage";
+import { createAvatarStorageKey, createOrganizationLogoStorageKey } from "@/lib/storage/avatar-storage";
 import { getPublicUrl, S3_PUBLIC_BUCKET, s3Client } from "@/lib/storage/s3-client";
 import { sanitizeTusFileKey } from "@/lib/upload/tus-ownership";
 
@@ -136,7 +136,9 @@ export async function POST(request: NextRequest) {
 		const finalKey =
 			uploadType === "avatar"
 				? createAvatarStorageKey(session.user.id)
-				: `${folderMap[uploadType] || "uploads"}/${organizationId}-${Date.now()}.webp`;
+				: uploadType === "org-logo" && organizationId
+					? createOrganizationLogoStorageKey(organizationId)
+					: `${folderMap[uploadType] || "uploads"}/${organizationId}-${Date.now()}.webp`;
 
 		// Upload optimized image to S3
 		await s3Client.send(

--- a/apps/webapp/src/components/organization-switcher.tsx
+++ b/apps/webapp/src/components/organization-switcher.tsx
@@ -8,11 +8,11 @@ import {
 	IconPlus,
 } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
-import Image from "next/image";
 import { useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { CreateOrganizationDialog } from "@/components/organization/create-organization-dialog";
+import { OrganizationLogo } from "@/components/organization/organization-logo";
 import { saveLastOrganization } from "@/lib/org-persistence";
 import {
 	DropdownMenu,
@@ -135,17 +135,12 @@ export function OrganizationSwitcher({
 								disabled={switching}
 							>
 								<div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
-									{activeOrg.logo ? (
-										<Image
-											src={activeOrg.logo}
-											alt={activeOrg.name}
-											width={32}
-											height={32}
-											className="size-8 rounded-lg object-cover"
-										/>
-									) : (
-										<IconBuilding className="size-4" />
-									)}
+									<OrganizationLogo
+										logo={activeOrg.logo}
+										name={activeOrg.name}
+										size="sm"
+										fallbackClassName="bg-transparent text-sidebar-primary-foreground"
+									/>
 								</div>
 								<div className="grid flex-1 text-left text-sm leading-tight">
 									<span className="truncate font-semibold">{activeOrg.name}</span>
@@ -181,17 +176,13 @@ export function OrganizationSwitcher({
 									disabled={switching}
 								>
 									<div className="flex size-6 items-center justify-center rounded-sm border">
-										{org.logo ? (
-											<Image
-												src={org.logo}
-												alt={org.name}
-												width={24}
-												height={24}
-												className="size-6 rounded-sm object-cover"
-											/>
-										) : (
-											<IconBuilding className="size-4" />
-										)}
+										<OrganizationLogo
+											logo={org.logo}
+											name={org.name}
+											size="xs"
+											className="rounded-sm"
+											fallbackClassName="rounded-sm bg-transparent"
+										/>
 									</div>
 									<div className="flex-1">
 										<div className="font-medium">{org.name}</div>

--- a/apps/webapp/src/components/organization/organization-details-card.test.tsx
+++ b/apps/webapp/src/components/organization/organization-details-card.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { removeOrganizationLogoMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+	removeOrganizationLogoMock: vi.fn(),
+	toastErrorMock: vi.fn(),
+	toastSuccessMock: vi.fn(),
+}));
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, defaultValue?: string) => defaultValue ?? _key,
+	}),
+}));
+
+vi.mock("sonner", () => ({
+	toast: {
+		error: toastErrorMock,
+		success: toastSuccessMock,
+	},
+}));
+
+vi.mock("@/hooks/use-image-upload", () => ({
+	useImageUpload: () => ({
+		addFile: vi.fn(),
+		isUploading: false,
+		previewUrl: null,
+		progress: 0,
+	}),
+}));
+
+vi.mock("@/app/[locale]/(app)/settings/organizations/actions", () => ({
+	removeOrganizationLogo: removeOrganizationLogoMock,
+}));
+
+vi.mock("./edit-organization-dialog", () => ({
+	EditOrganizationDialog: () => null,
+}));
+
+import { OrganizationDetailsCard } from "./organization-details-card";
+
+const organization = {
+	id: "org-1",
+	name: "Acme",
+	slug: "acme",
+	logo: "https://cdn.example.com/org-logos/org-1/logo.webp",
+	metadata: null,
+};
+
+describe("OrganizationDetailsCard", () => {
+	it("lets owners clear the organization logo without deleting storage objects", async () => {
+		removeOrganizationLogoMock.mockResolvedValue({ success: true, data: undefined });
+
+		render(
+			<OrganizationDetailsCard
+				organization={organization as never}
+				memberCount={3}
+				currentMemberRole="owner"
+			/>,
+		);
+
+		expect(screen.getByRole("img", { name: "Acme" })).toBeTruthy();
+
+		const removeButton = screen.getByRole("button", { name: "Remove organization logo" });
+		const trashIcon = removeButton.querySelector("svg");
+
+		expect(trashIcon?.getAttribute("class")).toContain("text-white");
+
+		fireEvent.click(removeButton);
+
+		await waitFor(() => {
+			expect(removeOrganizationLogoMock).toHaveBeenCalledWith("org-1");
+		});
+		await waitFor(() => {
+			expect(screen.queryByRole("img", { name: "Acme" })).toBeNull();
+		});
+		expect(toastSuccessMock).toHaveBeenCalledWith("Organization logo removed");
+	});
+});

--- a/apps/webapp/src/components/organization/organization-details-card.tsx
+++ b/apps/webapp/src/components/organization/organization-details-card.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { IconBuilding, IconCamera, IconEdit, IconLoader2, IconUsers } from "@tabler/icons-react";
+import { IconCamera, IconEdit, IconLoader2, IconTrash, IconUsers } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { removeOrganizationLogo } from "@/app/[locale]/(app)/settings/organizations/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type * as authSchema from "@/db/auth-schema";
 import { useImageUpload } from "@/hooks/use-image-upload";
 import { EditOrganizationDialog } from "./edit-organization-dialog";
+import { OrganizationLogo } from "./organization-logo";
 
 interface OrganizationDetailsCardProps {
 	organization: typeof authSchema.organization.$inferSelect;
@@ -25,6 +26,7 @@ export function OrganizationDetailsCard({
 	const { t } = useTranslate();
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [logoUrl, setLogoUrl] = useState(organization.logo);
+	const [isRemovingLogo, setIsRemovingLogo] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const canEdit = currentMemberRole === "owner";
@@ -67,6 +69,20 @@ export function OrganizationDetailsCard({
 		[addFile],
 	);
 
+	const handleRemoveLogo = useCallback(async () => {
+		setIsRemovingLogo(true);
+		const result = await removeOrganizationLogo(organization.id);
+		setIsRemovingLogo(false);
+
+		if (!result.success) {
+			toast.error(result.error || t("organization.logo-remove-failed", "Failed to remove logo"));
+			return;
+		}
+
+		setLogoUrl(null);
+		toast.success(t("organization.logo-removed", "Organization logo removed"));
+	}, [organization.id, t]);
+
 	return (
 		<>
 			<Card>
@@ -83,12 +99,7 @@ export function OrganizationDetailsCard({
 								onChange={handleFileInputChange}
 							/>
 							<div className="relative size-16 shrink-0">
-								<Avatar className="size-16">
-									<AvatarImage src={previewUrl || logoUrl || undefined} alt={organization.name} />
-									<AvatarFallback className="bg-primary/10">
-										<IconBuilding className="size-8 text-primary" />
-									</AvatarFallback>
-								</Avatar>
+								<OrganizationLogo logo={previewUrl || logoUrl} name={organization.name} />
 								{/* Upload progress overlay */}
 								{isUploading && (
 									<div className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-full bg-black/70">
@@ -98,13 +109,29 @@ export function OrganizationDetailsCard({
 										</span>
 									</div>
 								)}
+								{canEdit && logoUrl && !isUploading && (
+									<button
+										type="button"
+										onClick={handleRemoveLogo}
+										disabled={isRemovingLogo}
+										aria-label={t("organization.logo.removeLabel", "Remove organization logo")}
+										className="absolute top-0 right-0 rounded-full bg-destructive p-1.5 text-destructive-foreground shadow-lg ring-2 ring-background transition-transform hover:scale-110 focus-visible:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
+									>
+										{isRemovingLogo ? (
+											<IconLoader2 className="size-3 animate-spin text-white" aria-hidden="true" />
+										) : (
+											<IconTrash className="size-3 text-white" aria-hidden="true" />
+										)}
+									</button>
+								)}
 								{canEdit && !isUploading && (
 									<button
 										type="button"
 										onClick={() => inputRef.current?.click()}
-										className="absolute bottom-0 right-0 rounded-full bg-primary p-1.5 text-primary-foreground shadow-lg transition-transform hover:scale-110"
+										aria-label={t("organization.logo.changeLabel", "Change organization logo")}
+										className="absolute right-0 bottom-0 rounded-full bg-primary p-1.5 text-primary-foreground shadow-lg transition-transform hover:scale-110 focus-visible:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 									>
-										<IconCamera className="size-3" />
+										<IconCamera className="size-3" aria-hidden="true" />
 									</button>
 								)}
 							</div>

--- a/apps/webapp/src/components/organization/organization-logo.test.tsx
+++ b/apps/webapp/src/components/organization/organization-logo.test.tsx
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { OrganizationLogo } from "./organization-logo";
+
+describe("OrganizationLogo", () => {
+	it("renders a plain image for an uploaded organization logo", () => {
+		render(<OrganizationLogo logo="https://cdn.example.com/org-logos/org-1/logo.webp" name="Acme" />);
+
+		const image = screen.getByRole("img", { name: "Acme" });
+
+		expect(image.tagName).toBe("IMG");
+		expect(image.getAttribute("src")).toBe("https://cdn.example.com/org-logos/org-1/logo.webp");
+	});
+
+	it("renders the building fallback when no logo is available", () => {
+		render(<OrganizationLogo logo={null} name="Acme" />);
+
+		expect(screen.getByTestId("organization-logo-fallback")).toBeTruthy();
+		expect(screen.queryByRole("img", { name: "Acme" })).toBeNull();
+	});
+});

--- a/apps/webapp/src/components/organization/organization-logo.tsx
+++ b/apps/webapp/src/components/organization/organization-logo.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { IconBuilding } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+const sizeClass = {
+	xs: "size-6",
+	sm: "size-8",
+	md: "size-16",
+} as const;
+
+const sizePixels = {
+	xs: 24,
+	sm: 32,
+	md: 64,
+} as const;
+
+const iconClass = {
+	xs: "size-4",
+	sm: "size-4",
+	md: "size-8",
+} as const;
+
+type OrganizationLogoSize = keyof typeof sizeClass;
+
+interface OrganizationLogoProps {
+	logo?: string | null;
+	name: string;
+	size?: OrganizationLogoSize;
+	className?: string;
+	fallbackClassName?: string;
+}
+
+export function OrganizationLogo({
+	logo,
+	name,
+	size = "md",
+	className,
+	fallbackClassName,
+}: OrganizationLogoProps) {
+	const [imageFailed, setImageFailed] = useState(false);
+
+	useEffect(() => {
+		setImageFailed(false);
+	}, [logo]);
+
+	const showLogo = Boolean(logo) && !imageFailed;
+
+	return (
+		<Avatar className={cn(sizeClass[size], "rounded-lg", className)}>
+			{showLogo ? (
+				<img
+					src={logo ?? undefined}
+					alt={name}
+					width={sizePixels[size]}
+					height={sizePixels[size]}
+					className="aspect-square size-full object-cover"
+					onError={() => setImageFailed(true)}
+				/>
+			) : (
+				<AvatarFallback
+					className={cn("rounded-lg bg-primary/10 text-primary", fallbackClassName)}
+					data-testid="organization-logo-fallback"
+				>
+					<IconBuilding className={cn(iconClass[size], "text-current")} />
+				</AvatarFallback>
+			)}
+		</Avatar>
+	);
+}

--- a/apps/webapp/src/components/settings/profile-form.tsx
+++ b/apps/webapp/src/components/settings/profile-form.tsx
@@ -403,7 +403,7 @@ export function ProfileForm({ user }: ProfileFormProps) {
 											{removeAvatarMutation.isPending ? (
 												<IconLoader2 className="size-3.5 animate-spin" aria-hidden="true" />
 											) : (
-												<IconTrash className="size-3.5" aria-hidden="true" />
+												<IconTrash className="size-3.5 text-white" aria-hidden="true" />
 											)}
 										</button>
 									)}

--- a/apps/webapp/src/lib/storage/avatar-storage.test.ts
+++ b/apps/webapp/src/lib/storage/avatar-storage.test.ts
@@ -28,8 +28,12 @@ vi.mock("@aws-sdk/client-s3", () => ({
 	}),
 }));
 
-const { createAvatarStorageKey, deleteOwnedAvatarObject, getOwnedAvatarKeyFromPublicUrl } =
-	await import("./avatar-storage");
+const {
+	createAvatarStorageKey,
+	createOrganizationLogoStorageKey,
+	deleteOwnedAvatarObject,
+	getOwnedAvatarKeyFromPublicUrl,
+} = await import("./avatar-storage");
 
 describe("avatar storage", () => {
 	beforeEach(() => {
@@ -39,6 +43,12 @@ describe("avatar storage", () => {
 
 	it("creates per-user immutable avatar keys", () => {
 		expect(createAvatarStorageKey("user-1", "avatar-id")).toBe("avatars/user-1/avatar-id.webp");
+	});
+
+	it("creates per-organization immutable logo keys", () => {
+		expect(createOrganizationLogoStorageKey("org-1", "logo-id")).toBe(
+			"org-logos/org-1/logo-id.webp",
+		);
 	});
 
 	it("extracts owned avatar keys from the public S3 URL", () => {

--- a/apps/webapp/src/lib/storage/avatar-storage.ts
+++ b/apps/webapp/src/lib/storage/avatar-storage.ts
@@ -6,6 +6,10 @@ export function createAvatarStorageKey(userId: string, id = nanoid()): string {
 	return `avatars/${userId}/${id}.webp`;
 }
 
+export function createOrganizationLogoStorageKey(organizationId: string, id = nanoid()): string {
+	return `org-logos/${organizationId}/${id}.webp`;
+}
+
 export function getOwnedAvatarKeyFromPublicUrl(
 	url: string | null | undefined,
 	userId: string,

--- a/docs/superpowers/plans/2026-05-25-organization-logo-handling.md
+++ b/docs/superpowers/plans/2026-05-25-organization-logo-handling.md
@@ -1,0 +1,225 @@
+# Organization Logo Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make organization logos render with plain image tags, upload to `org-logos/{orgId}/{nanoid}.webp`, and allow organization owners to clear the current logo from settings without deleting S3 objects.
+
+**Architecture:** Add a reusable `OrganizationLogo` component around existing avatar primitives. Add a focused org-logo storage-key helper and use it in the upload process route. Add a server action to clear the organization logo and wire it into the existing organization settings card.
+
+**Tech Stack:** Next.js App Router, React client components, Better Auth organization API, Drizzle-backed auth schema, Vitest, Testing Library, pnpm.
+
+---
+
+## File Structure
+
+- Create `apps/webapp/src/components/organization/organization-logo.tsx`: reusable organization logo display component with plain image behavior through the existing avatar primitive.
+- Create `apps/webapp/src/components/organization/organization-logo.test.tsx`: verifies uploaded-logo and fallback rendering.
+- Modify `apps/webapp/src/components/organization/organization-details-card.tsx`: use `OrganizationLogo`, add remove-logo button, call clear-logo server action.
+- Add or modify `apps/webapp/src/components/organization/organization-details-card.test.tsx`: verifies remove-logo behavior and white trash icon class.
+- Modify `apps/webapp/src/components/organization-switcher.tsx`: remove `next/image`, use `OrganizationLogo` in the sidebar and dropdown.
+- Modify `apps/webapp/src/lib/storage/avatar-storage.ts`: add `createOrganizationLogoStorageKey` while leaving avatar helpers unchanged.
+- Modify `apps/webapp/src/lib/storage/avatar-storage.test.ts`: verify the new org-logo key helper.
+- Modify `apps/webapp/src/app/api/upload/process/route.ts`: use the org-logo key helper for `uploadType === "org-logo"`.
+- Modify `apps/webapp/src/app/api/upload/process/route.test.ts`: expect `org-logos/org_1/{id}.webp` public URLs.
+- Modify `apps/webapp/src/app/[locale]/(app)/settings/organizations/actions.ts`: add `removeOrganizationLogo` action with owner authorization and `logo: null` Better Auth update.
+
+### Task 1: Storage Key Helper
+
+**Files:**
+- Modify: `apps/webapp/src/lib/storage/avatar-storage.ts`
+- Modify: `apps/webapp/src/lib/storage/avatar-storage.test.ts`
+
+- [ ] **Step 1: Add a failing helper test**
+
+Add this test to `avatar-storage.test.ts`:
+
+```ts
+it("creates per-organization immutable logo keys", () => {
+	expect(createOrganizationLogoStorageKey("org-1", "logo-id")).toBe(
+		"org-logos/org-1/logo-id.webp",
+	);
+});
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run: `pnpm --filter webapp test src/lib/storage/avatar-storage.test.ts`
+
+Expected: FAIL because `createOrganizationLogoStorageKey` is not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+In `avatar-storage.ts`, add:
+
+```ts
+export function createOrganizationLogoStorageKey(organizationId: string, id = nanoid()): string {
+	return `org-logos/${organizationId}/${id}.webp`;
+}
+```
+
+- [ ] **Step 4: Run the focused test again**
+
+Run: `pnpm --filter webapp test src/lib/storage/avatar-storage.test.ts`
+
+Expected: PASS.
+
+### Task 2: Upload Process Route
+
+**Files:**
+- Modify: `apps/webapp/src/app/api/upload/process/route.ts`
+- Modify: `apps/webapp/src/app/api/upload/process/route.test.ts`
+
+- [ ] **Step 1: Update the expected org-logo URL test**
+
+Change the expectation to:
+
+```ts
+logo: expect.stringMatching(/^https:\/\/cdn\.example\.com\/org-logos\/org_1\/[A-Za-z0-9_-]+\.webp$/),
+```
+
+- [ ] **Step 2: Run the route test and verify failure**
+
+Run: `pnpm --filter webapp test src/app/api/upload/process/route.test.ts`
+
+Expected: FAIL because the route still writes `org-logos/org_1-{timestamp}.webp`.
+
+- [ ] **Step 3: Use the new helper in the route**
+
+Change the storage import to include `createOrganizationLogoStorageKey` and replace the `finalKey` logic with explicit branches:
+
+```ts
+const finalKey =
+	uploadType === "avatar"
+		? createAvatarStorageKey(session.user.id)
+		: uploadType === "org-logo" && organizationId
+			? createOrganizationLogoStorageKey(organizationId)
+			: `${folderMap[uploadType] || "uploads"}/${organizationId}-${Date.now()}.webp`;
+```
+
+- [ ] **Step 4: Run the route test again**
+
+Run: `pnpm --filter webapp test src/app/api/upload/process/route.test.ts`
+
+Expected: PASS.
+
+### Task 3: Reusable OrganizationLogo Component
+
+**Files:**
+- Create: `apps/webapp/src/components/organization/organization-logo.tsx`
+- Create: `apps/webapp/src/components/organization/organization-logo.test.tsx`
+
+- [ ] **Step 1: Write component tests**
+
+Create tests that assert a provided logo URL renders as an `img` with the organization name as alt text, and that missing logo falls back to a building icon container.
+
+- [ ] **Step 2: Run the component tests and verify failure**
+
+Run: `pnpm --filter webapp test src/components/organization/organization-logo.test.tsx`
+
+Expected: FAIL because the component file does not exist.
+
+- [ ] **Step 3: Implement `OrganizationLogo`**
+
+Create a client component that accepts `logo`, `name`, `size = "md"`, `className`, and `fallbackClassName`, uses `Avatar`, `AvatarImage`, and `AvatarFallback`, and maps sizes to existing Tailwind size classes.
+
+- [ ] **Step 4: Run the component tests again**
+
+Run: `pnpm --filter webapp test src/components/organization/organization-logo.test.tsx`
+
+Expected: PASS.
+
+### Task 4: Sidebar Integration
+
+**Files:**
+- Modify: `apps/webapp/src/components/organization-switcher.tsx`
+- Modify: `apps/webapp/src/components/app-sidebar.test.tsx` if existing sidebar tests assert image details.
+
+- [ ] **Step 1: Remove `next/image` from the organization switcher**
+
+Delete `import Image from "next/image";`.
+
+- [ ] **Step 2: Render `OrganizationLogo` for active and dropdown organizations**
+
+Use `OrganizationLogo` with `size="sm"` for the active organization and `size="xs"` for dropdown rows, preserving current layout classes.
+
+- [ ] **Step 3: Run sidebar tests**
+
+Run: `pnpm --filter webapp test src/components/app-sidebar.test.tsx`
+
+Expected: PASS, or update mocks only if tests depend on the old direct image implementation.
+
+### Task 5: Clear Logo Server Action
+
+**Files:**
+- Modify: `apps/webapp/src/app/[locale]/(app)/settings/organizations/actions.ts`
+
+- [ ] **Step 1: Add `removeOrganizationLogo` action**
+
+Add an action that loads the current session, verifies the user is an owner member of the target organization, and calls:
+
+```ts
+await auth.api.updateOrganization({
+	body: {
+		organizationId,
+		data: { logo: null },
+	},
+	headers: await headers(),
+});
+```
+
+- [ ] **Step 2: Preserve authorization error behavior**
+
+Use the same `AuthorizationError`, `NotFoundError`, `ValidationError`, `runServerActionSafe`, and tracing pattern used by `updateOrganizationDetails`.
+
+### Task 6: Organization Settings Remove Button
+
+**Files:**
+- Modify: `apps/webapp/src/components/organization/organization-details-card.tsx`
+- Add or modify: `apps/webapp/src/components/organization/organization-details-card.test.tsx`
+
+- [ ] **Step 1: Add a failing component test**
+
+Mock `removeOrganizationLogo`, render an owner organization with a `logo`, click the remove button, and assert the server action receives the organization id and the rendered logo image is removed.
+
+- [ ] **Step 2: Run the focused component test**
+
+Run: `pnpm --filter webapp test src/components/organization/organization-details-card.test.tsx`
+
+Expected: FAIL because the button and action wiring are not present.
+
+- [ ] **Step 3: Implement UI wiring**
+
+Import `IconTrash` from `@tabler/icons-react` and `removeOrganizationLogo` from the organization actions. Add `isRemovingLogo` state and a remove button that appears when `canEdit`, `logoUrl`, and `!isUploading` are true. The trash icon must include `text-white`.
+
+- [ ] **Step 4: Implement mutation behavior**
+
+On click, call `removeOrganizationLogo(organization.id)`. On success, set `logoUrl` to `null` and show a success toast. On failure, show the returned error message or a translated fallback. Do not call any S3 deletion helper.
+
+- [ ] **Step 5: Run focused component test again**
+
+Run: `pnpm --filter webapp test src/components/organization/organization-details-card.test.tsx`
+
+Expected: PASS.
+
+### Task 7: Verification
+
+**Files:**
+- All modified files.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run: `pnpm --filter webapp test src/lib/storage/avatar-storage.test.ts src/app/api/upload/process/route.test.ts src/components/organization/organization-logo.test.tsx src/components/organization/organization-details-card.test.tsx src/components/app-sidebar.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type/lint checks if available for webapp**
+
+Run the repository's standard webapp verification command discovered in `package.json`.
+
+Expected: PASS or document unavailable environment constraints.
+
+## Self-Review
+
+- Spec coverage: The plan covers reusable rendering, sidebar plain image behavior, nested org-logo S3 keys, owner-only clear-logo behavior, no S3 deletion, white trash icon, and tests.
+- Placeholder scan: No placeholders remain; each task names files and exact behavior.
+- Type consistency: `createOrganizationLogoStorageKey`, `OrganizationLogo`, and `removeOrganizationLogo` names are used consistently across tasks.

--- a/docs/superpowers/specs/2026-05-25-organization-logo-handling-design.md
+++ b/docs/superpowers/specs/2026-05-25-organization-logo-handling-design.md
@@ -1,0 +1,52 @@
+# Organization Logo Handling Design
+
+## Goal
+
+Make organization logos work reliably with public S3 URLs, store new organization-logo uploads under immutable per-organization keys, and let owners clear the current organization logo from settings without deleting S3 objects.
+
+## Scope
+
+- Replace `next/image` usage for organization logos in the main sidebar with plain image rendering.
+- Add a reusable `OrganizationLogo` component for organization logo display and fallback behavior.
+- Change processed `org-logo` uploads from `org-logos/{orgId}-{timestamp}.webp` to `org-logos/{orgId}/{nanoid}.webp`.
+- Add a remove-logo control to `/settings/organizations` that clears the organization `logo` database value.
+- Do not delete old S3 logo objects automatically. Old objects are intentionally left in place for manual cleanup.
+
+## Architecture
+
+`OrganizationLogo` will live in `apps/webapp/src/components/organization/organization-logo.tsx`. It will be a small client component that wraps the existing avatar primitives, renders the uploaded logo through the primitive's underlying plain image element, and falls back to the building icon when no logo URL is present or the image cannot load. Callers pass `logo`, `name`, `size`, and optional `className` values.
+
+The sidebar organization switcher will stop importing `next/image` and use `OrganizationLogo` for both the active organization and dropdown organization rows. The organization settings details card will also use `OrganizationLogo`, preserving the existing upload overlay and camera button behavior.
+
+Upload processing will add a focused `createOrganizationLogoStorageKey(organizationId, id = nanoid())` helper. The existing process route will call it for `uploadType === "org-logo"`, while keeping avatar, branding logo, and branding background behavior unchanged.
+
+## Data Flow
+
+1. Owner uploads a logo in `/settings/organizations`.
+2. `useImageUpload` processes the upload as `org-logo`.
+3. The process route validates ownership, optimizes the image, writes it to `org-logos/{orgId}/{nanoid}.webp`, and updates Better Auth organization `logo` with the public URL.
+4. The settings card updates local `logoUrl`; the sidebar sees the new org logo after cache invalidation or refresh.
+5. Owner clicks the remove-logo button in settings.
+6. A server action validates owner permissions and updates Better Auth organization `logo` to `null`.
+7. The settings card updates local `logoUrl` to `null`; S3 objects are not touched.
+
+## Permissions And Safety
+
+Only organization owners can upload or clear organization logos. Existing owner checks in the upload process remain in place. The new clear-logo action will reuse the same organization owner authorization pattern as `updateOrganizationDetails`.
+
+## UI Behavior
+
+The organization settings logo area keeps the current upload affordance. When a logo exists and the owner is not uploading, a trash/remove button appears on the logo. The trash icon uses white foreground color. Removing the logo shows success and error toasts consistent with the profile picture removal pattern.
+
+## Testing
+
+- Unit test the storage-key helper to verify `org-logos/{orgId}/{id}.webp` output.
+- Update the upload process test to expect the new nested organization-logo key shape.
+- Add tests for `OrganizationLogo` fallback and image rendering.
+- Add a component test for the organization details card remove-logo button, mocking the server action and asserting the local logo is cleared.
+
+## Non-Goals
+
+- No automatic deletion of previous organization-logo S3 objects.
+- No migration of existing logo URLs.
+- No changes to branding login-page logo/background storage.


### PR DESCRIPTION
## Changelog
- Added immutable per-organization logo storage keys and updated upload processing to save `org-logo` files under `org-logos/{orgId}/{id}.webp`.
- Added a reusable plain-image `OrganizationLogo` component and switched organization sidebar/settings rendering to it.
- Added owner-only organization logo removal that clears the Better Auth logo value without deleting S3 objects.
- Improved avatar delete icon contrast and added focused regression coverage for the logo storage, rendering, upload, and removal flows.

## Verification
- `pnpm --filter webapp test src/lib/storage/avatar-storage.test.ts src/app/api/upload/process/route.test.ts src/components/organization/organization-logo.test.tsx src/components/organization/organization-details-card.test.tsx src/components/app-sidebar.test.tsx src/components/settings/profile-form.test.tsx`
- `pnpm test` (510 files, 3014 tests)
