### PR TITLE
Trial Banner Controls and Resilient Upload Callbacks

### DIFF
--- a/apps/webapp/messages/common/de.json
+++ b/apps/webapp/messages/common/de.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} Tage verbleibend. Fügen Sie jetzt Zahlungsdetails hinzu; Ihr kostenpflichtiges Abonnement beginnt nach der Testversion.",
+      "dismiss": "Testversionsbanner ausblenden",
       "title": "14-tägige Testversion aktiv",
       "upgrade": "Upgrade"
     }

--- a/apps/webapp/messages/common/en.json
+++ b/apps/webapp/messages/common/en.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} days remaining. Add payment details now; your paid subscription starts after the trial.",
+      "dismiss": "Dismiss trial banner",
       "title": "14-day trial active",
       "upgrade": "Upgrade"
     }

--- a/apps/webapp/messages/common/es.json
+++ b/apps/webapp/messages/common/es.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} días restantes. Agregue los detalles de pago ahora; su suscripción de pago comienza después de la prueba.",
+      "dismiss": "Descartar banner de prueba",
       "title": "Prueba de 14 días activa",
       "upgrade": "Actualizar"
     }

--- a/apps/webapp/messages/common/fr.json
+++ b/apps/webapp/messages/common/fr.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} jours restants. Ajoutez vos coordonnées de paiement maintenant ; votre abonnement payé commence après la période d'essai.",
+      "dismiss": "Masquer la bannière d'essai",
       "title": "Essai de 14 jours actif",
       "upgrade": "Mettre à niveau"
     }

--- a/apps/webapp/messages/common/it.json
+++ b/apps/webapp/messages/common/it.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} giorni rimanenti. Aggiungi ora i dettagli di pagamento; l'abbonamento a pagamento inizierà dopo la prova.",
+      "dismiss": "Nascondi banner della prova",
       "title": "Prova di 14 giorni attiva",
       "upgrade": "Aggiorna"
     }

--- a/apps/webapp/messages/common/pt.json
+++ b/apps/webapp/messages/common/pt.json
@@ -29,6 +29,7 @@
     },
     "trialBanner": {
       "description": "{days} dias restantes. Adicione os detalhes de pagamento agora; sua assinatura paga começa após o teste.",
+      "dismiss": "Dispensar banner de teste",
       "title": "Teste de 14 dias ativo",
       "upgrade": "Atualizar"
     }

--- a/apps/webapp/src/app/api/upload/process/route.test.ts
+++ b/apps/webapp/src/app/api/upload/process/route.test.ts
@@ -161,4 +161,18 @@ describe("image upload processing", () => {
 			},
 		});
 	});
+
+	it("keeps the completed TUS object available for duplicate processing callbacks", async () => {
+		const response = await POST({
+			json: () =>
+				Promise.resolve({
+					tusFileKey: ".tmp/tus/dXNlcl8x-upload",
+					uploadType: "org-logo",
+					organizationId: "org_1",
+				}),
+		} as never);
+
+		expect(response.status).toBe(200);
+		expect(mockState.deleteCommand).not.toHaveBeenCalled();
+	});
 });

--- a/apps/webapp/src/app/api/upload/process/route.ts
+++ b/apps/webapp/src/app/api/upload/process/route.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { and, eq } from "drizzle-orm";
 import { fileTypeFromBuffer } from "file-type";
 import { headers } from "next/headers";
@@ -154,9 +154,6 @@ export async function POST(request: NextRequest) {
 				},
 			}),
 		);
-
-		// Delete temp file from S3
-		await s3Client.send(new DeleteObjectCommand({ Bucket: S3_PUBLIC_BUCKET, Key: safeTusFileKey }));
 
 		const publicUrl = getPublicUrl(finalKey);
 

--- a/apps/webapp/src/components/billing/trial-banner.test.tsx
+++ b/apps/webapp/src/components/billing/trial-banner.test.tsx
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { TrialBanner } from "./trial-banner";
@@ -56,6 +56,20 @@ describe("TrialBanner", () => {
 		expect(screen.queryByRole("link", { name: "Upgrade" })).toBeNull();
 	});
 
+	it("can be dismissed for the current page session", () => {
+		render(
+			<TrialBanner
+				daysRemaining={9}
+				billingHref="/en/settings/billing"
+				showUpgradeButton={true}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Dismiss trial banner" }));
+
+		expect(screen.queryByText("14-day trial active")).toBeNull();
+	});
+
 	it("uses the localized app navigation link", () => {
 		const bannerSource = readFileSync(join(process.cwd(), "src/components/billing/trial-banner.tsx"), "utf8");
 
@@ -71,36 +85,42 @@ describe("TrialBanner", () => {
 				description:
 					"{days} days remaining. Add payment details now; your paid subscription starts after the trial.",
 				upgrade: "Upgrade",
+				dismiss: "Dismiss trial banner",
 			},
 			de: {
 				title: "14-tägige Testversion aktiv",
 				description:
 					"{days} Tage verbleibend. Fügen Sie jetzt Zahlungsdetails hinzu; Ihr kostenpflichtiges Abonnement beginnt nach der Testversion.",
 				upgrade: "Upgrade",
+				dismiss: "Testversionsbanner ausblenden",
 			},
 			es: {
 				title: "Prueba de 14 días activa",
 				description:
 					"{days} días restantes. Agregue los detalles de pago ahora; su suscripción de pago comienza después de la prueba.",
 				upgrade: "Actualizar",
+				dismiss: "Descartar banner de prueba",
 			},
 			fr: {
 				title: "Essai de 14 jours actif",
 				description:
 					"{days} jours restants. Ajoutez vos coordonnées de paiement maintenant ; votre abonnement payé commence après la période d'essai.",
 				upgrade: "Mettre à niveau",
+				dismiss: "Masquer la bannière d'essai",
 			},
 			it: {
 				title: "Prova di 14 giorni attiva",
 				description:
 					"{days} giorni rimanenti. Aggiungi ora i dettagli di pagamento; l'abbonamento a pagamento inizierà dopo la prova.",
 				upgrade: "Aggiorna",
+				dismiss: "Nascondi banner della prova",
 			},
 			pt: {
 				title: "Teste de 14 dias ativo",
 				description:
 					"{days} dias restantes. Adicione os detalhes de pagamento agora; sua assinatura paga começa após o teste.",
 				upgrade: "Atualizar",
+				dismiss: "Dispensar banner de teste",
 			},
 		};
 

--- a/apps/webapp/src/components/billing/trial-banner.tsx
+++ b/apps/webapp/src/components/billing/trial-banner.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { IconCreditCard } from "@tabler/icons-react";
+import { IconCreditCard, IconX } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
+import { useState } from "react";
 import { Link } from "@/navigation";
 
 interface TrialBannerProps {
@@ -12,10 +13,15 @@ interface TrialBannerProps {
 
 export function TrialBanner({ daysRemaining, billingHref, showUpgradeButton }: TrialBannerProps) {
 	const { t } = useTranslate();
+	const [isDismissed, setIsDismissed] = useState(false);
+
+	if (isDismissed) {
+		return null;
+	}
 
 	return (
 		<aside className="border-b border-blue-200 bg-blue-50/80 px-4 py-3 text-blue-950 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-50">
-			<div className="mx-auto flex max-w-7xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+			<div className="mx-auto flex max-w-7xl gap-3">
 				<div className="flex items-start gap-3">
 					<div className="mt-0.5 rounded-full bg-blue-100 p-2 text-blue-700 dark:bg-blue-900 dark:text-blue-200">
 						<IconCreditCard className="size-4" aria-hidden="true" />
@@ -31,14 +37,24 @@ export function TrialBanner({ daysRemaining, billingHref, showUpgradeButton }: T
 						</p>
 					</div>
 				</div>
-				{showUpgradeButton ? (
-					<Link
-						href={billingHref}
-						className="inline-flex h-9 shrink-0 items-center justify-center rounded-md bg-blue-600 px-4 text-sm font-medium text-white shadow-xs transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400"
+				<div className="ml-auto flex shrink-0 items-start gap-2 sm:items-center">
+					{showUpgradeButton ? (
+						<Link
+							href={billingHref}
+							className="inline-flex h-9 shrink-0 items-center justify-center rounded-md bg-blue-600 px-4 text-sm font-medium text-white shadow-xs transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400"
+						>
+							{t("billing.trialBanner.upgrade", "Upgrade")}
+						</Link>
+					) : null}
+					<button
+						type="button"
+						className="inline-flex size-9 items-center justify-center rounded-md text-blue-700 transition-colors hover:bg-blue-100 hover:text-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:text-blue-100 dark:hover:bg-blue-900 dark:hover:text-white"
+						onClick={() => setIsDismissed(true)}
+						aria-label={t("billing.trialBanner.dismiss", "Dismiss trial banner")}
 					>
-						{t("billing.trialBanner.upgrade", "Upgrade")}
-					</Link>
-				) : null}
+						<IconX className="size-4" aria-hidden="true" />
+					</button>
+				</div>
 			</div>
 		</aside>
 	);


### PR DESCRIPTION
## Changelog
- Kept completed TUS upload objects available after image processing so duplicate processing callbacks can succeed.
- Added an in-session dismiss control for the billing trial banner.
- Localized the trial banner dismiss label across supported common locales.

## Test Plan
- pnpm --dir apps/webapp test src/components/billing/trial-banner.test.tsx src/app/api/upload/process/route.test.ts
- pnpm test