### PR TITLE
Fix approval policy migration constraints

### DIFF
--- a/apps/webapp/drizzle/0042_approval_policy_runtime_tables.sql
+++ b/apps/webapp/drizzle/0042_approval_policy_runtime_tables.sql
@@ -28,6 +28,27 @@ EXCEPTION
 	WHEN duplicate_object THEN NULL;
 END $$;
 --> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'location_id_organizationId_idx' AND conrelid = 'public.location'::regclass)
+		AND NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'location_id_organizationId_idx' AND n.nspname = 'public') THEN
+		ALTER TABLE "public"."location" ADD CONSTRAINT "location_id_organizationId_idx" UNIQUE("id","organization_id");
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'absenceCategory_id_organizationId_idx' AND conrelid = 'public.absence_category'::regclass)
+		AND NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'absenceCategory_id_organizationId_idx' AND n.nspname = 'public') THEN
+		ALTER TABLE "public"."absence_category" ADD CONSTRAINT "absenceCategory_id_organizationId_idx" UNIQUE("id","organization_id");
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'approvalRequest_id_organizationId_idx' AND conrelid = 'public.approval_request'::regclass)
+		AND NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = 'approvalRequest_id_organizationId_idx' AND n.nspname = 'public') THEN
+		ALTER TABLE "public"."approval_request" ADD CONSTRAINT "approvalRequest_id_organizationId_idx" UNIQUE("id","organization_id");
+	END IF;
+END $$;
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "employee_group" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"organization_id" text NOT NULL,

--- a/apps/webapp/src/db/schema/__tests__/approval-policy-schema.test.ts
+++ b/apps/webapp/src/db/schema/__tests__/approval-policy-schema.test.ts
@@ -306,4 +306,18 @@ describe("approval policy schema exports", () => {
 		expect(migration).toContain('JOIN "team" ON "team"."id" = "employee"."team_id"');
 		expect(migration).toContain('AND "team"."organization_id" = "employee"."organization_id"');
 	});
+
+	it("adds parent uniqueness required by approval policy composite foreign keys", () => {
+		const migration = readFileSync("drizzle/0042_approval_policy_runtime_tables.sql", "utf8");
+
+		expect(migration).toContain(
+			'ADD CONSTRAINT "location_id_organizationId_idx" UNIQUE("id","organization_id")',
+		);
+		expect(migration).toContain(
+			'ADD CONSTRAINT "absenceCategory_id_organizationId_idx" UNIQUE("id","organization_id")',
+		);
+		expect(migration).toContain(
+			'ADD CONSTRAINT "approvalRequest_id_organizationId_idx" UNIQUE("id","organization_id")',
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- Add guarded parent uniqueness constraints required by approval policy composite foreign keys
- Cover location, absence category, and approval request composite references before runtime tables are created
- Add regression coverage for the migration constraint requirements

## Test Plan
- [x] pnpm vitest run src/db/schema/__tests__/approval-policy-schema.test.ts