### PR TITLE
Hardening the Secret Store Path

### DIFF
--- a/apps/webapp/src/lib/vault/scaleway-key-manager-client.test.ts
+++ b/apps/webapp/src/lib/vault/scaleway-key-manager-client.test.ts
@@ -158,7 +158,7 @@ describe("ScalewayKeyManagerClient", () => {
 		);
 		expect(await getJsonBody(encryptRequest)).toEqual({
 			plaintext: Buffer.from("secret value", "utf8").toString("base64"),
-			associated_data: { value: "org-1:email/api_key" },
+			associated_data: { value: Buffer.from("org-1:email/api_key", "utf8").toString("base64") },
 		});
 
 		const [decryptUrl, decryptRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
@@ -167,7 +167,7 @@ describe("ScalewayKeyManagerClient", () => {
 		);
 		expect(await getJsonBody(decryptRequest)).toEqual({
 			ciphertext: "scw-km-v1:opaque-ciphertext",
-			associated_data: { value: "org-1:email/api_key" },
+			associated_data: { value: Buffer.from("org-1:email/api_key", "utf8").toString("base64") },
 		});
 	});
 

--- a/apps/webapp/src/lib/vault/scaleway-key-manager-client.ts
+++ b/apps/webapp/src/lib/vault/scaleway-key-manager-client.ts
@@ -7,6 +7,10 @@ export type ScalewayKeyManagerClientOptions = {
 
 type JsonRecord = Record<string, unknown>;
 
+function encodeBytes(value: string) {
+	return Buffer.from(value, "utf8").toString("base64");
+}
+
 export class ScalewayKeyManagerClient {
 	private readonly apiUrl: string;
 	private readonly secretKey: string;
@@ -67,8 +71,8 @@ export class ScalewayKeyManagerClient {
 			{
 				method: "POST",
 				body: {
-					plaintext: Buffer.from(plaintext, "utf8").toString("base64"),
-					associated_data: { value: associatedData },
+					plaintext: encodeBytes(plaintext),
+					associated_data: { value: encodeBytes(associatedData) },
 				},
 			},
 		);
@@ -82,7 +86,7 @@ export class ScalewayKeyManagerClient {
 				method: "POST",
 				body: {
 					ciphertext,
-					associated_data: { value: associatedData },
+					associated_data: { value: encodeBytes(associatedData) },
 				},
 			},
 		);


### PR DESCRIPTION
## Changelog
- Encode Scaleway KMS associated data consistently for encrypt and decrypt calls.
- Added matching client expectations so plaintext and associated data payloads use the same base64 transport format.

## Verification
- pnpm test: first fresh post-commit run hit one non-vault dashboard widget failure.
- pnpm --filter webapp test -- src/components/dashboard/manager-today-widget.test.tsx: rerun completed with 524 test files passed and 3077 tests passed.

## Commits
- fix: encode scaleway associated data