### PR TITLE
Traceable Image Build Hash Propagation

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -103,6 +103,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.repository }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
+            NEXT_DEPLOYMENT_ID=${{ github.sha }}
+            BUILD_HASH=${{ github.sha }}
             NEXT_PUBLIC_BUILD_HASH=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.repository }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.repository }}-${{ matrix.arch }}

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -3,6 +3,8 @@ ARG ALPINE_VERSION=3.21
 ARG NODE_VERSION=22
 ARG PNPM_VERSION=11.4.0
 ARG TURBO_VERSION=2.9.14
+ARG NEXT_DEPLOYMENT_ID
+ARG BUILD_HASH
 ARG NEXT_PUBLIC_BUILD_HASH
 
 FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS base
@@ -55,8 +57,12 @@ COPY --from=pruner /app/out/full/ ./
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 
 FROM workspace AS webapp-builder
+ARG NEXT_DEPLOYMENT_ID
+ARG BUILD_HASH
 ARG NEXT_PUBLIC_BUILD_HASH
-ENV NEXT_PUBLIC_BUILD_HASH=${NEXT_PUBLIC_BUILD_HASH}
+ENV NEXT_DEPLOYMENT_ID=${NEXT_DEPLOYMENT_ID} \
+    BUILD_HASH=${BUILD_HASH} \
+    NEXT_PUBLIC_BUILD_HASH=${NEXT_PUBLIC_BUILD_HASH}
 RUN pnpm --filter webapp run generate-licenses || echo "{}" > apps/webapp/src/data/licenses.json
 RUN --mount=type=cache,id=next-cache,target=/app/apps/webapp/.next/cache \
     pnpm --filter webapp exec next build

--- a/scripts/ci/verify-publish-images-workflow.mjs
+++ b/scripts/ci/verify-publish-images-workflow.mjs
@@ -203,6 +203,16 @@ if (publishTargetsJob) {
 		"publish-targets build step must use file: ./${{ matrix.dockerfile }}",
 	);
 
+	includesAll(
+		publishTargetsJob,
+		[
+			"NEXT_DEPLOYMENT_ID=${{ github.sha }}",
+			"BUILD_HASH=${{ github.sha }}",
+			"NEXT_PUBLIC_BUILD_HASH=${{ github.sha }}",
+		],
+		"publish-targets build args",
+	);
+
 	expect(
 		expectedMatrixEntries.size === 0,
 		`publish-targets missing matrix entries: ${[...expectedMatrixEntries].join(", ")}`,


### PR DESCRIPTION
## Changelog
- Pass `NEXT_DEPLOYMENT_ID` and `BUILD_HASH` from the publish-images workflow into webapp Docker builds.
- Export server-side and public build hash environment values during `next build`.
- Extend the publish-images workflow verifier to lock the required build args.

## Verification
- `pnpm test`
- `node scripts/ci/verify-publish-images-workflow.mjs`