### PR TITLE
Stabilize Client Theme and Billing Banner Polish

### DIFF
--- a/apps/webapp/src/app/[locale]/layout.test.tsx
+++ b/apps/webapp/src/app/[locale]/layout.test.tsx
@@ -130,7 +130,7 @@ vi.mock("drizzle-orm", () => ({
 }));
 
 describe("LocaleLayout", () => {
-	it("inlines font size preference initialization before paint", async () => {
+	it("does not render font size initialization as a script during locale navigation", async () => {
 		const layout = await LocaleLayout({
 			children: <div>Auth content</div>,
 			params: Promise.resolve({ locale: "en" }),
@@ -138,14 +138,7 @@ describe("LocaleLayout", () => {
 
 		const script = findFontSizeInitScript(layout);
 
-		expect(script).not.toBeNull();
-		expect(script?.id).toBe("font-size-init");
-		expect(script?.strategy).toBe("beforeInteractive");
-		expect(script?.children).toContain("localStorage.getItem(\"z8-font-size\")");
-		expect(script?.children).toContain("document.documentElement.dataset.fontSize");
-		expect(script?.children).toContain("comfortable");
-		expect(script?.children).toContain("large");
-		expect(script?.children).toContain("catch");
+		expect(script).toBeNull();
 	});
 
 	it("does not block the shell on the PostHog consent session lookup", async () => {

--- a/apps/webapp/src/app/[locale]/layout.tsx
+++ b/apps/webapp/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import { headers } from "next/headers";
-import Script from "next/script";
 import { NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { type ReactNode, Suspense } from "react";
@@ -58,8 +57,6 @@ const DEFAULT_META = {
 	description: "z8 - time app",
 	keywords: "z8, time, app, productivity",
 };
-
-const FONT_SIZE_INIT_SCRIPT = `try{var fontSize=localStorage.getItem("z8-font-size");if(fontSize==="comfortable"||fontSize==="large"){document.documentElement.dataset.fontSize=fontSize;}else{document.documentElement.removeAttribute("data-font-size");}}catch{}`;
 
 function TranslatedMeta() {
 	return (
@@ -134,9 +131,6 @@ export default async function LocaleLayout({ children, params }: Props) {
 				<meta content="yes" name="mobile-web-app-capable" />
 				<meta content="yes" name="apple-mobile-web-app-capable" />
 				<meta content="default" name="apple-mobile-web-app-status-bar-style" />
-				<Script id="font-size-init" strategy="beforeInteractive">
-					{FONT_SIZE_INIT_SCRIPT}
-				</Script>
 				<TranslatedMeta />
 			</head>
 			<body>

--- a/apps/webapp/src/components/billing/trial-banner.test.tsx
+++ b/apps/webapp/src/components/billing/trial-banner.test.tsx
@@ -66,6 +66,7 @@ describe("TrialBanner", () => {
 		);
 
 		fireEvent.click(screen.getByRole("button", { name: "Dismiss trial banner" }));
+		fireEvent.transitionEnd(screen.getByRole("complementary"));
 
 		expect(screen.queryByText("14-day trial active")).toBeNull();
 	});

--- a/apps/webapp/src/components/billing/trial-banner.tsx
+++ b/apps/webapp/src/components/billing/trial-banner.tsx
@@ -13,22 +13,48 @@ interface TrialBannerProps {
 
 export function TrialBanner({ daysRemaining, billingHref, showUpgradeButton }: TrialBannerProps) {
 	const { t } = useTranslate();
+	const [isDismissing, setIsDismissing] = useState(false);
 	const [isDismissed, setIsDismissed] = useState(false);
+	const isUrgent = daysRemaining < 5;
+	const bannerAccentClassName = isUrgent
+		? "border-red-200 bg-red-50/80 text-red-950 dark:border-red-900 dark:bg-red-950/40 dark:text-red-50"
+		: "border-blue-200 bg-blue-50/80 text-blue-950 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-50";
+	const iconAccentClassName = isUrgent
+		? "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200"
+		: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-200";
+	const descriptionAccentClassName = isUrgent ? "text-red-800 dark:text-red-100" : "text-blue-800 dark:text-blue-100";
+	const upgradeAccentClassName = isUrgent
+		? "bg-red-600 hover:bg-red-700 focus-visible:ring-red-500 dark:bg-red-500 dark:hover:bg-red-400"
+		: "bg-blue-600 hover:bg-blue-700 focus-visible:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400";
+	const dismissAccentClassName = isUrgent
+		? "text-red-700 hover:bg-red-100 hover:text-red-900 focus-visible:ring-red-500 dark:text-red-100 dark:hover:bg-red-900"
+		: "text-blue-700 hover:bg-blue-100 hover:text-blue-900 focus-visible:ring-blue-500 dark:text-blue-100 dark:hover:bg-blue-900";
 
 	if (isDismissed) {
 		return null;
 	}
 
 	return (
-		<aside className="border-b border-blue-200 bg-blue-50/80 px-4 py-3 text-blue-950 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-50">
+		<aside
+			className={`overflow-hidden border-b px-4 transition-[max-height,transform,opacity,padding,border-color] duration-200 ease-out motion-reduce:transition-none ${bannerAccentClassName} ${
+				isDismissing ? "max-h-0 -translate-y-1 border-transparent py-0 opacity-0" : "max-h-40 py-3 opacity-100"
+			}`}
+			onTransitionEnd={(event) => {
+				if (event.target !== event.currentTarget || !isDismissing) {
+					return;
+				}
+
+				setIsDismissed(true);
+			}}
+		>
 			<div className="mx-auto flex max-w-7xl gap-3">
 				<div className="flex items-start gap-3">
-					<div className="mt-0.5 rounded-full bg-blue-100 p-2 text-blue-700 dark:bg-blue-900 dark:text-blue-200">
+					<div className={`mt-0.5 rounded-full p-2 ${iconAccentClassName}`}>
 						<IconCreditCard className="size-4" aria-hidden="true" />
 					</div>
 					<div className="space-y-1">
 						<p className="font-medium">{t("billing.trialBanner.title", "14-day trial active")}</p>
-						<p className="text-sm text-blue-800 dark:text-blue-100">
+						<p className={`text-sm ${descriptionAccentClassName}`}>
 							{t(
 								"billing.trialBanner.description",
 								"{days} days remaining. Add payment details now; your paid subscription starts after the trial.",
@@ -41,15 +67,16 @@ export function TrialBanner({ daysRemaining, billingHref, showUpgradeButton }: T
 					{showUpgradeButton ? (
 						<Link
 							href={billingHref}
-							className="inline-flex h-9 shrink-0 items-center justify-center rounded-md bg-blue-600 px-4 text-sm font-medium text-white shadow-xs transition-colors hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400"
+							className={`inline-flex h-9 shrink-0 items-center justify-center rounded-md px-4 text-sm font-medium text-white shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${upgradeAccentClassName}`}
 						>
 							{t("billing.trialBanner.upgrade", "Upgrade")}
 						</Link>
 					) : null}
 					<button
 						type="button"
-						className="inline-flex size-9 items-center justify-center rounded-md text-blue-700 transition-colors hover:bg-blue-100 hover:text-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:text-blue-100 dark:hover:bg-blue-900 dark:hover:text-white"
-						onClick={() => setIsDismissed(true)}
+						className={`inline-flex size-9 items-center justify-center rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:hover:text-white ${dismissAccentClassName}`}
+						onClick={() => setIsDismissing(true)}
+						disabled={isDismissing}
 						aria-label={t("billing.trialBanner.dismiss", "Dismiss trial banner")}
 					>
 						<IconX className="size-4" aria-hidden="true" />

--- a/apps/webapp/src/components/calendar/schedule-x-calendar.tsx
+++ b/apps/webapp/src/components/calendar/schedule-x-calendar.tsx
@@ -21,10 +21,10 @@ import "./schedule-x-calendar.css";
 import { IconChevronLeft, IconChevronRight, IconReload } from "@tabler/icons-react";
 import { useTolgee, useTranslate } from "@tolgee/react";
 import { DateTime } from "luxon";
-import { useTheme } from "next-themes";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWeekStartDay } from "@/components/providers/user-preferences-provider";
+import { useTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {

--- a/apps/webapp/src/components/nav-user.tsx
+++ b/apps/webapp/src/components/nav-user.tsx
@@ -2,7 +2,6 @@
 
 import {
 	IconChevronDown,
-	IconClock,
 	IconDeviceDesktop,
 	IconDotsVertical,
 	IconLanguage,
@@ -10,20 +9,18 @@ import {
 	IconLogout,
 	IconMoon,
 	IconPalette,
+	IconShield,
 	IconSun,
 	IconTextSize,
 	IconUserCircle,
 } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
 import { useLocale } from "next-intl";
-import { useTheme } from "next-themes";
 import { useState, useTransition } from "react";
 import { createPortal } from "react-dom";
 import { useFontSizePreference } from "@/components/font-size-preference";
-import {
-	FONT_SIZE_OPTIONS,
-	isFontSizePreference,
-} from "@/components/font-size-preference-utils";
+import { FONT_SIZE_OPTIONS, isFontSizePreference } from "@/components/font-size-preference-utils";
+import { useTheme } from "@/components/theme-provider";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
 	DropdownMenu,
@@ -90,7 +87,7 @@ export function NavUser({
 					onSuccess: () => {
 						// Keep the overlay visible during navigation
 						setTimeout(() => {
-						push("/sign-in");
+							push("/sign-in");
 						}, 100);
 					},
 					onError: (error) => {
@@ -193,9 +190,9 @@ export function NavUser({
 									<IconUserCircle />
 									{t("user.profile", "Profile")}
 								</DropdownMenuItem>
-								<DropdownMenuItem>
-									<IconClock />
-									{t("user.time-settings", "Time Settings")}
+								<DropdownMenuItem onClick={() => push("/settings/security")}>
+									<IconShield />
+									{t("user.security", "Security")}
 								</DropdownMenuItem>
 							</DropdownMenuGroup>
 							<DropdownMenuSeparator />

--- a/apps/webapp/src/components/scheduling/scheduler/shift-scheduler.tsx
+++ b/apps/webapp/src/components/scheduling/scheduler/shift-scheduler.tsx
@@ -9,13 +9,13 @@ import { createEventModalPlugin } from "@schedule-x/event-modal";
 import { ScheduleXCalendar, useCalendarApp } from "@schedule-x/react";
 import "@schedule-x/theme-default/dist/index.css";
 import { useTranslate } from "@tolgee/react";
-import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
 import type {
 	DateRange,
 	ShiftTemplate,
 	ShiftWithRelations,
 } from "@/app/[locale]/(app)/scheduling/types";
+import { useTheme } from "@/components/theme-provider";
 import { ShiftDialog } from "../shifts/shift-dialog";
 import {
 	CoverageHeatmapOverlay,

--- a/apps/webapp/src/components/theme-provider.test.tsx
+++ b/apps/webapp/src/components/theme-provider.test.tsx
@@ -1,0 +1,69 @@
+/* @vitest-environment jsdom */
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider, useTheme } from "./theme-provider";
+
+function Consumer() {
+	const { resolvedTheme, setTheme, theme } = useTheme();
+
+	return (
+		<div>
+			<p>Theme: {theme}</p>
+			<p>Resolved: {resolvedTheme}</p>
+			<button type="button" onClick={() => setTheme("dark")}>
+				Set Dark
+			</button>
+		</div>
+	);
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	document.documentElement.className = "";
+	document.documentElement.style.colorScheme = "";
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: vi.fn(() => ({
+			matches: false,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		})),
+	});
+});
+
+describe("ThemeProvider", () => {
+	it("does not render script tags during client navigation", () => {
+		const { container } = render(
+			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+				<Consumer />
+			</ThemeProvider>,
+		);
+
+		expect(container.querySelector("script")).toBeNull();
+	});
+
+	it("loads the stored theme and updates html when changed", async () => {
+		localStorage.setItem("theme", "light");
+
+		render(
+			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+				<Consumer />
+			</ThemeProvider>,
+		);
+
+		expect(await screen.findByText("Theme: light")).toBeTruthy();
+		expect(screen.getByText("Resolved: light")).toBeTruthy();
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+
+		act(() => {
+			screen.getByRole("button", { name: "Set Dark" }).click();
+		});
+
+		expect(screen.getByText("Theme: dark")).toBeTruthy();
+		expect(screen.getByText("Resolved: dark")).toBeTruthy();
+		expect(localStorage.getItem("theme")).toBe("dark");
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+		expect(document.documentElement.classList.contains("light")).toBe(false);
+	});
+});

--- a/apps/webapp/src/components/theme-provider.tsx
+++ b/apps/webapp/src/components/theme-provider.tsx
@@ -3,13 +3,185 @@
 // Note: Temporal polyfill is loaded dynamically in schedule-x-wrapper.tsx
 // before Schedule-X is rendered (required for Schedule-X v3+).
 
-import type { ThemeProviderProps } from "next-themes";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+type ThemeProviderProps = {
+	children: React.ReactNode;
+	attribute?: "class" | `data-${string}` | Array<"class" | `data-${string}`>;
+	defaultTheme?: Theme;
+	disableTransitionOnChange?: boolean;
+	enableColorScheme?: boolean;
+	enableSystem?: boolean;
+	storageKey?: string;
+	themes?: string[];
+	value?: Record<string, string>;
+};
+
+type ThemeContextValue = {
+	forcedTheme?: string;
+	resolvedTheme?: "light" | "dark";
+	setTheme: React.Dispatch<React.SetStateAction<string>>;
+	systemTheme?: "light" | "dark";
+	theme?: string;
+	themes: string[];
+};
+
+const DEFAULT_THEMES = ["light", "dark"];
+const ThemeContext = createContext<ThemeContextValue>({
+	setTheme: () => {},
+	themes: [],
+});
+
+function getLocalStorage(): Storage | undefined {
+	try {
+		return typeof window === "undefined" ? undefined : window.localStorage;
+	} catch {
+		return undefined;
+	}
+}
+
+function getSystemTheme(): "light" | "dark" {
+	if (typeof window === "undefined" || !window.matchMedia) {
+		return "light";
+	}
+
+	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function resolveTheme(theme: string | undefined, enableSystem: boolean): "light" | "dark" {
+	return enableSystem && theme === "system"
+		? getSystemTheme()
+		: theme === "dark"
+			? "dark"
+			: "light";
+}
+
+function writeStoredTheme(storageKey: string, theme: string) {
+	try {
+		getLocalStorage()?.setItem(storageKey, theme);
+	} catch {
+		// Keep the current session updated even when persistence is blocked.
+	}
+}
+
+function disableTransitionsTemporarily() {
+	if (typeof document === "undefined") {
+		return;
+	}
+
+	const css = document.createElement("style");
+	css.appendChild(document.createTextNode("*,*::before,*::after{transition:none!important}"));
+	document.head.appendChild(css);
+
+	window.getComputedStyle(document.body);
+	setTimeout(() => css.remove(), 1);
+}
+
+function applyTheme({
+	attribute,
+	enableColorScheme,
+	resolvedTheme,
+	themes,
+	value,
+}: {
+	attribute: NonNullable<ThemeProviderProps["attribute"]>;
+	enableColorScheme: boolean;
+	resolvedTheme: "light" | "dark";
+	themes: string[];
+	value?: Record<string, string>;
+}) {
+	if (typeof document === "undefined") {
+		return;
+	}
+
+	const html = document.documentElement;
+	const attributes = Array.isArray(attribute) ? attribute : [attribute];
+	const resolvedValue = value?.[resolvedTheme] ?? resolvedTheme;
+	const values = value ? Object.values(value) : themes;
+
+	for (const item of attributes) {
+		if (item === "class") {
+			html.classList.remove(...values);
+			html.classList.add(resolvedValue);
+		} else {
+			html.setAttribute(item, resolvedValue);
+		}
+	}
+
+	if (enableColorScheme) {
+		html.style.colorScheme = resolvedTheme;
+	}
+}
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-	return (
-		<NextThemesProvider {...props}>
-			{children}
-		</NextThemesProvider>
+	const {
+		attribute = "data-theme",
+		defaultTheme,
+		disableTransitionOnChange = false,
+		enableColorScheme = true,
+		enableSystem = true,
+		storageKey = "theme",
+		themes = DEFAULT_THEMES,
+		value,
+	} = props;
+	const initialTheme = defaultTheme ?? (enableSystem ? "system" : "light");
+	const [theme, setThemeState] = useState<string>(() => {
+		try {
+			return getLocalStorage()?.getItem(storageKey) ?? initialTheme;
+		} catch {
+			return initialTheme;
+		}
+	});
+	const [systemTheme, setSystemTheme] = useState<"light" | "dark">(() => getSystemTheme());
+	const resolvedTheme = resolveTheme(theme, enableSystem);
+
+	useEffect(() => {
+		if (!enableSystem || typeof window === "undefined" || !window.matchMedia) {
+			return;
+		}
+
+		const media = window.matchMedia("(prefers-color-scheme: dark)");
+		const updateSystemTheme = () => setSystemTheme(media.matches ? "dark" : "light");
+		updateSystemTheme();
+		media.addEventListener("change", updateSystemTheme);
+
+		return () => media.removeEventListener("change", updateSystemTheme);
+	}, [enableSystem]);
+
+	useEffect(() => {
+		applyTheme({ attribute, enableColorScheme, resolvedTheme, themes, value });
+	}, [attribute, enableColorScheme, resolvedTheme, themes, value]);
+
+	const setTheme = useCallback<React.Dispatch<React.SetStateAction<string>>>(
+		(nextTheme) => {
+			setThemeState((currentTheme) => {
+				const value = typeof nextTheme === "function" ? nextTheme(currentTheme) : nextTheme;
+				if (disableTransitionOnChange) {
+					disableTransitionsTemporarily();
+				}
+				writeStoredTheme(storageKey, value);
+				return value;
+			});
+		},
+		[disableTransitionOnChange, storageKey],
 	);
+
+	const context = useMemo<ThemeContextValue>(
+		() => ({
+			resolvedTheme,
+			setTheme,
+			systemTheme,
+			theme,
+			themes: enableSystem ? [...themes, "system"] : themes,
+		}),
+		[enableSystem, resolvedTheme, setTheme, systemTheme, theme, themes],
+	);
+
+	return <ThemeContext.Provider value={context}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+	return useContext(ThemeContext);
 }

--- a/apps/webapp/src/components/theme-toggle.tsx
+++ b/apps/webapp/src/components/theme-toggle.tsx
@@ -2,8 +2,8 @@
 
 import { IconMoon, IconSun } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
-import { useTheme } from "next-themes";
 import { useSyncExternalStore } from "react";
+import { useTheme } from "@/components/theme-provider";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,

--- a/apps/webapp/src/components/ui/sonner.tsx
+++ b/apps/webapp/src/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { useTheme } from "@/components/theme-provider";
 
 const Toaster = ({ ...props }: ToasterProps) => {
 	const { theme = "system" } = useTheme();

--- a/apps/webapp/src/env-usage.test.ts
+++ b/apps/webapp/src/env-usage.test.ts
@@ -31,8 +31,9 @@ describe("environment variable usage", () => {
 	it("reads env vars from @/env outside env and instrumentation setup", () => {
 		const offenders = collectRuntimeFiles(SRC_ROOT).flatMap((filePath) => {
 			const source = readFileSync(filePath, "utf8");
+			const sourceWithoutNodeEnv = source.replaceAll("process.env.NODE_ENV", "");
 
-			if (!source.includes("process.env")) {
+			if (!sourceWithoutNodeEnv.includes("process.env")) {
 				return [];
 			}
 
@@ -40,5 +41,11 @@ describe("environment variable usage", () => {
 		});
 
 		expect(offenders).toEqual([]);
+	});
+
+	it("does not import the server env wrapper from Tolgee shared runtime code", () => {
+		const source = readFileSync(join(SRC_ROOT, "tolgee/shared.ts"), "utf8");
+
+		expect(source).not.toContain('from "@/env"');
 	});
 });

--- a/apps/webapp/src/tolgee/shared.ts
+++ b/apps/webapp/src/tolgee/shared.ts
@@ -2,9 +2,7 @@ import { FormatIcu } from "@tolgee/format-icu";
 import type { TolgeeStaticData } from "@tolgee/react";
 import { DevTools, Tolgee } from "@tolgee/web";
 
-import { env } from "@/env";
-
-const isDevelopment = env.NODE_ENV === "development";
+const isDevelopment = process.env.NODE_ENV === "development";
 
 export const ALL_LANGUAGES = ["en", "de", "fr", "es", "it", "pt"];
 


### PR DESCRIPTION
## Changelog
- Replace the next-themes wrapper with an owned client theme provider and tests that avoid injecting navigation-time scripts.
- Smooth and harden trial banner dismissal, including urgent-state styling and transition-aware coverage.
- Keep Tolgee shared runtime code off the server env wrapper and route the user menu security item to security settings.

## Test Plan
- pnpm --filter webapp test src/components/billing/trial-banner.test.tsx
- pnpm test