### PR TITLE
Fix Docker pruned lockfile installs

### DIFF
--- a/docker/Dockerfile.docs
+++ b/docker/Dockerfile.docs
@@ -43,6 +43,7 @@ COPY --from=docs-pruner /app/out/pnpm-lock.yaml ./
 COPY --from=docs-pruner /app/out/full/apps/docs/source.config.ts ./apps/docs/
 COPY --from=docs-pruner /app/out/full/apps/docs/content ./apps/docs/content
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --lockfile-only && \
     pnpm install --frozen-lockfile
 
 FROM base AS docs-workspace
@@ -62,6 +63,7 @@ COPY --from=docs-pruner /app/out/pnpm-lock.yaml ./
 COPY --from=docs-pruner /app/out/full/apps/docs/source.config.ts ./apps/docs/
 COPY --from=docs-pruner /app/out/full/apps/docs/content ./apps/docs/content
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --lockfile-only && \
     pnpm install --frozen-lockfile --prod
 
 FROM base AS docs

--- a/docker/Dockerfile.marketing
+++ b/docker/Dockerfile.marketing
@@ -42,6 +42,7 @@ FROM base AS marketing-deps
 COPY --from=marketing-pruner /app/out/json/ ./
 COPY --from=marketing-pruner /app/out/pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --lockfile-only && \
     pnpm install --frozen-lockfile
 
 FROM base AS marketing-workspace
@@ -60,6 +61,7 @@ FROM base AS marketing-runtime-deps
 COPY --from=marketing-pruner /app/out/json/ ./
 COPY --from=marketing-pruner /app/out/pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --lockfile-only && \
     pnpm install --frozen-lockfile --prod
 
 FROM oven/bun:1.3.11-alpine AS marketing-base

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -44,6 +44,7 @@ FROM base AS deps
 COPY --from=pruner /app/out/json/ ./
 COPY --from=pruner /app/out/pnpm-lock.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --lockfile-only && \
     pnpm install --frozen-lockfile
 
 FROM base AS workspace


### PR DESCRIPTION
## Summary
- Normalize Turbo pruned pnpm lockfiles before frozen installs in webapp, docs, and marketing Docker dependency stages
- Fixes publish image failures caused by pnpm overrides changing effective manifest specifiers after turbo prune

## Verification
- docker build -f docker/Dockerfile.webapp --target deps .
- docker build -f docker/Dockerfile.docs --target docs-deps .
- docker build -f docker/Dockerfile.marketing --target marketing-deps .
- docker build -f docker/Dockerfile.docs --target docs-runtime-deps .
- docker build -f docker/Dockerfile.marketing --target marketing-runtime-deps .