### PR TITLE
Polish the Mobile Workday Surface

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.test.tsx
@@ -157,6 +157,30 @@ describe("ApprovalDetailPanel", () => {
 		expect(screen.getByText("No conflicts detected.")).toBeTruthy();
 	});
 
+	it("keeps the header badge clear of the close button and pads the detail content", async () => {
+		render(
+			<ApprovalDetailPanel
+				approval={approvalItem}
+				open={true}
+				onOpenChange={vi.fn()}
+				onActioned={vi.fn()}
+			/>,
+		);
+
+		const dialog = await screen.findByRole("dialog");
+		const header = dialog.querySelector('[data-slot="sheet-header"]');
+		const body = dialog.querySelector('[data-slot="approval-detail-body"]');
+		const footer = dialog.querySelector('[data-slot="sheet-footer"]');
+		const badge = screen.getByText("Sick Leave");
+
+		expect(header?.className).toContain("pr-12");
+		expect(header?.className).toContain("px-5");
+		expect(body?.className).toContain("px-5");
+		expect(footer?.className).toContain("px-5");
+		expect(badge.className).toContain("max-w-");
+		expect(badge.className).toContain("truncate");
+	});
+
 	it("approves with the approval id when approval is allowed", async () => {
 		render(
 			<ApprovalDetailPanel

--- a/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.tsx
@@ -41,7 +41,7 @@ interface ApprovalDetailPanelProps {
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
-	return <h4 className="mb-2 text-sm font-medium text-muted-foreground">{children}</h4>;
+	return <h4 className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">{children}</h4>;
 }
 
 function renderDetailSection(section: ApprovalInboxDetailSection) {
@@ -50,13 +50,16 @@ function renderDetailSection(section: ApprovalInboxDetailSection) {
 			return (
 				<section key={section.title}>
 					<SectionTitle>{section.title}</SectionTitle>
-					<div className="space-y-3 rounded-md border bg-card/40 p-3">
+					<div className="space-y-3 rounded-xl border bg-card/60 p-4 shadow-sm">
 						{section.rows.map((row) => (
-							<div key={`${row.label}-${row.value}`} className="flex justify-between gap-4">
+							<div
+								key={`${row.label}-${row.value}`}
+								className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,max-content)] items-start gap-4"
+							>
 								<span className="text-sm text-muted-foreground">{row.label}</span>
 								<span
 									className={cn(
-										"text-right text-sm font-medium",
+										"min-w-0 text-right text-sm font-semibold text-foreground",
 										row.tone === "warning" && "text-amber-600 dark:text-amber-400",
 										row.tone === "danger" && "text-destructive",
 									)}
@@ -72,17 +75,17 @@ function renderDetailSection(section: ApprovalInboxDetailSection) {
 			return (
 				<section key={section.title}>
 					<SectionTitle>{section.title}</SectionTitle>
-					<p className="rounded-md border bg-card/40 p-3 text-sm leading-6">{section.body}</p>
+					<p className="rounded-xl border bg-card/60 p-4 text-sm leading-6 shadow-sm">{section.body}</p>
 				</section>
 			);
 		case "timeline":
 			return (
 				<section key={section.title}>
 					<SectionTitle>{section.title}</SectionTitle>
-					<div className="space-y-3 rounded-md border bg-card/40 p-3">
+					<div className="space-y-3 rounded-xl border bg-card/60 p-4 shadow-sm">
 						{section.events.map((event) => (
-							<div key={event.id} className="border-l pl-3">
-								<p className="text-sm font-medium">{event.label}</p>
+							<div key={event.id} className="border-l-2 border-primary/30 pl-3">
+								<p className="text-sm font-semibold">{event.label}</p>
 								<p className="text-xs text-muted-foreground">
 									{event.at}
 									{event.actorName ? ` by ${event.actorName}` : ""}
@@ -97,7 +100,7 @@ function renderDetailSection(section: ApprovalInboxDetailSection) {
 				<section
 					key={section.title}
 					className={cn(
-						"rounded-md border p-3",
+						"rounded-xl border p-4 shadow-sm",
 						section.tone === "info" && "border-blue-200 bg-blue-50/60 dark:border-blue-900 dark:bg-blue-950/20",
 						section.tone === "warning" &&
 							"border-amber-200 bg-amber-50/60 dark:border-amber-900 dark:bg-amber-950/20",
@@ -177,16 +180,18 @@ export function ApprovalDetailPanel({
 
 	return (
 		<Sheet open={open} onOpenChange={handleClose}>
-			<SheetContent className="w-[500px] sm:max-w-[500px] overflow-y-auto overscroll-behavior-contain">
-				<SheetHeader>
-					<div className="flex items-start justify-between gap-3">
-						<div>
+			<SheetContent className="w-[min(100vw,560px)] gap-0 overflow-hidden p-0 sm:max-w-[560px]">
+				<SheetHeader className="border-b px-5 py-5 pr-12 sm:px-6">
+					<div className="flex items-start gap-3">
+						<div className="min-w-0 flex-1">
 							<SheetTitle>{t("approvals:approvals.detailTitle", "Approval details")}</SheetTitle>
-							<SheetDescription>{panelItem.summary.detail}</SheetDescription>
+							<SheetDescription className="mt-1 line-clamp-2">{panelItem.summary.detail}</SheetDescription>
 						</div>
 						{panelItem.summary.badge && (
 							<Badge
+								className="mt-0.5 max-w-[10rem] shrink-0 truncate sm:max-w-[13rem]"
 								variant="secondary"
+								title={panelItem.summary.badge.label}
 								style={
 									panelItem.summary.badge.color
 										? { backgroundColor: panelItem.summary.badge.color }
@@ -199,12 +204,12 @@ export function ApprovalDetailPanel({
 					</div>
 				</SheetHeader>
 
-				<div className="mt-6 space-y-6">
+				<div data-slot="approval-detail-body" className="flex-1 space-y-6 overflow-y-auto px-5 py-5 sm:px-6">
 					<div>
 						<SectionTitle>
 							{t("approvals:approvals.requester", "Requester")}
 						</SectionTitle>
-						<div className="flex items-center gap-3">
+						<div className="flex items-center gap-3 rounded-xl border bg-card/60 p-4 shadow-sm">
 							<UserAvatar
 								image={panelItem.requester.image}
 								seed={panelItem.requester.id}
@@ -212,9 +217,9 @@ export function ApprovalDetailPanel({
 								size="md"
 								clockStatus={presence.getStatus(panelItem.requester.id)}
 							/>
-							<div>
-								<div className="font-medium">{panelItem.requester.name}</div>
-								<div className="text-sm text-muted-foreground">{panelItem.requester.email}</div>
+							<div className="min-w-0">
+								<div className="truncate font-semibold">{panelItem.requester.name}</div>
+								<div className="truncate text-sm text-muted-foreground">{panelItem.requester.email}</div>
 							</div>
 						</div>
 					</div>
@@ -224,7 +229,7 @@ export function ApprovalDetailPanel({
 					{sections.map(renderDetailSection)}
 				</div>
 
-				<SheetFooter className="mt-8">
+				<SheetFooter className="border-t bg-muted/95 px-5 py-4 sm:px-6">
 					{isRejecting ? (
 						<div className="w-full space-y-4">
 							<div>

--- a/apps/webapp/src/app/[locale]/(app)/settings/enterprise/domains/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/settings/enterprise/domains/page.tsx
@@ -28,7 +28,7 @@ export default async function CustomDomainsPage() {
 			columns: { id: true, slug: true },
 		}),
 	]);
-	const [canonicalDefaultUrl, aliasDefaultUrl] = getOrganizationPlatformOrigins({
+	const [canonicalDefaultUrl] = getOrganizationPlatformOrigins({
 		id: organizationId,
 		slug: organizationRecord?.slug ?? organizationId,
 	});
@@ -53,7 +53,7 @@ export default async function CustomDomainsPage() {
 					initialProviders={providers as any}
 					initialSocialOAuthConfigs={socialOAuthConfigs}
 					organizationId={organizationId}
-					defaultUrls={{ canonical: canonicalDefaultUrl, alias: aliasDefaultUrl }}
+					defaultUrls={{ canonical: canonicalDefaultUrl }}
 				/>
 			</div>
 		</div>

--- a/apps/webapp/src/app/[locale]/(app)/team/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/team/actions.ts
@@ -2,10 +2,12 @@
 
 import { and, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
+import { unstable_cache } from "next/cache";
 import { headers } from "next/headers";
 import { db } from "@/db";
 import { employee, employeeManagers } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { CACHE_TAGS } from "@/lib/cache/tags";
 import { AuthorizationError, NotFoundError } from "@/lib/effect/errors";
 import { runServerActionSafe, type ServerActionResult } from "@/lib/effect/result";
 import { AppLayer } from "@/lib/effect/runtime";
@@ -49,6 +51,146 @@ export async function getCurrentEmployee(): Promise<CurrentTeamEmployee | null> 
 	}
 
 	return null;
+}
+
+function getCachedCalendarManagedEmployeeRecords(organizationId: string, managerId: string) {
+	return unstable_cache(
+		async () => {
+			return await db.query.employeeManagers.findMany({
+				where: and(
+					eq(employeeManagers.managerId, managerId),
+					inArray(
+						employeeManagers.employeeId,
+						db
+							.select({ id: employee.id })
+							.from(employee)
+							.where(eq(employee.organizationId, organizationId)),
+					),
+				),
+				with: {
+					employee: {
+						with: {
+							user: true,
+							team: true,
+						},
+					},
+				},
+			});
+		},
+		["calendar-managed-employees", organizationId, managerId],
+		{
+			revalidate: 5 * 60,
+			tags: [CACHE_TAGS.EMPLOYEES(organizationId)],
+		},
+	)();
+}
+
+/**
+ * Lightweight employee list for the calendar selector.
+ * Avoids team-page balance refresh work and caches the manager relationship lookup.
+ */
+export async function getCalendarManagedEmployees(): Promise<
+	ServerActionResult<ManagedEmployee[]>
+> {
+	const effect = Effect.gen(function* (_) {
+		const session = yield* _(
+			Effect.promise(async () => auth.api.getSession({ headers: await headers() })),
+		);
+		if (!session?.user) {
+			return yield* _(
+				Effect.fail(
+					new NotFoundError({
+						message: "Employee profile not found",
+						entityType: "employee",
+					}),
+				),
+			);
+		}
+
+		const activeOrgId = session.session?.activeOrganizationId;
+		const currentEmp = activeOrgId
+			? yield* _(
+					Effect.promise(async () => {
+						return await db.query.employee.findFirst({
+							where: (e, { and, eq }) =>
+								and(
+									eq(e.userId, session.user.id),
+									eq(e.organizationId, activeOrgId),
+									eq(e.isActive, true),
+								),
+							with: { user: true, team: true },
+						});
+					}),
+				)
+			: null;
+
+		if (!currentEmp) {
+			return yield* _(
+				Effect.fail(
+					new NotFoundError({
+						message: "Employee profile not found",
+						entityType: "employee",
+					}),
+				),
+			);
+		}
+
+		if (!canUseTeamPage(currentEmp.role)) {
+			return yield* _(
+				Effect.fail(
+					new AuthorizationError({
+						message: "Not authorized",
+						resource: "calendar_employees",
+						action: "read",
+					}),
+				),
+			);
+		}
+
+		const records = yield* _(
+			Effect.promise(() =>
+				getCachedCalendarManagedEmployeeRecords(currentEmp.organizationId, currentEmp.id),
+			),
+		);
+		const typedRecords = records as unknown as ManagedEmployeeRecord[];
+		const byId = new Map<string, ManagedEmployee>();
+
+		for (const record of typedRecords) {
+			if (record.employee.organizationId !== currentEmp.organizationId) continue;
+			if (record.employee.id === currentEmp.id) continue;
+
+			byId.set(record.employee.id, {
+				id: record.employee.id,
+				userId: record.employee.userId,
+				firstName: record.employee.user.firstName,
+				lastName: record.employee.user.lastName,
+				pronouns: record.employee.pronouns,
+				position: record.employee.position,
+				role: record.employee.role,
+				isActive: record.employee.isActive,
+				isPrimaryManager: record.isPrimary,
+				isCurrentUser: false,
+				timeBalance: null,
+				user: {
+					id: record.employee.user.id,
+					firstName: record.employee.user.firstName,
+					lastName: record.employee.user.lastName,
+					name: record.employee.user.name,
+					email: record.employee.user.email,
+					image: record.employee.user.image,
+				},
+				team: record.employee.team
+					? { id: record.employee.team.id, name: record.employee.team.name }
+					: null,
+			});
+		}
+
+		return [...byId.values()].sort((a, b) =>
+			(a.user.name || a.user.email).localeCompare(b.user.name || b.user.email),
+		);
+	});
+
+	return runServerActionSafe(effect);
 }
 
 /**

--- a/apps/webapp/src/components/app-search.test.tsx
+++ b/apps/webapp/src/components/app-search.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppSearchResult } from "@/lib/app-search/types";
 
@@ -190,6 +191,17 @@ describe("AppSearch", () => {
 				options: { preventDefault: true },
 			}),
 		);
+	});
+
+	it("server-renders a hydration-stable shortcut label", () => {
+		const markup = renderToString(
+			<SidebarProvider>
+				<AppSearch staticCommands={staticCommands} staticResults={staticResults} />
+			</SidebarProvider>,
+		);
+
+		expect(markup).toContain("Ctrl+K");
+		expect(markup).not.toContain("⌘ K");
 	});
 
 	it("shows the OS-aware search shortcut in the main menu", async () => {

--- a/apps/webapp/src/components/app-search.tsx
+++ b/apps/webapp/src/components/app-search.tsx
@@ -45,6 +45,7 @@ const EMPTY_LIVE_RESULTS: LiveAppSearchResults = {
 };
 
 const SEARCH_HOTKEY = "Mod+K";
+const SEARCH_HOTKEY_FALLBACK_LABEL = "Ctrl+K";
 
 const EMPTY_STATIC_COMMANDS: AppSearchResult[] = [];
 
@@ -177,11 +178,15 @@ export function AppSearch({
 	const visibleLiveResults = shouldSearchLiveRecords ? liveResults : EMPTY_LIVE_RESULTS;
 	const visibleLiveError = shouldSearchLiveRecords ? liveError : null;
 
-	const searchShortcutLabel = formatForDisplay(SEARCH_HOTKEY);
+	const [searchShortcutLabel, setSearchShortcutLabel] = useState(SEARCH_HOTKEY_FALLBACK_LABEL);
 
 	useHotkey(SEARCH_HOTKEY, () => setOpen((currentOpen) => !currentOpen), {
 		preventDefault: true,
 	});
+
+	useEffect(() => {
+		setSearchShortcutLabel(formatForDisplay(SEARCH_HOTKEY));
+	}, []);
 
 	useEffect(() => {
 		if (!shouldSearchLiveRecords) {

--- a/apps/webapp/src/components/calendar/calendar-filters.test.tsx
+++ b/apps/webapp/src/components/calendar/calendar-filters.test.tsx
@@ -1,0 +1,52 @@
+/** @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CalendarFilters } from "@/hooks/use-calendar-data";
+import { CalendarFiltersComponent } from "./calendar-filters";
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, fallback: string) => fallback,
+	}),
+}));
+
+const filters: CalendarFilters = {
+	showHolidays: true,
+	showAbsences: true,
+	showTimeEntries: false,
+	showWorkPeriods: true,
+};
+
+describe("CalendarFiltersComponent", () => {
+	it("uses prefixed switch ids to avoid duplicates when rendered twice", () => {
+		render(
+			<>
+				<CalendarFiltersComponent
+					filters={filters}
+					onFiltersChange={vi.fn()}
+					idPrefix="calendar-desktop"
+				/>
+				<CalendarFiltersComponent
+					filters={filters}
+					onFiltersChange={vi.fn()}
+					idPrefix="calendar-mobile"
+				/>
+			</>,
+		);
+
+		const switchIds = screen.getAllByRole("switch").map((control) => control.id);
+
+		expect(switchIds).toEqual([
+			"calendar-desktop-show-holidays",
+			"calendar-desktop-show-absences",
+			"calendar-desktop-show-time-entries",
+			"calendar-desktop-show-work-periods",
+			"calendar-mobile-show-holidays",
+			"calendar-mobile-show-absences",
+			"calendar-mobile-show-time-entries",
+			"calendar-mobile-show-work-periods",
+		]);
+		expect(new Set(switchIds).size).toBe(switchIds.length);
+	});
+});

--- a/apps/webapp/src/components/calendar/calendar-filters.tsx
+++ b/apps/webapp/src/components/calendar/calendar-filters.tsx
@@ -10,10 +10,20 @@ interface CalendarFiltersProps {
 	filters: CalendarFilters;
 	onFiltersChange: (filters: CalendarFilters) => void;
 	currentEmployeeId?: string;
+	idPrefix?: string;
 }
 
-export function CalendarFiltersComponent({ filters, onFiltersChange }: CalendarFiltersProps) {
+export function CalendarFiltersComponent({
+	filters,
+	onFiltersChange,
+	idPrefix,
+}: CalendarFiltersProps) {
 	const { t } = useTranslate();
+	const getSwitchId = (id: string) => (idPrefix ? `${idPrefix}-${id}` : id);
+	const holidaysId = getSwitchId("show-holidays");
+	const absencesId = getSwitchId("show-absences");
+	const timeEntriesId = getSwitchId("show-time-entries");
+	const workPeriodsId = getSwitchId("show-work-periods");
 
 	const handleToggle = (key: keyof CalendarFilters) => {
 		onFiltersChange({
@@ -29,41 +39,41 @@ export function CalendarFiltersComponent({ filters, onFiltersChange }: CalendarF
 			</CardHeader>
 			<CardContent className="space-y-3 px-4 py-3">
 				<div className="flex items-center justify-between">
-					<Label htmlFor="show-holidays" className="text-sm">
+					<Label htmlFor={holidaysId} className="text-sm">
 						{t("calendar.filter.holidays", "Holidays")}
 					</Label>
 					<Switch
-						id="show-holidays"
+						id={holidaysId}
 						checked={filters.showHolidays}
 						onCheckedChange={() => handleToggle("showHolidays")}
 					/>
 				</div>
 				<div className="flex items-center justify-between">
-					<Label htmlFor="show-absences" className="text-sm">
+					<Label htmlFor={absencesId} className="text-sm">
 						{t("calendar.filter.absences", "Absences")}
 					</Label>
 					<Switch
-						id="show-absences"
+						id={absencesId}
 						checked={filters.showAbsences}
 						onCheckedChange={() => handleToggle("showAbsences")}
 					/>
 				</div>
 				<div className="flex items-center justify-between">
-					<Label htmlFor="show-time-entries" className="text-sm">
+					<Label htmlFor={timeEntriesId} className="text-sm">
 						{t("calendar.filter.timeEntries", "Time Entries")}
 					</Label>
 					<Switch
-						id="show-time-entries"
+						id={timeEntriesId}
 						checked={filters.showTimeEntries}
 						onCheckedChange={() => handleToggle("showTimeEntries")}
 					/>
 				</div>
 				<div className="flex items-center justify-between">
-					<Label htmlFor="show-work-periods" className="text-sm">
+					<Label htmlFor={workPeriodsId} className="text-sm">
 						{t("calendar.filter.workPeriods", "Work Periods")}
 					</Label>
 					<Switch
-						id="show-work-periods"
+						id={workPeriodsId}
 						checked={filters.showWorkPeriods}
 						onCheckedChange={() => handleToggle("showWorkPeriods")}
 					/>

--- a/apps/webapp/src/components/calendar/calendar-view.test.tsx
+++ b/apps/webapp/src/components/calendar/calendar-view.test.tsx
@@ -25,6 +25,12 @@ vi.mock("@/navigation", () => ({
 	useRouter: () => ({ push }),
 }));
 
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, fallback: string) => fallback,
+	}),
+}));
+
 vi.mock("@/components/providers/user-preferences-provider", () => ({
 	useUserTimezone: () => "Europe/Berlin",
 }));
@@ -45,7 +51,13 @@ vi.mock("@/hooks/use-calendar-data", () => ({
 }));
 
 vi.mock("@/components/work-balance/work-balance-card", () => ({
-	WorkBalanceCard: () => <div data-testid="work-balance-card" />,
+	WorkBalanceCard: ({ compact, mobileCompact }: { compact?: boolean; mobileCompact?: boolean }) => (
+		<div
+			data-testid="work-balance-card"
+			data-compact={String(compact)}
+			data-mobile-compact={String(mobileCompact)}
+		/>
+	),
 }));
 
 vi.mock("./calendar-employee-selector", () => ({
@@ -217,6 +229,20 @@ const runningWorkPeriod: CalendarEvent = {
 	},
 };
 
+function setMobileViewport(isMobile: boolean) {
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: query === "(max-width: 767px)" ? isMobile : false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+}
+
 describe("CalendarView", () => {
 	beforeEach(() => {
 		capturedCalendarFilters.length = 0;
@@ -225,6 +251,21 @@ describe("CalendarView", () => {
 		mockCalendarData.isFetching = false;
 		push.mockClear();
 		refetch.mockClear();
+		setMobileViewport(false);
+	});
+
+	it("defaults to week view on desktop", () => {
+		render(<CalendarView organizationId="org-1" currentEmployeeId="employee-1" />);
+
+		expect(screen.getByTestId("schedule-x-wrapper").getAttribute("data-view-mode")).toBe("week");
+	});
+
+	it("defaults to day view on mobile", () => {
+		setMobileViewport(true);
+
+		render(<CalendarView organizationId="org-1" currentEmployeeId="employee-1" />);
+
+		expect(screen.getByTestId("schedule-x-wrapper").getAttribute("data-view-mode")).toBe("day");
 	});
 
 	it("initializes filters from initialSelectedEmployeeId", () => {
@@ -285,6 +326,50 @@ describe("CalendarView", () => {
 		expect(capturedCalendarFilters.at(-1)).toMatchObject({ employeeId: "employee-1" });
 	});
 
+	it("renders desktop sidebar controls and mobile controls sheet trigger in non-year views", () => {
+		render(<CalendarView organizationId="org-1" currentEmployeeId="employee-1" />);
+
+		const desktopControls = screen.getByTestId("calendar-desktop-controls");
+		const mobileControls = screen.getByTestId("calendar-mobile-controls");
+
+		expect(desktopControls.className).toContain("hidden");
+		expect(desktopControls.className).toContain("md:block");
+		expect(mobileControls.className).toContain("md:hidden");
+		const controlsButton = screen.getByRole("button", {
+			name: /^(Filter & Legende|Filters & Legend)$/,
+		});
+
+		expect(controlsButton).toBeTruthy();
+		fireEvent.click(controlsButton);
+		expect(screen.getAllByTestId("calendar-filters")).toHaveLength(2);
+		expect(screen.getAllByTestId("calendar-legend")).toHaveLength(2);
+	});
+
+	it("renders a denser mobile work balance and compact mobile controls trigger", () => {
+		render(<CalendarView organizationId="org-1" currentEmployeeId="employee-1" />);
+
+		const mobileControls = screen.getByTestId("calendar-mobile-controls");
+		const mobileBalance = screen.getByTestId("calendar-mobile-work-balance");
+		const mobileControlsButton = screen.getByRole("button", {
+			name: /^(Filter & Legende|Filters & Legend)$/,
+		});
+
+		expect(mobileControls.className).toContain("space-y-2");
+		expect(mobileBalance.className).toContain("md:hidden");
+		expect(
+			mobileBalance
+				.querySelector("[data-testid='work-balance-card']")
+				?.getAttribute("data-compact"),
+		).toBe("true");
+		expect(
+			mobileBalance
+				.querySelector("[data-testid='work-balance-card']")
+				?.getAttribute("data-mobile-compact"),
+		).toBe("true");
+		expect(mobileControlsButton.className).toContain("h-8");
+		expect(mobileControlsButton.className).toContain("px-3");
+	});
+
 	it("passes completed work periods but not running work periods to month view", () => {
 		mockCalendarData.events = [completedWorkPeriod, runningWorkPeriod];
 
@@ -317,7 +402,7 @@ describe("CalendarView", () => {
 		expect(screen.getByTestId("month-work-summary-view").getAttribute("data-view-mode")).toBe(
 			"month",
 		);
-		expect(screen.getByTestId("work-balance-card")).toBeTruthy();
+		expect(screen.getAllByTestId("work-balance-card")).toHaveLength(2);
 		expect(screen.queryByTestId("schedule-x-wrapper")).toBeNull();
 
 		fireEvent.click(screen.getByRole("button", { name: "Refresh month" }));

--- a/apps/webapp/src/components/calendar/calendar-view.tsx
+++ b/apps/webapp/src/components/calendar/calendar-view.tsx
@@ -1,10 +1,21 @@
 "use client";
 
+import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
+import { useTranslate } from "@tolgee/react";
 import { DateTime } from "luxon";
 import { useState } from "react";
 import type { SelectableEmployee } from "@/components/employee-select/types";
 import { useUserTimezone } from "@/components/providers/user-preferences-provider";
 import { ManualTimeEntryDialog } from "@/components/time-tracking/manual-time-entry-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
 import { WorkBalanceCard } from "@/components/work-balance/work-balance-card";
 import type { CalendarFilters } from "@/hooks/use-calendar-data";
 import { useCalendarData } from "@/hooks/use-calendar-data";
@@ -35,6 +46,14 @@ function isRunningWorkPeriod(event: CalendarEvent): boolean {
 	return event.type === "work_period" && event.metadata.isRunning === true;
 }
 
+function getInitialViewMode(): ViewMode {
+	if (typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches) {
+		return "day";
+	}
+
+	return "week";
+}
+
 interface ManualEntryDefaults {
 	date: string;
 	clockInTime: string;
@@ -47,13 +66,20 @@ export function CalendarView({
 	initialSelectedEmployeeId,
 }: CalendarViewProps) {
 	const router = useRouter();
+	const { t } = useTranslate();
 	const { isManagerOrAbove } = useOrganization();
 	const viewerTimeZone = useUserTimezone();
 	const initialEmployeeId = initialSelectedEmployeeId ?? currentEmployeeId ?? null;
 	const initialFilterEmployeeId = initialEmployeeId ?? undefined;
+	const mobileControlsTitle = t("calendar.mobileControls.title", "Filters & Legend");
+	const mobileControlsDescription = t(
+		"calendar.mobileControls.description",
+		"Choose which calendar entries are visible.",
+	);
 
 	// View mode state
-	const [viewMode, setViewMode] = useState<ViewMode>("week");
+	const [viewMode, setViewMode] = useState<ViewMode>(() => getInitialViewMode());
+	const [mobileControlsOpen, setMobileControlsOpen] = useState(false);
 
 	// Selected employee for calendar view (defaults to current user)
 	const [previousInitialEmployeeId, setPreviousInitialEmployeeId] = useState(initialEmployeeId);
@@ -251,7 +277,7 @@ export function CalendarView({
 			>
 				{/* Filters sidebar - hidden for year view */}
 				{viewMode !== "year" && (
-					<div className="space-y-4 order-2 md:order-1">
+					<div className="space-y-2 order-2 md:order-1 md:space-y-4">
 						{/* Employee selector - replaces team toggle for better performance */}
 						<CalendarEmployeeSelector
 							currentEmployeeId={currentEmployeeId}
@@ -259,13 +285,51 @@ export function CalendarView({
 							onEmployeeChange={handleEmployeeChange}
 							isManagerOrAbove={isManagerOrAbove}
 						/>
-						<WorkBalanceCard balance={workBalance} compact />
-						<CalendarFiltersComponent
-							filters={filters}
-							onFiltersChange={setFilters}
-							currentEmployeeId={currentEmployeeId}
-						/>
-						<CalendarLegend />
+						<div data-testid="calendar-desktop-work-balance" className="hidden md:block">
+							<WorkBalanceCard balance={workBalance} compact />
+						</div>
+						<div data-testid="calendar-mobile-work-balance" className="md:hidden">
+							<WorkBalanceCard balance={workBalance} compact mobileCompact />
+						</div>
+						<div data-testid="calendar-desktop-controls" className="hidden space-y-4 md:block">
+							<CalendarFiltersComponent
+								filters={filters}
+								onFiltersChange={setFilters}
+								currentEmployeeId={currentEmployeeId}
+								idPrefix="calendar-desktop"
+							/>
+							<CalendarLegend />
+						</div>
+						<div data-testid="calendar-mobile-controls" className="space-y-2 md:hidden">
+							<Sheet open={mobileControlsOpen} onOpenChange={setMobileControlsOpen}>
+								<SheetTrigger asChild>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										className="h-8 w-full gap-2 px-3"
+									>
+										<IconAdjustmentsHorizontal className="size-4" />
+										{mobileControlsTitle}
+									</Button>
+								</SheetTrigger>
+								<SheetContent side="bottom" className="max-h-[85dvh] overflow-y-auto">
+									<SheetHeader>
+										<SheetTitle>{mobileControlsTitle}</SheetTitle>
+										<SheetDescription>{mobileControlsDescription}</SheetDescription>
+									</SheetHeader>
+									<div className="space-y-4 p-4 pt-0">
+										<CalendarFiltersComponent
+											filters={filters}
+											onFiltersChange={setFilters}
+											currentEmployeeId={currentEmployeeId}
+											idPrefix="calendar-mobile"
+										/>
+										<CalendarLegend />
+									</div>
+								</SheetContent>
+							</Sheet>
+						</div>
 					</div>
 				)}
 

--- a/apps/webapp/src/components/calendar/schedule-x-calendar.test.tsx
+++ b/apps/webapp/src/components/calendar/schedule-x-calendar.test.tsx
@@ -2,9 +2,11 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
 import { DateTime } from "luxon";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorkPeriodEvent } from "@/lib/calendar/types";
+import { ScheduleXCalendarWrapper } from "./schedule-x-calendar";
 import {
 	buildCalendarTimeZoneDate,
 	buildCurrentTimeIndicatorPosition,
@@ -15,6 +17,50 @@ import {
 	resolveClickableCalendarEvent,
 	shouldRetryRequirementHeaderInjection,
 } from "./schedule-x-calendar-utils";
+
+const useCalendarAppMock = vi.hoisted(() =>
+	vi.fn(() => ({
+		events: { set: vi.fn() },
+		setTheme: vi.fn(),
+	})),
+);
+
+vi.mock("@schedule-x/calendar", () => ({
+	createViewDay: () => "day",
+	createViewMonthAgenda: () => "month-agenda",
+	createViewMonthGrid: () => "month-grid",
+	createViewWeek: () => "week",
+}));
+
+vi.mock("@schedule-x/calendar-controls", () => ({
+	createCalendarControlsPlugin: () => ({
+		setDate: vi.fn(),
+		setView: vi.fn(),
+	}),
+}));
+
+vi.mock("@schedule-x/event-modal", () => ({
+	createEventModalPlugin: () => ({}),
+}));
+
+vi.mock("@schedule-x/react", () => ({
+	ScheduleXCalendar: () => <div data-testid="schedule-x-calendar" />,
+	useCalendarApp: useCalendarAppMock,
+}));
+
+vi.mock("@/components/providers/user-preferences-provider", () => ({
+	useUserTimezone: () => "Europe/Berlin",
+	useWeekStartDay: () => 1,
+}));
+
+vi.mock("@/components/theme-provider", () => ({
+	useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("@tolgee/react", () => ({
+	useTolgee: () => ({ getLanguage: () => "en" }),
+	useTranslate: () => ({ t: (_key: string, fallback: string) => fallback }),
+}));
 
 const completedWorkPeriod: WorkPeriodEvent = {
 	id: "work-completed",
@@ -41,6 +87,53 @@ const runningWorkPeriod: WorkPeriodEvent = {
 		isRunning: true,
 	},
 };
+
+beforeEach(() => {
+	useCalendarAppMock.mockClear();
+});
+
+describe("ScheduleXCalendarWrapper header", () => {
+	it("renders separate desktop and mobile headers with compact mobile week text", () => {
+		render(
+			<ScheduleXCalendarWrapper
+				events={[]}
+				onRefresh={vi.fn()}
+				onViewModeChange={vi.fn()}
+				viewMode="week"
+			/>,
+		);
+
+		const desktopHeader = screen.getByTestId("calendar-desktop-header");
+		const mobileHeader = screen.getByTestId("calendar-mobile-header");
+		const mobileDateRange = screen.getByTestId("calendar-mobile-date-range");
+		const mobileControls = screen.getByTestId("calendar-mobile-header-controls");
+
+		expect(desktopHeader.classList.contains("hidden")).toBe(true);
+		expect(desktopHeader.classList.contains("lg:flex")).toBe(true);
+		expect(mobileHeader.classList.contains("lg:hidden")).toBe(true);
+		expect(mobileDateRange.classList.contains("whitespace-nowrap")).toBe(true);
+		expect(mobileDateRange.classList.contains("truncate")).toBe(true);
+		expect(mobileControls.classList.contains("overflow-x-auto")).toBe(true);
+		expect(mobileControls.classList.contains("whitespace-nowrap")).toBe(true);
+		expect(mobileDateRange.textContent).not.toMatch(/, \d{4}$/);
+	});
+
+	it("uses the parent-provided initial view without Schedule-X responsive view coercion", () => {
+		render(
+			<ScheduleXCalendarWrapper
+				events={[]}
+				onRefresh={vi.fn()}
+				onViewModeChange={vi.fn()}
+				viewMode="day"
+			/>,
+		);
+
+		const calendarConfig = useCalendarAppMock.mock.calls[0]?.[0];
+
+		expect(calendarConfig.defaultView).toBe("day");
+		expect(calendarConfig.isResponsive).toBe(false);
+	});
+});
 
 describe("filterEventsForScheduleXView", () => {
 	it("keeps running work periods in day and week views", () => {

--- a/apps/webapp/src/components/calendar/schedule-x-calendar.tsx
+++ b/apps/webapp/src/components/calendar/schedule-x-calendar.tsx
@@ -279,6 +279,29 @@ export function ScheduleXCalendarWrapper({
 		}
 	})();
 
+	const mobileDateRangeDisplay = (() => {
+		const localizedCurrentDate = currentDate.setLocale(locale);
+
+		switch (viewMode) {
+			case "day":
+				return localizedCurrentDate.toFormat("ccc, d. LLL yyyy");
+			case "week": {
+				const { start: weekStart, end: weekEnd } = getWeekBounds(
+					localizedCurrentDate,
+					weekStartDay,
+				);
+				if (weekStart.year === weekEnd.year) {
+					return `${weekStart.toFormat("d. LLL")} - ${weekEnd.toFormat("d. LLL yyyy")}`;
+				}
+				return `${weekStart.toFormat("d. LLL yyyy")} - ${weekEnd.toFormat("d. LLL yyyy")}`;
+			}
+			case "month":
+				return localizedCurrentDate.toFormat("LLL yyyy");
+			default:
+				return localizedCurrentDate.toFormat("d. LLL yyyy");
+		}
+	})();
+
 	const visibleRequirementDates = (() => {
 		if (viewMode === "day") return [currentDate.startOf("day")];
 		if (viewMode === "week") {
@@ -329,6 +352,7 @@ export function ScheduleXCalendarWrapper({
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		events: scheduleXEvents as any,
 		isDark,
+		isResponsive: false,
 		locale: scheduleXLocale,
 		calendars: getScheduleXCalendars(),
 		plugins: [createEventModalPlugin(), calendarControls],
@@ -595,7 +619,10 @@ export function ScheduleXCalendarWrapper({
 	return (
 		<div className="flex flex-col h-full min-h-[500px]">
 			{/* Custom navigation header */}
-			<div className="flex items-center justify-between gap-4 pb-3 mb-3">
+			<div
+				data-testid="calendar-desktop-header"
+				className="hidden items-center justify-between gap-4 pb-3 mb-3 lg:flex"
+			>
 				<div className="flex items-center gap-2">
 					<Button
 						variant="outline"
@@ -637,6 +664,59 @@ export function ScheduleXCalendarWrapper({
 						<TabsTrigger value="year">{t("calendar.view.year", "Year")}</TabsTrigger>
 					</TabsList>
 				</Tabs>
+			</div>
+			<div data-testid="calendar-mobile-header" className="pb-3 mb-3 lg:hidden">
+				<h2
+					data-testid="calendar-mobile-date-range"
+					className="mb-2 truncate whitespace-nowrap text-lg font-semibold"
+				>
+					{mobileDateRangeDisplay}
+				</h2>
+				<div
+					data-testid="calendar-mobile-header-controls"
+					className="overflow-x-auto whitespace-nowrap"
+				>
+					<div className="flex w-max items-center gap-2">
+						<Button
+							variant="outline"
+							size="icon"
+							onClick={navigatePrevious}
+							aria-label={t("calendar.view.previous", "Previous")}
+						>
+							<IconChevronLeft className="size-4" />
+						</Button>
+						<Button
+							variant="outline"
+							size="icon"
+							onClick={navigateNext}
+							aria-label={t("calendar.view.next", "Next")}
+						>
+							<IconChevronRight className="size-4" />
+						</Button>
+						<Button variant="outline" size="sm" onClick={navigateToday}>
+							{t("calendar.view.today", "Today")}
+						</Button>
+						{onRefresh && (
+							<Button
+								variant="outline"
+								size="icon"
+								onClick={onRefresh}
+								aria-label={t("calendar.view.refresh", "Refresh")}
+								title={t("calendar.view.refresh", "Refresh")}
+							>
+								<IconReload className="size-4" />
+							</Button>
+						)}
+						<Tabs value={viewMode} onValueChange={(v) => onViewModeChange(v as ViewMode)}>
+							<TabsList>
+								<TabsTrigger value="day">{t("calendar.view.day", "Day")}</TabsTrigger>
+								<TabsTrigger value="week">{t("calendar.view.week", "Week")}</TabsTrigger>
+								<TabsTrigger value="month">{t("calendar.view.month", "Month")}</TabsTrigger>
+								<TabsTrigger value="year">{t("calendar.view.year", "Year")}</TabsTrigger>
+							</TabsList>
+						</Tabs>
+					</div>
+				</div>
 			</div>
 
 			{/* Calendar with internal scroll - styles applied via style tag above */}

--- a/apps/webapp/src/components/employee-select/employee-select-modal.test.tsx
+++ b/apps/webapp/src/components/employee-select/employee-select-modal.test.tsx
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("EmployeeSelectModal layout", () => {
+	it("lets the employee list fill the available sheet height", () => {
+		const source = readFileSync(resolve(__dirname, "employee-select-modal.tsx"), "utf8");
+
+		expect(source).not.toContain("max-h-[320px]");
+		expect(source).toContain("flex-1 min-h-0 overflow-y-auto");
+	});
+});

--- a/apps/webapp/src/components/employee-select/employee-select-modal.tsx
+++ b/apps/webapp/src/components/employee-select/employee-select-modal.tsx
@@ -261,7 +261,7 @@ export function EmployeeSelectModal({
 					<CommandPrimitive
 						shouldFilter={false}
 						className={cn(
-							"bg-popover text-popover-foreground flex h-full flex-col overflow-hidden",
+							"bg-popover text-popover-foreground flex h-full min-h-0 flex-col overflow-hidden",
 							"border-0",
 						)}
 					>
@@ -412,7 +412,7 @@ export function EmployeeSelectModal({
 						{/* Employee list */}
 						<CommandPrimitive.List
 							id={listboxId}
-							className="max-h-[320px] overflow-y-auto overflow-x-hidden scroll-py-2 p-2"
+							className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scroll-py-2 p-2"
 						>
 							<EmployeeSelectList
 								employees={employees}

--- a/apps/webapp/src/components/notifications/notification-popover.test.tsx
+++ b/apps/webapp/src/components/notifications/notification-popover.test.tsx
@@ -1,0 +1,152 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationPopover } from "@/components/notifications/notification-popover";
+import { useNotifications } from "@/hooks/use-notifications";
+import { useOrganization } from "@/hooks/use-organization";
+
+vi.mock("@/hooks/use-notifications", () => ({
+	useNotifications: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-organization", () => ({
+	useOrganization: vi.fn(),
+}));
+
+vi.mock("@tolgee/react", () => ({
+	useTranslate: () => ({
+		t: (_key: string, defaultValue: string) => defaultValue,
+	}),
+}));
+
+vi.mock("@/navigation", () => ({
+	Link: ({ href, children, ...props }: ComponentProps<"a">) => (
+		<a href={String(href)} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+vi.mock("@/components/ui/sheet", async () => {
+	const React = await import("react");
+	const SheetContext = React.createContext<{
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+	} | null>(null);
+
+	return {
+		Sheet: ({
+			open,
+			onOpenChange,
+			children,
+		}: {
+			open: boolean;
+			onOpenChange: (open: boolean) => void;
+			children: React.ReactNode;
+		}) => (
+			<SheetContext.Provider value={{ open, onOpenChange }}>{children}</SheetContext.Provider>
+		),
+		SheetContent: ({
+			side,
+			className,
+			showCloseButton = true,
+			children,
+		}: {
+			side: string;
+			className?: string;
+			showCloseButton?: boolean;
+			children: React.ReactNode;
+		}) => {
+			const context = React.useContext(SheetContext);
+
+			if (!context?.open) {
+				return null;
+			}
+
+			return (
+				<div aria-label="Notifications" className={className} data-side={side} role="dialog">
+					{showCloseButton && <button type="button">Close</button>}
+					{children}
+				</div>
+			);
+		},
+		SheetDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+		SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+		SheetTrigger: ({ children }: { children: React.ReactElement<{ onClick?: () => void }> }) => {
+			const context = React.useContext(SheetContext);
+
+			return React.cloneElement(children, {
+				"data-slot": "sheet-trigger",
+				onClick: () => context?.onOpenChange(true),
+			});
+		},
+	};
+});
+
+const useNotificationsMock = vi.mocked(useNotifications);
+const useOrganizationMock = vi.mocked(useOrganization);
+
+function mockNotificationDependencies() {
+	useOrganizationMock.mockReturnValue({
+		organizationId: "org_123",
+		employeeId: "emp_123",
+		role: "employee",
+		isLoading: false,
+		error: null,
+		isAdmin: false,
+		isManager: false,
+		isManagerOrAbove: false,
+		refetch: vi.fn(),
+	});
+
+	useNotificationsMock.mockReturnValue({
+		notifications: [],
+		total: 0,
+		hasMore: false,
+		isLoading: false,
+		isFetching: false,
+		isError: false,
+		unreadCount: 0,
+		isLoadingCount: false,
+		markAsRead: vi.fn(),
+		markAllAsRead: vi.fn(),
+		deleteNotification: vi.fn(),
+		deleteAllNotifications: vi.fn(),
+		isMarkingRead: false,
+		isMarkingAllRead: false,
+		isDeleting: false,
+		isDeletingAll: false,
+		refresh: vi.fn(),
+	});
+}
+
+describe("NotificationPopover", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockNotificationDependencies();
+	});
+
+	it("opens notifications in a top sheet from the mobile trigger", async () => {
+		const user = userEvent.setup();
+
+		render(
+			<NotificationPopover>
+				<button type="button">Open notifications</button>
+			</NotificationPopover>,
+		);
+
+		await user.click(screen.getAllByRole("button", { name: "Open notifications" })[0]);
+
+		const sheetContent = await waitFor(() =>
+			screen.getByRole("dialog", { name: "Notifications" }),
+		);
+		expect(sheetContent).toBeTruthy();
+		expect(sheetContent.getAttribute("data-side")).toBe("top");
+		expect(sheetContent.className).toContain("max-h-[85dvh]");
+		expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+		expect(screen.getByText("No notifications")).toBeTruthy();
+	});
+});

--- a/apps/webapp/src/components/notifications/notification-popover.tsx
+++ b/apps/webapp/src/components/notifications/notification-popover.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { useNotifications } from "@/hooks/use-notifications";
 import { useOrganization } from "@/hooks/use-organization";
 import { Link } from "@/navigation";
@@ -17,9 +18,11 @@ interface NotificationPopoverProps {
 
 export function NotificationPopover({ children }: NotificationPopoverProps) {
 	const { t } = useTranslate();
-	const [open, setOpen] = useState(false);
+	const [mobileOpen, setMobileOpen] = useState(false);
+	const [desktopOpen, setDesktopOpen] = useState(false);
 	const { organizationId } = useOrganization();
 	const hasOrganization = Boolean(organizationId);
+	const isOpen = mobileOpen || desktopOpen;
 
 	const {
 		notifications,
@@ -31,7 +34,7 @@ export function NotificationPopover({ children }: NotificationPopoverProps) {
 		deleteAllNotifications,
 		isMarkingAllRead,
 		isDeletingAll,
-	} = useNotifications({ enabled: open && hasOrganization, organizationId });
+	} = useNotifications({ enabled: isOpen && hasOrganization, organizationId });
 
 	const handleMarkAsRead = async (id: string) => {
 		try {
@@ -66,92 +69,122 @@ export function NotificationPopover({ children }: NotificationPopoverProps) {
 	};
 
 	const handleClose = () => {
-		setOpen(false);
+		setMobileOpen(false);
+		setDesktopOpen(false);
 	};
 
-	return (
-		<Popover open={open} onOpenChange={setOpen}>
-			<PopoverTrigger asChild>{children}</PopoverTrigger>
-			<PopoverContent className="w-96 p-0" align="end" sideOffset={8}>
-				{/* Header */}
-				<div className="flex items-center justify-between px-4 py-3">
-					<div className="flex items-center gap-2">
-						<h3 className="font-semibold">{t("common:notifications.title", "Notifications")}</h3>
-						{unreadCount > 0 && (
-							<span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
-								{unreadCount > 99
-									? t("common:notifications.unreadCountOverflow", "99+")
-									: unreadCount}
+	const notificationContent = (
+		<>
+			<div className="flex items-center justify-between px-4 py-3">
+				<div className="flex items-center gap-2">
+					<h3 className="font-semibold">{t("common:notifications.title", "Notifications")}</h3>
+					{unreadCount > 0 && (
+						<span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+							{unreadCount > 99
+								? t("common:notifications.unreadCountOverflow", "99+")
+								: unreadCount}
+						</span>
+					)}
+				</div>
+				<div className="flex items-center gap-1">
+					{unreadCount > 0 && (
+						<Button
+							size="icon"
+							variant="ghost"
+							className="size-8"
+							onClick={handleMarkAllAsRead}
+							disabled={isMarkingAllRead}
+							aria-label={t("common:notifications.actions.markAllRead", "Mark all read")}
+							title={t("common:notifications.actions.markAllRead", "Mark all read")}
+						>
+							<IconChecks className="size-4" />
+						</Button>
+					)}
+					{notifications.length > 0 && (
+						<Button
+							size="icon"
+							variant="ghost"
+							className="size-8 text-muted-foreground hover:text-destructive"
+							onClick={handleDeleteAll}
+							disabled={isDeletingAll}
+							aria-label={t("common:notifications.actions.deleteAll", "Delete all")}
+							title={t("common:notifications.actions.deleteAll", "Delete all")}
+						>
+							<IconTrash className="size-4" />
+						</Button>
+					)}
+					<Button size="icon" variant="ghost" className="size-8" asChild onClick={handleClose}>
+						<Link
+							href="/settings/notifications"
+							aria-label={t("common:notifications.actions.settings", "Notification settings")}
+							title={t("common:notifications.actions.settings", "Notification settings")}
+						>
+							<IconSettings className="size-4" />
+							<span className="sr-only">
+								{t("common:notifications.actions.settings", "Notification settings")}
 							</span>
-						)}
-					</div>
-					<div className="flex items-center gap-1">
-						{unreadCount > 0 && (
-							<Button
-								size="icon"
-								variant="ghost"
-								className="size-8"
-								onClick={handleMarkAllAsRead}
-								disabled={isMarkingAllRead}
-								aria-label={t("common:notifications.actions.markAllRead", "Mark all read")}
-								title={t("common:notifications.actions.markAllRead", "Mark all read")}
-							>
-								<IconChecks className="size-4" />
-							</Button>
-						)}
-						{notifications.length > 0 && (
-							<Button
-								size="icon"
-								variant="ghost"
-								className="size-8 text-muted-foreground hover:text-destructive"
-								onClick={handleDeleteAll}
-								disabled={isDeletingAll}
-								aria-label={t("common:notifications.actions.deleteAll", "Delete all")}
-								title={t("common:notifications.actions.deleteAll", "Delete all")}
-							>
-								<IconTrash className="size-4" />
-							</Button>
-						)}
-						<Button size="icon" variant="ghost" className="size-8" asChild onClick={handleClose}>
-							<Link
-								href="/settings/notifications"
-								aria-label={t("common:notifications.actions.settings", "Notification settings")}
-								title={t("common:notifications.actions.settings", "Notification settings")}
-							>
-								<IconSettings className="size-4" />
-								<span className="sr-only">
-									{t("common:notifications.actions.settings", "Notification settings")}
-								</span>
+						</Link>
+					</Button>
+				</div>
+			</div>
+
+			<Separator />
+
+			<NotificationList
+				notifications={notifications}
+				isLoading={isLoading}
+				onMarkAsRead={handleMarkAsRead}
+				onDelete={handleDelete}
+				onClose={handleClose}
+			/>
+
+			{notifications.length > 0 && (
+				<>
+					<Separator />
+					<div className="p-2">
+						<Button variant="ghost" className="w-full text-sm" asChild onClick={handleClose}>
+							<Link href="/notifications">
+								{t("common:notifications.actions.viewAll", "View all notifications")}
 							</Link>
 						</Button>
 					</div>
-				</div>
+				</>
+			)}
+		</>
+	);
 
-				<Separator />
+	return (
+		<>
+			<div className="md:hidden">
+				<Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+					<SheetTrigger asChild>{children}</SheetTrigger>
+					<SheetContent
+						side="top"
+						className="max-h-[85dvh] gap-0 overflow-hidden p-0"
+						showCloseButton={false}
+					>
+						<SheetTitle className="sr-only">
+							{t("common:notifications.title", "Notifications")}
+						</SheetTitle>
+						<SheetDescription className="sr-only">
+							{t(
+								"common:notifications.description",
+								"Review recent notifications and notification actions.",
+							)}
+						</SheetDescription>
+						{notificationContent}
+					</SheetContent>
+				</Sheet>
+			</div>
 
-				{/* Notification List */}
-				<NotificationList
-					notifications={notifications}
-					isLoading={isLoading}
-					onMarkAsRead={handleMarkAsRead}
-					onDelete={handleDelete}
-					onClose={handleClose}
-				/>
-
-				{/* Footer */}
-				{notifications.length > 0 && (
-					<>
-						<Separator />
-						<div className="p-2">
-							<Button variant="ghost" className="w-full text-sm" asChild onClick={handleClose}>
-								<Link href="/notifications">
-									{t("common:notifications.actions.viewAll", "View all notifications")}
-								</Link>
-							</Button>
-						</div>
-					</>
-				)}
-			</PopoverContent>
-		</Popover>
+			<div className="hidden md:block">
+				<Popover open={desktopOpen} onOpenChange={setDesktopOpen}>
+					<PopoverTrigger asChild>{children}</PopoverTrigger>
+					<PopoverContent className="w-96 p-0" align="end" sideOffset={8}>
+						{notificationContent}
+					</PopoverContent>
+				</Popover>
+			</div>
+		</>
 	);
 }

--- a/apps/webapp/src/components/settings/enterprise/domain-management.tsx
+++ b/apps/webapp/src/components/settings/enterprise/domain-management.tsx
@@ -54,7 +54,6 @@ interface DomainManagementProps {
 	organizationId: string;
 	defaultUrls: {
 		canonical: string;
-		alias: string;
 	};
 }
 
@@ -201,10 +200,6 @@ export function DomainManagement({
 						{
 							label: t("settings.enterprise.domains.defaultUrl.canonical", "Canonical"),
 							url: defaultUrls.canonical,
-						},
-						{
-							label: t("settings.enterprise.domains.defaultUrl.alias", "Organization ID alias"),
-							url: defaultUrls.alias,
 						},
 					].map(({ label, url }) => (
 						<div

--- a/apps/webapp/src/components/settings/enterprise/domains-branding-tabs.tsx
+++ b/apps/webapp/src/components/settings/enterprise/domains-branding-tabs.tsx
@@ -40,7 +40,6 @@ interface DomainsAndBrandingTabsProps {
 	organizationId: string;
 	defaultUrls: {
 		canonical: string;
-		alias: string;
 	};
 }
 

--- a/apps/webapp/src/components/work-balance/work-balance-card.tsx
+++ b/apps/webapp/src/components/work-balance/work-balance-card.tsx
@@ -9,20 +9,33 @@ import type { EmployeeWorkBalancePayload } from "@/lib/work-balance/types";
 interface WorkBalanceCardProps {
 	balance: EmployeeWorkBalancePayload | null;
 	compact?: boolean;
+	mobileCompact?: boolean;
 }
 
-export function WorkBalanceCard({ balance, compact = false }: WorkBalanceCardProps) {
+export function WorkBalanceCard({
+	balance,
+	compact = false,
+	mobileCompact = false,
+}: WorkBalanceCardProps) {
 	const { t } = useTranslate();
 	const status = balance ? getWorkBalanceStatus(balance.balanceMinutes) : "neutral";
 
 	return (
-		<Card className={compact ? "min-w-52 gap-0 overflow-hidden py-0" : undefined}>
-			<CardHeader className={compact ? "bg-muted/45 px-4 py-3 dark:bg-muted/25" : undefined}>
+		<Card
+			className={cn(compact && "min-w-52 gap-0 overflow-hidden py-0", mobileCompact && "min-w-0")}
+		>
+			<CardHeader
+				className={cn(
+					compact && "bg-muted/45 px-4 py-3 dark:bg-muted/25",
+					mobileCompact && "flex-row items-center justify-between gap-3 px-3 py-2",
+				)}
+			>
 				<CardDescription>{t("workBalance.label", "All-time balance")}</CardDescription>
 				<CardTitle
 					className={cn(
 						"tabular-nums text-2xl",
 						compact && "text-xl",
+						mobileCompact && "text-lg",
 						status === "positive" && "text-emerald-600 dark:text-emerald-400",
 						status === "negative" && "text-destructive",
 					)}
@@ -31,7 +44,7 @@ export function WorkBalanceCard({ balance, compact = false }: WorkBalanceCardPro
 						? formatSignedWorkBalance(balance.balanceMinutes)
 						: t("workBalance.notCalculated", "Not calculated yet")}
 				</CardTitle>
-				<p className="text-muted-foreground text-xs">
+				<p className={cn("text-muted-foreground text-xs", mobileCompact && "hidden")}>
 					{balance?.computedAt
 						? t("workBalance.updatedEveryThreeHours", "Updated every 3 hours")
 						: t("workBalance.pendingDescription", "The worker will calculate this balance soon.")}

--- a/apps/webapp/src/hooks/use-calendar-employees.test.ts
+++ b/apps/webapp/src/hooks/use-calendar-employees.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const hookSource = readFileSync(
+	fileURLToPath(new URL("./use-calendar-employees.ts", import.meta.url)),
+	"utf8",
+);
+const teamActionsSource = readFileSync(
+	fileURLToPath(new URL("../app/[locale]/(app)/team/actions.ts", import.meta.url)),
+	"utf8",
+);
+
+describe("useCalendarEmployees data source", () => {
+	it("uses a lightweight cached calendar action instead of the team-page balance action", () => {
+		expect(hookSource).toContain("getCalendarManagedEmployees");
+		expect(hookSource).not.toContain("getManagedEmployees");
+		expect(teamActionsSource).toContain("getCalendarManagedEmployees");
+		expect(teamActionsSource).toContain("unstable_cache");
+		expect(teamActionsSource).toContain("CACHE_TAGS.EMPLOYEES(organizationId)");
+
+		const calendarActionBody = teamActionsSource.slice(
+			teamActionsSource.indexOf("export async function getCalendarManagedEmployees"),
+			teamActionsSource.indexOf("export async function getManagedEmployees"),
+		);
+
+		expect(calendarActionBody).not.toContain("refreshEmployeeTimeBalances");
+	});
+});

--- a/apps/webapp/src/hooks/use-calendar-employees.ts
+++ b/apps/webapp/src/hooks/use-calendar-employees.ts
@@ -3,8 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 import {
 	type CurrentTeamEmployee,
+	getCalendarManagedEmployees,
 	getCurrentEmployee,
-	getManagedEmployees,
 	type ManagedEmployee,
 } from "@/app/[locale]/(app)/team/actions";
 import type { SelectableEmployee } from "@/components/employee-select/types";
@@ -102,7 +102,7 @@ export function useCalendarEmployees(currentEmployeeId?: string): UseCalendarEmp
 			// Fetch current employee and managed employees in parallel
 			const [currentEmp, managedResult] = await Promise.all([
 				getCurrentEmployee(),
-				getManagedEmployees(),
+				getCalendarManagedEmployees(),
 			]);
 
 			// Transform current employee if available

--- a/apps/webapp/src/lib/approvals/server/shared.test.ts
+++ b/apps/webapp/src/lib/approvals/server/shared.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Exit, Option } from "effect";
+import { Cause, Context, Effect, Exit, Option } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConflictError, DatabaseError, NotFoundError, ValidationError } from "@/lib/effect/errors";
 
@@ -532,6 +532,90 @@ describe("getApprovalStatusUpdate", () => {
 
 		expect(txInsertValues).toHaveBeenCalledTimes(1);
 		expect(outerInsertValues).not.toHaveBeenCalled();
+	});
+
+	it("preserves caller-provided services inside transactional approval side effects", async () => {
+		class TestApprovalSideEffectService extends Context.Tag("TestApprovalSideEffectService")<
+			TestApprovalSideEffectService,
+			{ readonly run: () => Effect.Effect<void> }
+		>() {}
+
+		const approvalFindFirst = vi.fn().mockResolvedValue({
+			id: "approval-1",
+			entityId: "claim-1",
+			entityType: "travel_expense_claim",
+			approverId: "employee-1",
+			organizationId: "org-1",
+			status: "pending",
+			approvedAt: null,
+			rejectionReason: null,
+			updatedAt: new Date("2026-04-09T09:30:00.000Z"),
+		});
+		const returning = vi.fn().mockResolvedValue([{ id: "approval-1" }]);
+		const where = vi.fn().mockReturnValue({ returning });
+		const set = vi.fn().mockReturnValue({ where });
+		const tx = {
+			query: {
+				approvalRequest: {
+					findFirst: approvalFindFirst,
+				},
+			},
+			update: vi.fn().mockReturnValue({ set }),
+			insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+		};
+		const dbService = DatabaseService.of({
+			db: {
+				query: {
+					approvalRequest: {
+						findFirst: approvalFindFirst,
+					},
+				},
+				update: vi.fn().mockReturnValue({ set }),
+				insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+				transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<void>) => {
+					await callback(tx);
+				}),
+			},
+			query: (_name: string, fn: () => Promise<unknown>) => Effect.promise(fn),
+		});
+		const auditLogger = ApprovalAuditLogger.of({
+			log: vi.fn().mockReturnValue(Effect.void),
+			logBatch: vi.fn(),
+		});
+		const sideEffect = vi.fn().mockReturnValue(Effect.void);
+
+		await Effect.runPromise(
+			processApprovalWithCurrentEmployee(
+				dbService,
+				{
+					id: "employee-1",
+					userId: "user-1",
+					organizationId: "org-1",
+					user: {
+						id: "user-1",
+						name: "Morgan Reviewer",
+						email: "morgan@example.com",
+						image: null,
+					},
+				},
+				"travel_expense_claim",
+				"claim-1",
+				"approve",
+				undefined,
+				() =>
+					Effect.gen(function* (_) {
+						const service = yield* _(TestApprovalSideEffectService);
+						yield* _(service.run());
+					}),
+				undefined,
+				{ transactional: true },
+			).pipe(
+				Effect.provideService(ApprovalAuditLogger, auditLogger),
+				Effect.provideService(TestApprovalSideEffectService, { run: sideEffect }),
+			),
+		);
+
+		expect(sideEffect).toHaveBeenCalledTimes(1);
 	});
 
 	it("continues existing side effects for unlinked approval requests", async () => {

--- a/apps/webapp/src/lib/approvals/server/shared.ts
+++ b/apps/webapp/src/lib/approvals/server/shared.ts
@@ -308,6 +308,7 @@ export function processApprovalWithCurrentEmployee<T>(
 ) {
 	return Effect.gen(function* (_) {
 		const auditLogger = yield* _(ApprovalAuditLogger);
+		const callerContext = yield* _(Effect.context<never>());
 
 		if (!options?.transactional) {
 			return yield* _(
@@ -350,6 +351,7 @@ export function processApprovalWithCurrentEmployee<T>(
 								options,
 							).pipe(
 								Effect.provideService(ApprovalAuditLogger, transactionalAuditLogger),
+								Effect.provide(callerContext),
 							) as Effect.Effect<T | undefined, AnyAppError, never>,
 						);
 

--- a/docs/superpowers/plans/2026-06-02-calendar-mobile-controls-employee-selector.md
+++ b/docs/superpowers/plans/2026-06-02-calendar-mobile-controls-employee-selector.md
@@ -1,0 +1,267 @@
+# Calendar Mobile Controls And Employee Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move calendar filters and legend into a mobile-only bottom sheet and make the employee selector list fill the available sheet height.
+
+**Architecture:** Keep calendar data and filter state in `CalendarView`. Add a mobile-only controls sheet that reuses the existing `CalendarFiltersComponent` and `CalendarLegend`, while preserving the current desktop sidebar. Fix `EmployeeSelectModal` layout by making the command/list region flex instead of using a fixed maximum list height.
+
+**Tech Stack:** Next.js client components, React state, Tailwind CSS, existing Z8 UI primitives (`Button`, `Sheet`, `Card`), Vitest, Testing Library.
+
+---
+
+## File Structure
+
+- Modify `apps/webapp/src/components/calendar/calendar-view.tsx`: add mobile-only bottom sheet state and render filters/legend in a mobile sheet while keeping desktop sidebar unchanged.
+- Modify `apps/webapp/src/components/employee-select/employee-select-modal.tsx`: replace fixed `max-h-[320px]` list sizing with flex-based full-height layout.
+- Modify `apps/webapp/src/components/calendar/calendar-view.test.tsx`: stop mocking filters/legend if needed and assert mobile controls render while desktop sidebar content stays desktop-only.
+- Add or modify `apps/webapp/src/components/employee-select/employee-select-modal.test.tsx`: verify the employee list uses flex-based available-height classes and no longer uses the fixed 320px cap.
+
+### Task 1: Calendar Mobile Controls Sheet
+
+**Files:**
+- Modify: `apps/webapp/src/components/calendar/calendar-view.tsx`
+- Test: `apps/webapp/src/components/calendar/calendar-view.test.tsx`
+
+- [ ] **Step 1: Write the failing calendar layout test**
+
+Update the existing mocks in `apps/webapp/src/components/calendar/calendar-view.test.tsx` so the filter and legend mocks expose their labels, then add this test inside `describe("CalendarView", ...)`:
+
+```tsx
+vi.mock("./calendar-filters", () => ({
+	CalendarFiltersComponent: () => <div data-testid="calendar-filters">Filters</div>,
+}));
+
+vi.mock("./calendar-legend", () => ({
+	CalendarLegend: () => <div data-testid="calendar-legend">Legend</div>,
+}));
+
+it("renders filters and legend in desktop sidebar and mobile controls sheet", () => {
+	render(<CalendarView organizationId="org-1" currentEmployeeId="employee-1" />);
+
+	expect(screen.getByTestId("calendar-desktop-controls")).toHaveClass("hidden");
+	expect(screen.getByTestId("calendar-desktop-controls")).toHaveClass("md:block");
+	expect(screen.getByTestId("calendar-mobile-controls")).toHaveClass("md:hidden");
+	expect(screen.getByRole("button", { name: /filter.*legende|filters.*legend/i })).toBeInTheDocument();
+	expect(screen.getAllByTestId("calendar-filters")).toHaveLength(2);
+	expect(screen.getAllByTestId("calendar-legend")).toHaveLength(2);
+});
+```
+
+- [ ] **Step 2: Run the failing calendar test**
+
+Run:
+
+```bash
+pnpm vitest apps/webapp/src/components/calendar/calendar-view.test.tsx --run
+```
+
+Expected: FAIL because `calendar-desktop-controls`, `calendar-mobile-controls`, and the mobile sheet trigger do not exist yet.
+
+- [ ] **Step 3: Implement the mobile controls sheet**
+
+In `apps/webapp/src/components/calendar/calendar-view.tsx`, add imports:
+
+```tsx
+import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+```
+
+Add state near the other dialog state:
+
+```tsx
+const [mobileControlsOpen, setMobileControlsOpen] = useState(false);
+```
+
+Replace the current sidebar block with this structure:
+
+```tsx
+{viewMode !== "year" && (
+	<div className="space-y-4 order-2 md:order-1">
+		<CalendarEmployeeSelector
+			currentEmployeeId={currentEmployeeId}
+			selectedEmployeeId={selectedEmployeeId}
+			onEmployeeChange={handleEmployeeChange}
+			isManagerOrAbove={isManagerOrAbove}
+		/>
+		<WorkBalanceCard balance={workBalance} compact />
+
+		<div data-testid="calendar-desktop-controls" className="hidden space-y-4 md:block">
+			<CalendarFiltersComponent
+				filters={filters}
+				onFiltersChange={setFilters}
+				currentEmployeeId={currentEmployeeId}
+			/>
+			<CalendarLegend />
+		</div>
+
+		<div data-testid="calendar-mobile-controls" className="md:hidden">
+			<Sheet open={mobileControlsOpen} onOpenChange={setMobileControlsOpen}>
+				<SheetTrigger asChild>
+					<Button type="button" variant="outline" className="w-full justify-start gap-2">
+						<IconAdjustmentsHorizontal className="size-4" />
+						Filter & Legende
+					</Button>
+				</SheetTrigger>
+				<SheetContent side="bottom" className="max-h-[85dvh] gap-0 overflow-y-auto p-0">
+					<SheetHeader className="border-b px-4 py-3 text-left">
+						<SheetTitle>Filter & Legende</SheetTitle>
+						<SheetDescription>
+							Steuere, welche Kalendereinträge sichtbar sind.
+						</SheetDescription>
+					</SheetHeader>
+					<div className="space-y-4 p-4">
+						<CalendarFiltersComponent
+							filters={filters}
+							onFiltersChange={setFilters}
+							currentEmployeeId={currentEmployeeId}
+						/>
+						<CalendarLegend />
+					</div>
+				</SheetContent>
+			</Sheet>
+		</div>
+	</div>
+)}
+```
+
+- [ ] **Step 4: Run the calendar test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest apps/webapp/src/components/calendar/calendar-view.test.tsx --run
+```
+
+Expected: PASS for the new test and existing calendar view tests.
+
+### Task 2: Employee Selector Full-Height List
+
+**Files:**
+- Modify: `apps/webapp/src/components/employee-select/employee-select-modal.tsx`
+- Test: `apps/webapp/src/components/employee-select/employee-select-modal.test.tsx`
+
+- [ ] **Step 1: Write the failing employee selector layout test**
+
+If `apps/webapp/src/components/employee-select/employee-select-modal.test.tsx` does not exist, create it with this source-level regression test:
+
+```tsx
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("EmployeeSelectModal layout", () => {
+	it("lets the employee list fill the available sheet height", () => {
+		const source = readFileSync(
+			resolve(__dirname, "employee-select-modal.tsx"),
+			"utf8",
+		);
+
+		expect(source).not.toContain("max-h-[320px]");
+		expect(source).toContain("flex-1 min-h-0 overflow-y-auto");
+	});
+});
+```
+
+- [ ] **Step 2: Run the failing employee selector test**
+
+Run:
+
+```bash
+pnpm vitest apps/webapp/src/components/employee-select/employee-select-modal.test.tsx --run
+```
+
+Expected: FAIL because `employee-select-modal.tsx` still contains `max-h-[320px]` and does not contain `flex-1 min-h-0 overflow-y-auto` on the list.
+
+- [ ] **Step 3: Implement the full-height list layout**
+
+In `apps/webapp/src/components/employee-select/employee-select-modal.tsx`, change the `CommandPrimitive` className from:
+
+```tsx
+className={cn(
+	"bg-popover text-popover-foreground flex h-full flex-col overflow-hidden",
+	"border-0",
+)}
+```
+
+to:
+
+```tsx
+className={cn(
+	"bg-popover text-popover-foreground flex h-full min-h-0 flex-col overflow-hidden",
+	"border-0",
+)}
+```
+
+Change the `CommandPrimitive.List` className from:
+
+```tsx
+className="max-h-[320px] overflow-y-auto overflow-x-hidden scroll-py-2 p-2"
+```
+
+to:
+
+```tsx
+className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden scroll-py-2 p-2"
+```
+
+- [ ] **Step 4: Run the employee selector test to verify it passes**
+
+Run:
+
+```bash
+pnpm vitest apps/webapp/src/components/employee-select/employee-select-modal.test.tsx --run
+```
+
+Expected: PASS.
+
+### Task 3: Final Verification
+
+**Files:**
+- Verify: `apps/webapp/src/components/calendar/calendar-view.tsx`
+- Verify: `apps/webapp/src/components/employee-select/employee-select-modal.tsx`
+- Verify: `docs/superpowers/specs/2026-06-02-calendar-mobile-controls-employee-selector-design.md`
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+pnpm vitest apps/webapp/src/components/calendar/calendar-view.test.tsx apps/webapp/src/components/employee-select/employee-select-modal.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type/lint check available in the repo**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS, or document any pre-existing unrelated failures with file paths.
+
+- [ ] **Step 3: Inspect git diff**
+
+Run:
+
+```bash
+git diff -- apps/webapp/src/components/calendar/calendar-view.tsx apps/webapp/src/components/calendar/calendar-view.test.tsx apps/webapp/src/components/employee-select/employee-select-modal.tsx apps/webapp/src/components/employee-select/employee-select-modal.test.tsx docs/superpowers/specs/2026-06-02-calendar-mobile-controls-employee-selector-design.md docs/superpowers/plans/2026-06-02-calendar-mobile-controls-employee-selector.md
+```
+
+Expected: Diff only contains the approved mobile controls, employee selector height fix, tests, spec, and plan.
+
+## Self-Review
+
+- Spec coverage: Task 1 covers the mobile-only filter and legend sheet while preserving desktop sidebar behavior. Task 2 covers the shared employee selector sheet height. Task 3 covers verification.
+- Placeholder scan: No `TBD`, `TODO`, or unspecified implementation steps remain.
+- Type consistency: The plan uses existing component names and prop names from `CalendarView`, `CalendarFiltersComponent`, `CalendarLegend`, and `EmployeeSelectModal`.

--- a/docs/superpowers/plans/2026-06-02-calendar-mobile-header.md
+++ b/docs/superpowers/plans/2026-06-02-calendar-mobile-header.md
@@ -1,0 +1,227 @@
+# Calendar Mobile Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Schedule-X calendar header readable and usable on mobile without changing desktop behavior.
+
+**Architecture:** Keep the existing `ScheduleXCalendarWrapper` custom header, but render responsive desktop and mobile header structures. Desktop keeps the current single-row layout; mobile uses a date row above a non-wrapping controls row. Add compact mobile date formatting alongside the existing desktop date label.
+
+**Tech Stack:** React, Next.js client components, Luxon, Tolgee, Tailwind CSS, Vitest, Testing Library.
+
+---
+
+## File Structure
+
+- Modify `apps/webapp/src/components/calendar/schedule-x-calendar.tsx`: add compact mobile date formatting and responsive header markup/classes.
+- Modify `apps/webapp/src/components/calendar/schedule-x-calendar.test.tsx`: add a regression test for mobile/desktop header structure and compact week label.
+- Verify existing calendar tests still pass.
+
+### Task 1: Mobile-Friendly Schedule-X Header
+
+**Files:**
+- Modify: `apps/webapp/src/components/calendar/schedule-x-calendar.tsx`
+- Test: `apps/webapp/src/components/calendar/schedule-x-calendar.test.tsx`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add this test to `apps/webapp/src/components/calendar/schedule-x-calendar.test.tsx`, inside the existing `describe` block for `ScheduleXCalendarWrapper` or create one if needed. Mock Tolgee language as German if the file does not already do so.
+
+```tsx
+it("renders a mobile header with compact date and non-wrapping controls", () => {
+	render(
+		<ScheduleXCalendarWrapper
+			events={[]}
+			timeZone="Europe/Berlin"
+			viewMode="week"
+			onViewModeChange={vi.fn()}
+		/>,
+	);
+
+	const desktopHeader = screen.getByTestId("calendar-desktop-header");
+	const mobileHeader = screen.getByTestId("calendar-mobile-header");
+	const mobileDate = screen.getByTestId("calendar-mobile-date-range");
+	const mobileControls = screen.getByTestId("calendar-mobile-header-controls");
+
+	expect(desktopHeader.className).toContain("hidden");
+	expect(desktopHeader.className).toContain("md:flex");
+	expect(mobileHeader.className).toContain("md:hidden");
+	expect(mobileDate.className).toContain("whitespace-nowrap");
+	expect(mobileControls.className).toContain("overflow-x-auto");
+	expect(mobileControls.className).toContain("whitespace-nowrap");
+	expect(mobileDate.textContent).not.toMatch(/, \d{4}$/);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run from `apps/webapp`:
+
+```bash
+pnpm vitest src/components/calendar/schedule-x-calendar.test.tsx --run
+```
+
+Expected: FAIL because the header test IDs and mobile date label do not exist yet.
+
+- [ ] **Step 3: Add compact mobile date formatting**
+
+In `apps/webapp/src/components/calendar/schedule-x-calendar.tsx`, keep `dateRangeDisplay` unchanged for desktop and add this `mobileDateRangeDisplay` near it:
+
+```tsx
+const mobileDateRangeDisplay = (() => {
+	const localizedCurrentDate = currentDate.setLocale(locale);
+
+	switch (viewMode) {
+		case "day":
+			return localizedCurrentDate.toFormat("ccc, d. LLL yyyy");
+		case "week": {
+			const { start: weekStart, end: weekEnd } = getWeekBounds(
+				localizedCurrentDate,
+				weekStartDay,
+			);
+			if (weekStart.year === weekEnd.year) {
+				return `${weekStart.toFormat("d. LLL")} - ${weekEnd.toFormat("d. LLL yyyy")}`;
+			}
+			return `${weekStart.toFormat("d. LLL yyyy")} - ${weekEnd.toFormat("d. LLL yyyy")}`;
+		}
+		case "month":
+			return localizedCurrentDate.toFormat("LLL yyyy");
+		default:
+			return localizedCurrentDate.toFormat("d. LLL yyyy");
+	}
+})();
+```
+
+- [ ] **Step 4: Replace the header markup with responsive desktop/mobile structures**
+
+Replace the current custom navigation header block in `schedule-x-calendar.tsx` with:
+
+```tsx
+<div className="pb-3 mb-3 space-y-3 md:space-y-0">
+	<div
+		data-testid="calendar-desktop-header"
+		className="hidden items-center justify-between gap-4 md:flex"
+	>
+		<div className="flex items-center gap-2">
+			<Button
+				variant="outline"
+				size="icon"
+				onClick={navigatePrevious}
+				aria-label={t("calendar.view.previous", "Previous")}
+			>
+				<IconChevronLeft className="size-4" />
+			</Button>
+			<Button
+				variant="outline"
+				size="icon"
+				onClick={navigateNext}
+				aria-label={t("calendar.view.next", "Next")}
+			>
+				<IconChevronRight className="size-4" />
+			</Button>
+			<Button variant="outline" size="sm" onClick={navigateToday}>
+				{t("calendar.view.today", "Today")}
+			</Button>
+			{onRefresh && (
+				<Button
+					variant="outline"
+					size="icon"
+					onClick={onRefresh}
+					aria-label={t("calendar.view.refresh", "Refresh")}
+					title={t("calendar.view.refresh", "Refresh")}
+				>
+					<IconReload className="size-4" />
+				</Button>
+			)}
+		</div>
+		<h2 className="text-lg font-semibold">{dateRangeDisplay}</h2>
+		<Tabs value={viewMode} onValueChange={(v) => onViewModeChange(v as ViewMode)}>
+			<TabsList>
+				<TabsTrigger value="day">{t("calendar.view.day", "Day")}</TabsTrigger>
+				<TabsTrigger value="week">{t("calendar.view.week", "Week")}</TabsTrigger>
+				<TabsTrigger value="month">{t("calendar.view.month", "Month")}</TabsTrigger>
+				<TabsTrigger value="year">{t("calendar.view.year", "Year")}</TabsTrigger>
+			</TabsList>
+		</Tabs>
+	</div>
+
+	<div data-testid="calendar-mobile-header" className="space-y-2 md:hidden">
+		<h2
+			data-testid="calendar-mobile-date-range"
+			className="truncate whitespace-nowrap text-base font-semibold leading-tight"
+		>
+			{mobileDateRangeDisplay}
+		</h2>
+		<div
+			data-testid="calendar-mobile-header-controls"
+			className="flex items-center justify-between gap-2 overflow-x-auto whitespace-nowrap pb-1"
+		>
+			<div className="flex shrink-0 items-center gap-2">
+				<Button
+					variant="outline"
+					size="icon"
+					onClick={navigatePrevious}
+					aria-label={t("calendar.view.previous", "Previous")}
+				>
+					<IconChevronLeft className="size-4" />
+				</Button>
+				<Button
+					variant="outline"
+					size="icon"
+					onClick={navigateNext}
+					aria-label={t("calendar.view.next", "Next")}
+				>
+					<IconChevronRight className="size-4" />
+				</Button>
+				<Button variant="outline" size="sm" onClick={navigateToday}>
+					{t("calendar.view.today", "Today")}
+				</Button>
+				{onRefresh && (
+					<Button
+						variant="outline"
+						size="icon"
+						onClick={onRefresh}
+						aria-label={t("calendar.view.refresh", "Refresh")}
+						title={t("calendar.view.refresh", "Refresh")}
+					>
+						<IconReload className="size-4" />
+					</Button>
+				)}
+			</div>
+			<Tabs value={viewMode} onValueChange={(v) => onViewModeChange(v as ViewMode)}>
+				<TabsList className="shrink-0">
+					<TabsTrigger value="day">{t("calendar.view.day", "Day")}</TabsTrigger>
+					<TabsTrigger value="week">{t("calendar.view.week", "Week")}</TabsTrigger>
+					<TabsTrigger value="month">{t("calendar.view.month", "Month")}</TabsTrigger>
+					<TabsTrigger value="year">{t("calendar.view.year", "Year")}</TabsTrigger>
+				</TabsList>
+			</Tabs>
+		</div>
+	</div>
+</div>
+```
+
+- [ ] **Step 5: Run the targeted test to verify it passes**
+
+Run from `apps/webapp`:
+
+```bash
+pnpm vitest src/components/calendar/schedule-x-calendar.test.tsx --run
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused formatting/checks**
+
+Run from repo root:
+
+```bash
+pnpm --dir apps/webapp exec biome check src/components/calendar/schedule-x-calendar.tsx src/components/calendar/schedule-x-calendar.test.tsx
+```
+
+Expected: PASS. If Biome reports safe formatting fixes, run the same command with `--write`, then rerun the check and targeted test.
+
+## Self-Review
+
+- Spec coverage: Task 1 implements the mobile two-row header, compact mobile date label, no-wrap controls row, and preserves desktop header behavior.
+- Placeholder scan: No placeholders or vague implementation steps remain.
+- Type consistency: The plan uses existing `ScheduleXCalendarWrapper`, `ViewMode`, `viewMode`, `onViewModeChange`, `dateRangeDisplay`, and Luxon/Tolgee patterns already present in the file.

--- a/docs/superpowers/plans/2026-06-02-mobile-notification-top-sheet.md
+++ b/docs/superpowers/plans/2026-06-02-mobile-notification-top-sheet.md
@@ -1,0 +1,171 @@
+# Mobile Notification Top Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show notifications in a top-sliding sheet on mobile while preserving the existing desktop popover.
+
+**Architecture:** Refactor `NotificationPopover` to share the notification panel markup between two responsive containers. Render a mobile-only Radix sheet using `md:hidden` and a desktop-only popover using `hidden md:block`, with separate open state for each surface so opening one portal does not mount the other. Notification loading remains enabled when either surface is open.
+
+**Tech Stack:** Next.js client component, React state, existing shadcn/Radix `Popover` and `Sheet` primitives, Tailwind responsive utilities, Tabler icons, Tolgee translations.
+
+---
+
+### Task 1: Responsive Notification Surface
+
+**Files:**
+- Modify: `apps/webapp/src/components/notifications/notification-popover.tsx`
+
+- [ ] **Step 1: Add sheet imports**
+
+Update the imports to include the existing sheet primitives:
+
+```tsx
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+```
+
+- [ ] **Step 2: Extract shared panel content**
+
+Inside `NotificationPopover`, create a `notificationContent` JSX constant after `handleClose`. Move the current popover header, separator, `NotificationList`, and footer into it:
+
+```tsx
+const notificationContent = (
+	<>
+		<div className="flex items-center justify-between px-4 py-3">
+			<div className="flex items-center gap-2">
+				<h3 className="font-semibold">{t("common:notifications.title", "Notifications")}</h3>
+				{unreadCount > 0 && (
+					<span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+						{unreadCount > 99
+							? t("common:notifications.unreadCountOverflow", "99+")
+							: unreadCount}
+					</span>
+				)}
+			</div>
+			<div className="flex items-center gap-1">
+				{unreadCount > 0 && (
+					<Button
+						size="icon"
+						variant="ghost"
+						className="size-8"
+						onClick={handleMarkAllAsRead}
+						disabled={isMarkingAllRead}
+						aria-label={t("common:notifications.actions.markAllRead", "Mark all read")}
+						title={t("common:notifications.actions.markAllRead", "Mark all read")}
+					>
+						<IconChecks className="size-4" />
+					</Button>
+				)}
+				{notifications.length > 0 && (
+					<Button
+						size="icon"
+						variant="ghost"
+						className="size-8 text-muted-foreground hover:text-destructive"
+						onClick={handleDeleteAll}
+						disabled={isDeletingAll}
+						aria-label={t("common:notifications.actions.deleteAll", "Delete all")}
+						title={t("common:notifications.actions.deleteAll", "Delete all")}
+					>
+						<IconTrash className="size-4" />
+					</Button>
+				)}
+				<Button size="icon" variant="ghost" className="size-8" asChild onClick={handleClose}>
+					<Link
+						href="/settings/notifications"
+						aria-label={t("common:notifications.actions.settings", "Notification settings")}
+						title={t("common:notifications.actions.settings", "Notification settings")}
+					>
+						<IconSettings className="size-4" />
+						<span className="sr-only">
+							{t("common:notifications.actions.settings", "Notification settings")}
+						</span>
+					</Link>
+				</Button>
+			</div>
+		</div>
+
+		<Separator />
+
+		<NotificationList
+			notifications={notifications}
+			isLoading={isLoading}
+			onMarkAsRead={handleMarkAsRead}
+			onDelete={handleDelete}
+			onClose={handleClose}
+		/>
+
+		{notifications.length > 0 && (
+			<>
+				<Separator />
+				<div className="p-2">
+					<Button variant="ghost" className="w-full text-sm" asChild onClick={handleClose}>
+						<Link href="/notifications">
+							{t("common:notifications.actions.viewAll", "View all notifications")}
+						</Link>
+					</Button>
+				</div>
+			</>
+		)}
+	</>
+);
+```
+
+- [ ] **Step 3: Split open state by responsive surface**
+
+Replace the existing single `open` state with mobile and desktop state:
+
+```tsx
+const [mobileOpen, setMobileOpen] = useState(false);
+const [desktopOpen, setDesktopOpen] = useState(false);
+const isOpen = mobileOpen || desktopOpen;
+```
+
+Update notification loading and close behavior:
+
+```tsx
+} = useNotifications({ enabled: isOpen && hasOrganization, organizationId });
+
+const handleClose = () => {
+	setMobileOpen(false);
+	setDesktopOpen(false);
+};
+```
+
+- [ ] **Step 4: Render mobile sheet and desktop popover**
+
+Replace the single `Popover` return with responsive wrappers:
+
+```tsx
+return (
+	<>
+		<div className="md:hidden">
+			<Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+				<SheetTrigger asChild>{children}</SheetTrigger>
+				<SheetContent side="top" className="max-h-[85dvh] gap-0 overflow-hidden p-0">
+					{notificationContent}
+				</SheetContent>
+			</Sheet>
+		</div>
+
+		<div className="hidden md:block">
+			<Popover open={desktopOpen} onOpenChange={setDesktopOpen}>
+				<PopoverTrigger asChild>{children}</PopoverTrigger>
+				<PopoverContent className="w-96 p-0" align="end" sideOffset={8}>
+					{notificationContent}
+				</PopoverContent>
+			</Popover>
+		</div>
+	</>
+);
+```
+
+- [ ] **Step 5: Verify formatting and types**
+
+Run a targeted check from the repository root:
+
+```bash
+pnpm --filter webapp lint
+```
+
+Expected: command completes without errors related to `notification-popover.tsx`.

--- a/docs/superpowers/specs/2026-06-02-calendar-mobile-controls-employee-selector-design.md
+++ b/docs/superpowers/specs/2026-06-02-calendar-mobile-controls-employee-selector-design.md
@@ -1,0 +1,37 @@
+# Calendar Mobile Controls And Employee Selector Sheet Design
+
+## Goal
+
+Make the `/calendar` view usable on mobile by moving bulky filter and legend controls out of the stacked page flow. Also make the shared employee selector use the available sheet height instead of leaving a large blank area below the list.
+
+## Scope
+
+- Mobile calendar layout for non-year calendar views.
+- Existing `CalendarFiltersComponent` and `CalendarLegend` presentation only.
+- Shared `EmployeeSelectModal` list sizing across mobile and desktop.
+
+## Non-Goals
+
+- No changes to calendar event fetching, filters state semantics, permissions, or employee scoping.
+- No redesign of desktop calendar sidebar behavior.
+- No changes to employee search, filtering, pagination, or selection behavior.
+
+## Calendar Mobile Controls
+
+On desktop, the current sidebar remains unchanged: employee selector, balance, filters, and legend stay in the left column.
+
+On mobile, the employee selector and work balance remain visible in the page because they are primary context. `Filter` and `Legende` move into a mobile-only bottom sheet opened from a compact control button. The bottom sheet contains the existing filter switches and legend content, preserving current labels, translations, and toggle behavior.
+
+The mobile control should be available only outside year view, matching the current sidebar visibility. The sheet should use the existing design system primitives and maintain dark/light theme support.
+
+## Employee Selector Sheet Height
+
+`EmployeeSelectModal` currently renders inside a full-height right-side action panel, but its employee list is capped at `max-h-[320px]`. Remove that fixed cap and make the command layout flex through the available height: header/search and footer keep their natural height, while the employee list gets `flex-1 min-h-0 overflow-y-auto`.
+
+This makes the list fill the sheet on mobile and desktop while keeping pagination, loading, empty states, and multi-select footer controls unchanged.
+
+## Testing
+
+- Add or update component tests where practical to assert the mobile controls render separately from desktop sidebar content.
+- Add a source-level or component-level regression test for the employee selector list layout class if existing tests support it.
+- Run targeted calendar and employee selector tests, then lint/type checks as needed.

--- a/docs/superpowers/specs/2026-06-02-calendar-mobile-header-design.md
+++ b/docs/superpowers/specs/2026-06-02-calendar-mobile-header-design.md
@@ -1,0 +1,31 @@
+# Calendar Mobile Header Design
+
+## Goal
+
+Make the custom Schedule-X calendar header usable on mobile. The current single-row layout squeezes navigation, the date range, and view tabs into one line, causing the date range to wrap into a tall vertical block.
+
+## Scope
+
+- Mobile layout of the custom header in `ScheduleXCalendarWrapper`.
+- Mobile date range formatting for day, week, and month display.
+- Existing navigation, refresh, and view mode behavior.
+
+## Non-Goals
+
+- No changes to Schedule-X event rendering, data fetching, time selection, filters, permissions, or calendar state semantics.
+- No redesign of the desktop calendar header.
+- No changes to year view, which is handled by `YearCalendarView`.
+
+## Design
+
+Desktop keeps the current single-row header: navigation controls, date range, and view tabs aligned horizontally.
+
+On mobile, the header becomes two rows. The first row shows the date range full-width with `whitespace-nowrap` and truncation protection. The second row contains navigation controls and view tabs, with horizontal overflow if the available width is too small. Controls should not wrap into multiple lines.
+
+The mobile week label should be shorter and locale-aware enough for the existing Tolgee/Luxon setup: for example, German mobile week display should read like `31. Mai - 6. Juni 2026` instead of wrapping `Mai 31 - Juni 6, 2026`. Day and month labels should also use compact mobile formats while preserving the desktop labels.
+
+## Testing
+
+- Add a regression test for `ScheduleXCalendarWrapper` that verifies the custom header exposes separate mobile and desktop date labels or mobile-specific responsive classes.
+- Verify the targeted calendar tests still pass.
+- Run Biome on touched files.

--- a/docs/superpowers/specs/2026-06-02-mobile-notification-top-sheet-design.md
+++ b/docs/superpowers/specs/2026-06-02-mobile-notification-top-sheet-design.md
@@ -1,0 +1,19 @@
+# Mobile Notification Top Sheet Design
+
+## Context
+
+The notification bell currently opens a fixed-width popover. That works on desktop but is awkward on mobile, where a floating popover can be cramped and poorly positioned.
+
+## Design
+
+Keep the desktop notification popover unchanged at `md` and larger breakpoints. On mobile, tapping the notification bell opens a sheet that slides down from the top. The sheet reuses the same notification header, action buttons, notification list, settings link, and view-all footer as the desktop popover.
+
+The mobile sheet should be full width, capped to the viewport height, and hide overflow at the container level so the notification list remains the scrollable content area. The bell trigger remains visually unchanged.
+
+## Behavior
+
+Opening either surface enables notification loading for the active organization. Closing the sheet or popover uses the same close path, including when users navigate to notification settings or all notifications. Mark-as-read, mark-all-read, delete, and delete-all behavior remain unchanged.
+
+## Testing
+
+Verify the implementation preserves desktop popover behavior and renders a top sheet for mobile breakpoints. At minimum, run the relevant TypeScript/lint or test target available for the webapp after the component change.


### PR DESCRIPTION
## Changelog
- Reworked calendar mobile controls with a bottom-sheet filter/legend flow, compact work-balance card, mobile-first default day view, and a scrollable mobile calendar header.
- Added a lightweight cached calendar employee lookup so calendar employee selection avoids team-page balance refresh work.
- Converted mobile notifications to a top sheet while preserving desktop popover behavior.
- Preserved caller-provided Effect services inside transactional approval side effects and tightened the approval detail sheet layout.
- Stabilized app search shortcut hydration and simplified enterprise domain default URL display.
- Added superpowers specs/plans for the new mobile calendar and notification interactions.

## Verification
- pnpm test: 569 test files passed, 3511 tests passed.