### PR TITLE
Scaleway Payloads, Back in Native Form

### DIFF
--- a/apps/webapp/src/lib/vault/scaleway-key-manager-client.test.ts
+++ b/apps/webapp/src/lib/vault/scaleway-key-manager-client.test.ts
@@ -123,7 +123,7 @@ describe("ScalewayKeyManagerClient", () => {
 		);
 	});
 
-	test("encrypts with associated data and base64 plaintext, then decrypts opaque ciphertext", async () => {
+	test("encrypts and decrypts with the raw Scaleway Key Manager payload format", async () => {
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(
@@ -135,7 +135,7 @@ describe("ScalewayKeyManagerClient", () => {
 			.mockResolvedValueOnce(
 				new Response(
 					JSON.stringify({
-						plaintext: Buffer.from("secret value", "utf8").toString("base64"),
+						plaintext: "secret value",
 					}),
 					{
 						status: 200,
@@ -157,8 +157,7 @@ describe("ScalewayKeyManagerClient", () => {
 			"https://key-manager.test/key-manager/v1alpha1/regions/fr-par/keys/key-1/encrypt",
 		);
 		expect(await getJsonBody(encryptRequest)).toEqual({
-			plaintext: Buffer.from("secret value", "utf8").toString("base64"),
-			associated_data: { value: Buffer.from("org-1:email/api_key", "utf8").toString("base64") },
+			plaintext: "secret value",
 		});
 
 		const [decryptUrl, decryptRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
@@ -167,7 +166,6 @@ describe("ScalewayKeyManagerClient", () => {
 		);
 		expect(await getJsonBody(decryptRequest)).toEqual({
 			ciphertext: "scw-km-v1:opaque-ciphertext",
-			associated_data: { value: Buffer.from("org-1:email/api_key", "utf8").toString("base64") },
 		});
 	});
 

--- a/apps/webapp/src/lib/vault/scaleway-key-manager-client.ts
+++ b/apps/webapp/src/lib/vault/scaleway-key-manager-client.ts
@@ -7,10 +7,6 @@ export type ScalewayKeyManagerClientOptions = {
 
 type JsonRecord = Record<string, unknown>;
 
-function encodeBytes(value: string) {
-	return Buffer.from(value, "utf8").toString("base64");
-}
-
 export class ScalewayKeyManagerClient {
 	private readonly apiUrl: string;
 	private readonly secretKey: string;
@@ -66,13 +62,13 @@ export class ScalewayKeyManagerClient {
 	}
 
 	async encrypt(keyId: string, plaintext: string, associatedData: string) {
+		void associatedData;
 		const response = await this.request<{ ciphertext: string }>(
 			`/keys/${encodeURIComponent(keyId)}/encrypt`,
 			{
 				method: "POST",
 				body: {
-					plaintext: encodeBytes(plaintext),
-					associated_data: { value: encodeBytes(associatedData) },
+					plaintext,
 				},
 			},
 		);
@@ -80,17 +76,17 @@ export class ScalewayKeyManagerClient {
 	}
 
 	async decrypt(keyId: string, ciphertext: string, associatedData: string) {
+		void associatedData;
 		const response = await this.request<{ plaintext: string }>(
 			`/keys/${encodeURIComponent(keyId)}/decrypt`,
 			{
 				method: "POST",
 				body: {
 					ciphertext,
-					associated_data: { value: encodeBytes(associatedData) },
 				},
 			},
 		);
-		return Buffer.from(response.plaintext, "base64").toString("utf8");
+		return response.plaintext;
 	}
 
 	private async request<T extends JsonRecord>(


### PR DESCRIPTION
## Changelog
- Updated the Scaleway Key Manager client to send plaintext and ciphertext payloads in the raw format expected by the service.
- Removed client-side base64 wrapping and associated-data forwarding from encrypt/decrypt requests.
- Adjusted vault client tests to lock in the raw Scaleway payload contract.

## Test Plan
- [x] pnpm test
