### PR TITLE
React Doctor triage: native dialogs and calmer state

### DIFF
--- a/apps/webapp/messages/common/de.json
+++ b/apps/webapp/messages/common/de.json
@@ -327,9 +327,25 @@
       "viewAll": "Alle Benachrichtigungen anzeigen"
     },
     "content": {
+      "absenceRequestSubmitted": {
+        "message": "Ihre Anfrage für {categoryName} für {dateRange} wurde eingereicht und wartet auf Genehmigung.",
+        "title": "Abwesenheitsanfrage eingereicht"
+      },
+      "passwordChanged": {
+        "message": "Ihr Passwort wurde erfolgreich geändert. Wenn Sie diese Änderung nicht vorgenommen haben, wenden Sie sich bitte sofort an den Support.",
+        "title": "Passwort geändert"
+      },
+      "shiftAssigned": {
+        "message": "Ihnen wurde eine Schicht am {shiftDate} von {startTime} bis {endTime} von {assignedByName} zugewiesen.",
+        "title": "Schicht zugewiesen"
+      },
       "teamMemberAdded": {
-        "message": "Du wurdest von {performedByName} zum Team {teamName} hinzugefügt.",
+        "message": "Sie wurden von {performedByName} zum Team {teamName} hinzugefügt.",
         "title": "Zum Team hinzugefügt"
+      },
+      "teamMemberRemoved": {
+        "message": "Sie wurden von {performedByName} aus dem Team {teamName} entfernt.",
+        "title": "Aus dem Team entfernt"
       }
     },
     "description": "Überprüfen Sie Updates, Genehmigungen und Systemmeldungen in einer Zeitleiste.",

--- a/apps/webapp/messages/common/en.json
+++ b/apps/webapp/messages/common/en.json
@@ -327,9 +327,25 @@
       "viewAll": "View all notifications"
     },
     "content": {
+      "absenceRequestSubmitted": {
+        "message": "Your {categoryName} request for {dateRange} has been submitted and is pending approval.",
+        "title": "Absence request submitted"
+      },
+      "passwordChanged": {
+        "message": "Your password was successfully changed. If you didn't make this change, please contact support immediately.",
+        "title": "Password changed"
+      },
+      "shiftAssigned": {
+        "message": "You have been assigned a shift on {shiftDate} from {startTime} to {endTime} by {assignedByName}.",
+        "title": "Shift assigned"
+      },
       "teamMemberAdded": {
         "message": "You have been added to the {teamName} team by {performedByName}.",
         "title": "Added to team"
+      },
+      "teamMemberRemoved": {
+        "message": "You have been removed from the {teamName} team by {performedByName}.",
+        "title": "Removed from team"
       }
     },
     "description": "Review updates, approvals, and system alerts in one timeline.",

--- a/apps/webapp/src/app/[locale]/(admin)/platform-admin/users/page.tsx
+++ b/apps/webapp/src/app/[locale]/(admin)/platform-admin/users/page.tsx
@@ -3,7 +3,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslate } from "@tolgee/react";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useRef, useState, useTransition } from "react";
+import { Suspense, useEffect, useReducer, useRef, useTransition } from "react";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -32,6 +32,67 @@ const LOADING_ROW_KEYS = ["loading-1", "loading-2", "loading-3", "loading-4", "l
 
 function getUserStatusFilter(status: string | null): UserStatusFilter {
 	return status === "active" || status === "banned" ? status : "all";
+}
+
+interface UsersPageState {
+	page: number;
+	search: string;
+	status: UserStatusFilter;
+	banDialogUser: PlatformUser | null;
+	banReason: string;
+	banExpiry: string;
+	sessionsDialogUser: PlatformUser | null;
+	sessions: UserSession[];
+	sessionsLoading: boolean;
+}
+
+type UsersPageAction =
+	| { type: "pageChanged"; page: number }
+	| { type: "filtersChanged"; search: string; status: UserStatusFilter }
+	| { type: "banDialogOpened"; user: PlatformUser }
+	| { type: "banDialogClosed" }
+	| { type: "banReasonChanged"; value: string }
+	| { type: "banExpiryChanged"; value: string }
+	| { type: "banCompleted" }
+	| { type: "sessionsOpened"; user: PlatformUser }
+	| { type: "sessionsLoaded"; sessions: UserSession[] }
+	| { type: "sessionsLoadingFinished" }
+	| { type: "sessionsClosed" }
+	| { type: "sessionRevoked"; sessionId: string }
+	| { type: "allSessionsRevoked" };
+
+function usersPageReducer(state: UsersPageState, action: UsersPageAction): UsersPageState {
+	switch (action.type) {
+		case "pageChanged":
+			return { ...state, page: action.page };
+		case "filtersChanged":
+			return { ...state, page: 1, search: action.search, status: action.status };
+		case "banDialogOpened":
+			return { ...state, banDialogUser: action.user };
+		case "banDialogClosed":
+			return { ...state, banDialogUser: null };
+		case "banReasonChanged":
+			return { ...state, banReason: action.value };
+		case "banExpiryChanged":
+			return { ...state, banExpiry: action.value };
+		case "banCompleted":
+			return { ...state, banDialogUser: null, banReason: "", banExpiry: "" };
+		case "sessionsOpened":
+			return { ...state, sessionsDialogUser: action.user, sessionsLoading: true };
+		case "sessionsLoaded":
+			return { ...state, sessions: action.sessions, sessionsLoading: false };
+		case "sessionsLoadingFinished":
+			return { ...state, sessionsLoading: false };
+		case "sessionsClosed":
+			return { ...state, sessionsDialogUser: null };
+		case "sessionRevoked":
+			return {
+				...state,
+				sessions: state.sessions.filter((session) => session.id !== action.sessionId),
+			};
+		case "allSessionsRevoked":
+			return { ...state, sessions: [] };
+	}
 }
 
 export default function UsersPage() {
@@ -94,19 +155,31 @@ function UsersPageContent({
 	const router = useRouter();
 	const queryClient = useQueryClient();
 
-	const [page, setPage] = useState(1);
-	const [search, setSearch] = useState(initialSearch);
-	const [status, setStatus] = useState<UserStatusFilter>(initialStatus);
-	const [organizationId] = useState(initialOrganizationId);
+	const [state, dispatch] = useReducer(usersPageReducer, {
+		page: 1,
+		search: initialSearch,
+		status: initialStatus,
+		banDialogUser: null,
+		banReason: "",
+		banExpiry: "",
+		sessionsDialogUser: null,
+		sessions: [],
+		sessionsLoading: false,
+	});
+	const {
+		page,
+		search,
+		status,
+		banDialogUser,
+		banReason,
+		banExpiry,
+		sessionsDialogUser,
+		sessions,
+		sessionsLoading,
+	} = state;
+	const organizationId = initialOrganizationId;
 	const [isPending, startTransition] = useTransition();
 	const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-	const [banDialogUser, setBanDialogUser] = useState<PlatformUser | null>(null);
-	const [banReason, setBanReason] = useState("");
-	const [banExpiry, setBanExpiry] = useState("");
-	const [sessionsDialogUser, setSessionsDialogUser] = useState<PlatformUser | null>(null);
-	const [sessions, setSessions] = useState<UserSession[]>([]);
-	const [sessionsLoading, setSessionsLoading] = useState(false);
 
 	const { data, isLoading } = useQuery({
 		queryKey: ["admin-users", search, status, organizationId, page],
@@ -132,11 +205,9 @@ function UsersPageContent({
 			clearTimeout(searchTimeoutRef.current);
 		}
 
-		setSearch(newSearch);
+		dispatch({ type: "filtersChanged", search: newSearch, status: newStatus });
 
 		if (newStatus !== status) {
-			setStatus(newStatus);
-			setPage(1);
 			const params = new URLSearchParams();
 			if (newSearch) params.set("search", newSearch);
 			if (newStatus !== "all") params.set("status", newStatus);
@@ -146,7 +217,6 @@ function UsersPageContent({
 		}
 
 		searchTimeoutRef.current = setTimeout(() => {
-			setPage(1);
 			const params = new URLSearchParams();
 			if (newSearch) params.set("search", newSearch);
 			if (newStatus !== "all") params.set("status", newStatus);
@@ -176,9 +246,7 @@ function UsersPageContent({
 						email: banDialogUser.email,
 					}),
 				);
-				setBanDialogUser(null);
-				setBanReason("");
-				setBanExpiry("");
+				dispatch({ type: "banCompleted" });
 				queryClient.invalidateQueries({ queryKey: ["admin-users"] });
 			} else {
 				toast.error(result.error);
@@ -203,15 +271,14 @@ function UsersPageContent({
 	};
 
 	const handleViewSessions = async (user: PlatformUser) => {
-		setSessionsDialogUser(user);
-		setSessionsLoading(true);
+		dispatch({ type: "sessionsOpened", user });
 		const result = await listUserSessionsAction(user.id);
 		if (result.success) {
-			setSessions(result.data);
+			dispatch({ type: "sessionsLoaded", sessions: result.data });
 		} else {
 			toast.error(result.error);
+			dispatch({ type: "sessionsLoadingFinished" });
 		}
-		setSessionsLoading(false);
 	};
 
 	const handleRevokeSession = async (sessionId: string) => {
@@ -219,7 +286,7 @@ function UsersPageContent({
 			const result = await revokeSessionAction(sessionId);
 			if (result.success) {
 				toast.success(t("admin:admin.users.toasts.sessionRevoked", "Session revoked"));
-				setSessions(sessions.filter((session) => session.id !== sessionId));
+				dispatch({ type: "sessionRevoked", sessionId });
 			} else {
 				toast.error(result.error);
 			}
@@ -237,7 +304,7 @@ function UsersPageContent({
 						count: result.data,
 					}),
 				);
-				setSessions([]);
+				dispatch({ type: "allSessionsRevoked" });
 			} else {
 				toast.error(result.error);
 			}
@@ -260,23 +327,23 @@ function UsersPageContent({
 				isPending={isPending}
 				onViewSessions={handleViewSessions}
 				onUnban={handleUnban}
-				onOpenBan={setBanDialogUser}
+				onOpenBan={(user) => dispatch({ type: "banDialogOpened", user })}
 			/>
 			<PlatformAdminUsersPagination
 				page={page}
 				total={total}
 				totalPages={totalPages}
 				pageSize={PAGE_SIZE}
-				onPageChange={setPage}
+				onPageChange={(nextPage) => dispatch({ type: "pageChanged", page: nextPage })}
 			/>
 			<PlatformAdminBanUserDialog
 				user={banDialogUser}
 				banReason={banReason}
 				banExpiry={banExpiry}
 				isPending={isPending}
-				onReasonChange={setBanReason}
-				onExpiryChange={setBanExpiry}
-				onClose={() => setBanDialogUser(null)}
+				onReasonChange={(value) => dispatch({ type: "banReasonChanged", value })}
+				onExpiryChange={(value) => dispatch({ type: "banExpiryChanged", value })}
+				onClose={() => dispatch({ type: "banDialogClosed" })}
 				onConfirm={handleBan}
 			/>
 			<PlatformAdminUserSessionsPanel
@@ -284,7 +351,7 @@ function UsersPageContent({
 				sessions={sessions}
 				sessionsLoading={sessionsLoading}
 				isPending={isPending}
-				onClose={() => setSessionsDialogUser(null)}
+				onClose={() => dispatch({ type: "sessionsClosed" })}
 				onRevokeSession={handleRevokeSession}
 				onRevokeAllSessions={handleRevokeAllSessions}
 			/>

--- a/apps/webapp/src/app/[locale]/(admin)/platform-admin/worker-queue/schedule-controls.tsx
+++ b/apps/webapp/src/app/[locale]/(admin)/platform-admin/worker-queue/schedule-controls.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from "@tanstack/react-form";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -137,6 +137,12 @@ export function ScheduleControls({ job, labels, presets }: ScheduleControlsProps
 			confirmation: "",
 		};
 	}
+
+	useEffect(() => {
+		if (isEditing) {
+			form.reset(getDefaultFormValues());
+		}
+	}, [form, isEditing, defaultPresetId]);
 
 	function openEditForm() {
 		form.reset(getDefaultFormValues());

--- a/apps/webapp/src/components/app-search.test.tsx
+++ b/apps/webapp/src/components/app-search.test.tsx
@@ -42,12 +42,12 @@ vi.mock("@/components/user-avatar", () => ({
 		name?: string | null;
 		seed: string;
 	}) => (
-		<span
-			aria-label={name ?? undefined}
+		<img
+			alt={name ?? ""}
 			data-image={image ?? ""}
 			data-seed={seed}
 			data-testid="employee-avatar"
-			role="img"
+			src={image ?? "data:,"}
 		/>
 	),
 }));
@@ -60,12 +60,21 @@ vi.mock("@/app/[locale]/(app)/search/actions", () => ({
 	searchAppRecordsAction: searchAppRecordsActionMock,
 }));
 
+vi.mock("@base-ui/react/dialog", () => ({
+	Dialog: {
+		Backdrop: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+		Close: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+		Popup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	},
+}));
+
 vi.mock("@/components/ui/dialog", () => ({
 	Dialog: ({ children, open }: { children: ReactNode; open?: boolean }) =>
 		open ? <div>{children}</div> : null,
 	DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 	DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
 	DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DialogPortal: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 	DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
 }));
 
@@ -100,6 +109,12 @@ const staticCommands: AppSearchResult[] = [
 ];
 
 const searchPlaceholder = "Search pages, people, teams, settings, or actions…";
+
+async function finishCommandDialogClose() {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(200);
+	});
+}
 
 function renderAppSearch({
 	commands = staticCommands,
@@ -159,6 +174,7 @@ describe("AppSearch", () => {
 		fireEvent.click(screen.getByText("Dashboard"));
 
 		expect(pushMock).toHaveBeenCalledWith("/dashboard");
+		await finishCommandDialogClose();
 		expect(screen.queryByPlaceholderText(searchPlaceholder)).toBeNull();
 	});
 
@@ -369,13 +385,14 @@ describe("AppSearch", () => {
 		expect(groupHeadings).toEqual(["Actions", "People", "Teams", "Pages", "Settings"]);
 	});
 
-	it("navigates to a selected action and closes the palette", () => {
+	it("navigates to a selected action and closes the palette", async () => {
 		renderAppSearch();
 
 		fireEvent.click(screen.getByRole("button", { name: /^search$/i }));
 		fireEvent.click(screen.getByText("Add manual time entry"));
 
 		expect(pushMock).toHaveBeenCalledWith("/time-tracking");
+		await finishCommandDialogClose();
 		expect(screen.queryByPlaceholderText(searchPlaceholder)).toBeNull();
 	});
 

--- a/apps/webapp/src/components/notifications/notification-popover.test.tsx
+++ b/apps/webapp/src/components/notifications/notification-popover.test.tsx
@@ -65,10 +65,10 @@ vi.mock("@/components/ui/sheet", async () => {
 			}
 
 			return (
-				<div aria-label="Notifications" className={className} data-side={side} role="dialog">
+				<dialog aria-label="Notifications" className={className} data-side={side} open>
 					{showCloseButton && <button type="button">Close</button>}
 					{children}
-				</div>
+				</dialog>
 			);
 		},
 		SheetDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,

--- a/apps/webapp/src/components/payroll/payroll-workspace.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.tsx
@@ -13,7 +13,7 @@ import {
 } from "@tabler/icons-react";
 import { DateTime } from "luxon";
 import type React from "react";
-import { useState, useTransition } from "react";
+import { useReducer, useTransition } from "react";
 import { toast } from "sonner";
 import {
 	exportPayrollPdfAction,
@@ -56,14 +56,71 @@ interface PayrollPeriodRequest {
 	employeeIds?: string[];
 }
 
+interface PayrollWorkspaceState {
+	summary: PayrollWorkspaceSummary;
+	dateMode: PayrollDateRangeMode;
+	startDate: string;
+	endDate: string;
+	selectedEmployeeIds: string[];
+	selectedTeamNames: string[];
+	formatId: string;
+}
+
+type PayrollWorkspaceAction =
+	| { type: "summaryRefreshed"; summary: PayrollWorkspaceSummary }
+	| { type: "dateModeChanged"; dateMode: PayrollDateRangeMode }
+	| { type: "startDateChanged"; value: string }
+	| { type: "endDateChanged"; value: string }
+	| { type: "employeeFilterChanged"; employeeIds: string[] }
+	| { type: "teamFilterChanged"; teamNames: string[] }
+	| { type: "formatChanged"; formatId: string };
+
+function payrollWorkspaceReducer(
+	state: PayrollWorkspaceState,
+	action: PayrollWorkspaceAction,
+): PayrollWorkspaceState {
+	switch (action.type) {
+		case "summaryRefreshed":
+			return {
+				...state,
+				summary: action.summary,
+				startDate: action.summary.period.start,
+				endDate: action.summary.period.end,
+			};
+		case "dateModeChanged":
+			return { ...state, dateMode: action.dateMode };
+		case "startDateChanged":
+			return { ...state, startDate: action.value };
+		case "endDateChanged":
+			return { ...state, endDate: action.value };
+		case "employeeFilterChanged":
+			return { ...state, selectedEmployeeIds: action.employeeIds };
+		case "teamFilterChanged":
+			return { ...state, selectedTeamNames: action.teamNames };
+		case "formatChanged":
+			return { ...state, formatId: action.formatId };
+	}
+}
+
 export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorkspaceProps) {
-	const [summary, setSummary] = useState(initialSummary);
-	const [dateMode, setDateMode] = useState<PayrollDateRangeMode>("month");
-	const [startDate, setStartDate] = useState(initialSummary.period.start);
-	const [endDate, setEndDate] = useState(initialSummary.period.end);
-	const [selectedEmployeeIds, setSelectedEmployeeIds] = useState<string[]>([]);
-	const [selectedTeamNames, setSelectedTeamNames] = useState<string[]>([]);
-	const [formatId, setFormatId] = useState(exportFormats[0]?.id ?? "");
+	const [state, dispatch] = useReducer(payrollWorkspaceReducer, {
+		summary: initialSummary,
+		dateMode: "month",
+		startDate: initialSummary.period.start,
+		endDate: initialSummary.period.end,
+		selectedEmployeeIds: [],
+		selectedTeamNames: [],
+		formatId: exportFormats[0]?.id ?? "",
+	});
+	const {
+		summary,
+		dateMode,
+		startDate,
+		endDate,
+		selectedEmployeeIds,
+		selectedTeamNames,
+		formatId,
+	} = state;
 	const [isPending, startTransition] = useTransition();
 
 	const scopedEmployees = initialSummary.employees;
@@ -106,9 +163,7 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 				return;
 			}
 
-			setSummary(result.data);
-			setStartDate(result.data.period.start);
-			setEndDate(result.data.period.end);
+			dispatch({ type: "summaryRefreshed", summary: result.data });
 			onSuccess?.();
 		});
 	}
@@ -123,7 +178,7 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 			selectedTeamNames,
 		);
 
-		setSelectedEmployeeIds(nextEmployeeIds);
+		dispatch({ type: "employeeFilterChanged", employeeIds: nextEmployeeIds });
 		refreshSummary(basePeriodRequest(summary), nextFilteredEmployeeIds);
 	}
 
@@ -137,20 +192,20 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 			nextTeamNames,
 		);
 
-		setSelectedTeamNames(nextTeamNames);
+		dispatch({ type: "teamFilterChanged", teamNames: nextTeamNames });
 		refreshSummary(basePeriodRequest(summary), nextFilteredEmployeeIds);
 	}
 
 	function applyDateMode(nextMode: PayrollDateRangeMode) {
 		if (nextMode === "custom") {
-			setDateMode(nextMode);
+			dispatch({ type: "dateModeChanged", dateMode: nextMode });
 			return;
 		}
 
 		refreshSummary(
 			buildPeriodRequest(DateTime.utc().startOf(nextMode), nextMode),
 			filteredEmployeeIds,
-			() => setDateMode(nextMode),
+			() => dispatch({ type: "dateModeChanged", dateMode: nextMode }),
 		);
 	}
 
@@ -323,7 +378,9 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 									type="date"
 									value={startDate}
 									disabled={dateMode !== "custom" || isPending}
-									onChange={(event) => setStartDate(event.target.value)}
+									onChange={(event) =>
+										dispatch({ type: "startDateChanged", value: event.target.value })
+									}
 								/>
 							</div>
 							<div className="space-y-1">
@@ -335,7 +392,9 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 									type="date"
 									value={endDate}
 									disabled={dateMode !== "custom" || isPending}
-									onChange={(event) => setEndDate(event.target.value)}
+									onChange={(event) =>
+										dispatch({ type: "endDateChanged", value: event.target.value })
+									}
 								/>
 							</div>
 							<Button
@@ -372,7 +431,7 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 							<Label htmlFor="payroll-export-target">Payroll export target</Label>
 							<Select
 								value={formatId}
-								onValueChange={setFormatId}
+								onValueChange={(formatId) => dispatch({ type: "formatChanged", formatId })}
 								disabled={!hasExportFormats || isPending}
 							>
 								<SelectTrigger id="payroll-export-target" className="w-full">

--- a/apps/webapp/src/lib/approvals/handlers/time-correction.handler.ts
+++ b/apps/webapp/src/lib/approvals/handlers/time-correction.handler.ts
@@ -218,17 +218,17 @@ export const TimeCorrectionHandler: ApprovalTypeHandler<WorkPeriodWithRelations>
 					const correctionEntries =
 						originalEntryIds.length > 0
 							? yield* _(
-								dbService.query("batchGetTimeCorrectionReviewEntries", async () => {
-									return await dbService.db.query.timeEntry.findMany({
-										where: and(
-											eq(timeEntry.type, "correction"),
-											inArray(timeEntry.employeeId, employeeIds),
-											inArray(timeEntry.organizationId, organizationIds),
-											inArray(timeEntry.replacesEntryId, originalEntryIds),
-										),
-									});
-								}),
-							)
+									dbService.query("batchGetTimeCorrectionReviewEntries", async () => {
+										return await dbService.db.query.timeEntry.findMany({
+											where: and(
+												eq(timeEntry.type, "correction"),
+												inArray(timeEntry.employeeId, employeeIds),
+												inArray(timeEntry.organizationId, organizationIds),
+												inArray(timeEntry.replacesEntryId, originalEntryIds),
+											),
+										});
+									}),
+								)
 							: [];
 
 					const correctionEntriesByReplacedId = new Map<string, CorrectionEntryForReview[]>();
@@ -393,8 +393,8 @@ export const TimeCorrectionHandler: ApprovalTypeHandler<WorkPeriodWithRelations>
 				correctionMetadata?.clockInCorrectionId,
 				correctionMetadata?.clockOutCorrectionId,
 			].filter((id): id is string => Boolean(id));
-			const replacesEntryIds = [period.clockIn.id, period.clockOut?.id].filter(
-				(id): id is string => Boolean(id),
+			const replacesEntryIds = [period.clockIn.id, period.clockOut?.id].filter((id): id is string =>
+				Boolean(id),
 			);
 			const correctionEntries = yield* _(
 				dbService.query("getPendingCorrectionEntriesForReview", async () => {

--- a/apps/webapp/src/lib/approvals/server/queries.test.ts
+++ b/apps/webapp/src/lib/approvals/server/queries.test.ts
@@ -126,6 +126,50 @@ describe("buildPendingApprovalResult", () => {
 		expect(result.absenceApprovals[0]?.absence.sickDetail).toBeNull();
 	});
 
+	it("excludes orphaned legacy time corrections from dashboard pending approvals", () => {
+		const result = buildPendingApprovalResult({
+			pendingRequests: [
+				{
+					id: "approval-1",
+					entityId: "period-1",
+					entityType: "time_entry",
+					status: "pending",
+					createdAt: new Date("2026-05-22T18:28:29.000Z"),
+					requester: {
+						user: {
+							id: "user-1",
+							name: "Kai Hentschel",
+							email: "kai@example.com",
+							image: null,
+						},
+					},
+				},
+			],
+			absencesById: new Map(),
+			periodsById: new Map([
+				[
+					"period-1",
+					{
+						id: "period-1",
+						startTime: new Date("2026-05-22T14:00:00.000Z"),
+						endTime: new Date("2026-05-22T18:00:00.000Z"),
+						clockIn: {
+							id: "clock-in-original",
+							timestamp: new Date("2026-05-22T14:00:00.000Z"),
+						},
+						clockOut: {
+							id: "clock-out-original",
+							timestamp: new Date("2026-05-22T18:00:00.000Z"),
+						},
+						correctionReviewEntries: [],
+					},
+				],
+			]),
+		});
+
+		expect(result.timeCorrectionApprovals).toEqual([]);
+	});
+
 	it("supports travel expense claims in the richer bulk decision contract", () => {
 		const approvalType: ApprovalType = "travel_expense_claim";
 		const decisionActions: ApprovalDecisionAction[] = ["approve", "reject"];

--- a/apps/webapp/src/lib/approvals/server/queries.ts
+++ b/apps/webapp/src/lib/approvals/server/queries.ts
@@ -1,7 +1,7 @@
 import { and, count, desc, eq, inArray, ne } from "drizzle-orm";
 import { getCurrentEmployee } from "@/app/[locale]/(app)/absences/actions";
 import { db } from "@/db";
-import { absenceEntry, approvalRequest, workPeriod } from "@/db/schema";
+import { absenceEntry, approvalRequest, timeEntry, workPeriod } from "@/db/schema";
 import type { SickDetail } from "@/lib/absences/types";
 import type { ApprovalWithAbsence, ApprovalWithTimeCorrection } from "./types";
 
@@ -11,6 +11,7 @@ interface PendingRequestRecord {
 	entityType: "absence_entry" | "time_entry";
 	status: "pending" | "approved" | "rejected";
 	createdAt: Date;
+	metadata?: unknown;
 	requester: {
 		user: {
 			id: string;
@@ -41,12 +42,29 @@ interface WorkPeriodLookupRecord {
 	startTime: Date;
 	endTime: Date | null;
 	clockIn: {
+		id: string;
 		timestamp: Date;
 	};
 	clockOut: {
+		id: string;
 		timestamp: Date;
 	} | null;
+	correctionReviewEntries?: CorrectionEntryForReview[];
 }
+
+interface CorrectionEntryForReview {
+	id: string;
+	timestamp: Date;
+	replacesEntryId: string | null;
+	isSuperseded?: boolean;
+}
+
+type TimeCorrectionApprovalMetadata = {
+	timeCorrection?: {
+		clockInCorrectionId?: string;
+		clockOutCorrectionId?: string;
+	};
+};
 
 function splitPendingApprovalIds(pendingRequests: PendingRequestRecord[]) {
 	const absenceIds: string[] = [];
@@ -62,6 +80,48 @@ function splitPendingApprovalIds(pendingRequests: PendingRequestRecord[]) {
 	}
 
 	return { absenceIds, timeCorrectionIds };
+}
+
+function correctionMetadataFromRequest(request: { metadata?: unknown }) {
+	return (request.metadata as TimeCorrectionApprovalMetadata | null)?.timeCorrection;
+}
+
+function isOrphanedTimeCorrectionApproval(
+	request: PendingRequestRecord,
+	period: WorkPeriodLookupRecord,
+): boolean {
+	const metadata = correctionMetadataFromRequest(request);
+	const correctionEntries = period.correctionReviewEntries ?? [];
+	const correctionById = new Map(correctionEntries.map((entry) => [entry.id, entry]));
+	const legacyCorrectionEntries = correctionEntries.filter((entry) => !entry.isSuperseded);
+	const clockInCandidates = legacyCorrectionEntries.filter(
+		(entry) => entry.replacesEntryId === period.clockIn.id,
+	);
+	const clockOutCandidates = period.clockOut
+		? legacyCorrectionEntries.filter((entry) => entry.replacesEntryId === period.clockOut?.id)
+		: [];
+	const clockInCorrection = metadata?.clockInCorrectionId
+		? correctionById.get(metadata.clockInCorrectionId)
+		: clockInCandidates.length === 1
+			? clockInCandidates[0]
+			: undefined;
+	const clockOutCorrection = metadata?.clockOutCorrectionId
+		? correctionById.get(metadata.clockOutCorrectionId)
+		: clockOutCandidates.length === 1
+			? clockOutCandidates[0]
+			: undefined;
+	const matchingClockInCorrection =
+		clockInCorrection?.replacesEntryId === period.clockIn.id ? clockInCorrection : null;
+	const matchingClockOutCorrection =
+		clockOutCorrection?.replacesEntryId === period.clockOut?.id ? clockOutCorrection : null;
+	const hasMetadataCorrectionIds = Boolean(
+		metadata?.clockInCorrectionId || metadata?.clockOutCorrectionId,
+	);
+
+	return hasMetadataCorrectionIds
+		? Boolean(metadata?.clockInCorrectionId && !matchingClockInCorrection) ||
+				Boolean(metadata?.clockOutCorrectionId && !matchingClockOutCorrection)
+		: !matchingClockInCorrection || clockInCandidates.length > 1 || clockOutCandidates.length > 1;
 }
 
 export function buildPendingApprovalResult({
@@ -109,6 +169,9 @@ export function buildPendingApprovalResult({
 
 		const period = periodsById.get(request.entityId);
 		if (!period?.clockIn) {
+			continue;
+		}
+		if (isOrphanedTimeCorrectionApproval(request, period)) {
 			continue;
 		}
 
@@ -184,6 +247,32 @@ export async function getPendingApprovals(): Promise<{
 	const periodsById = new Map(
 		(periods as WorkPeriodLookupRecord[]).map((period) => [period.id, period] as const),
 	);
+	const originalEntryIds = (periods as WorkPeriodLookupRecord[]).flatMap((period) =>
+		[period.clockIn?.id, period.clockOut?.id].filter((id): id is string => Boolean(id)),
+	);
+	const correctionEntries =
+		originalEntryIds.length > 0
+			? ((await db.query.timeEntry.findMany({
+					where: and(
+						eq(timeEntry.organizationId, currentEmployee.organizationId),
+						eq(timeEntry.type, "correction"),
+						inArray(timeEntry.replacesEntryId, originalEntryIds),
+					),
+				})) as CorrectionEntryForReview[])
+			: [];
+	const correctionEntriesByReplacedId = new Map<string, CorrectionEntryForReview[]>();
+	for (const entry of correctionEntries) {
+		if (!entry.replacesEntryId) continue;
+		const entries = correctionEntriesByReplacedId.get(entry.replacesEntryId) ?? [];
+		entries.push(entry);
+		correctionEntriesByReplacedId.set(entry.replacesEntryId, entries);
+	}
+	for (const period of periods as WorkPeriodLookupRecord[]) {
+		period.correctionReviewEntries = [
+			...(correctionEntriesByReplacedId.get(period.clockIn.id) ?? []),
+			...(period.clockOut?.id ? (correctionEntriesByReplacedId.get(period.clockOut.id) ?? []) : []),
+		];
+	}
 
 	return buildPendingApprovalResult({
 		pendingRequests,

--- a/docker/targets/db-seed/pnpm-lock.yaml
+++ b/docker/targets/db-seed/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   get-uri>basic-ftp: 5.3.0
   get-uri: 6.0.5
   glob@7.2.3>minimatch: 3.1.5
-  hono: 4.12.18
+  hono: 4.12.21
   kysely: 0.28.17
   lodash: 4.18.1
   lodash-es: 4.18.1

--- a/docker/targets/db-seed/pnpm-workspace.yaml
+++ b/docker/targets/db-seed/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ overrides:
   "get-uri>basic-ftp": "5.3.0"
   "get-uri": "6.0.5"
   "glob@7.2.3>minimatch": "3.1.5"
-  "hono": "4.12.18"
+  "hono": "4.12.21"
   "kysely": "0.28.17"
   "lodash": "4.18.1"
   "lodash-es": "4.18.1"

--- a/docker/targets/migration/pnpm-lock.yaml
+++ b/docker/targets/migration/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   get-uri>basic-ftp: 5.3.0
   get-uri: 6.0.5
   glob@7.2.3>minimatch: 3.1.5
-  hono: 4.12.18
+  hono: 4.12.21
   kysely: 0.28.17
   lodash: 4.18.1
   lodash-es: 4.18.1

--- a/docker/targets/migration/pnpm-workspace.yaml
+++ b/docker/targets/migration/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ overrides:
   "get-uri>basic-ftp": "5.3.0"
   "get-uri": "6.0.5"
   "glob@7.2.3>minimatch": "3.1.5"
-  "hono": "4.12.18"
+  "hono": "4.12.21"
   "kysely": "0.28.17"
   "lodash": "4.18.1"
   "lodash-es": "4.18.1"

--- a/docker/targets/worker/pnpm-lock.yaml
+++ b/docker/targets/worker/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   get-uri>basic-ftp: 5.3.0
   get-uri: 6.0.5
   glob@7.2.3>minimatch: 3.1.5
-  hono: 4.12.18
+  hono: 4.12.21
   kysely: 0.28.17
   lodash: 4.18.1
   lodash-es: 4.18.1

--- a/docker/targets/worker/pnpm-workspace.yaml
+++ b/docker/targets/worker/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ overrides:
   "get-uri>basic-ftp": "5.3.0"
   "get-uri": "6.0.5"
   "glob@7.2.3>minimatch": "3.1.5"
-  "hono": "4.12.18"
+  "hono": "4.12.21"
   "kysely": "0.28.17"
   "lodash": "4.18.1"
   "lodash-es": "4.18.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   get-uri>basic-ftp: 5.3.0
   get-uri: 6.0.5
   glob@7.2.3>minimatch: 3.1.5
-  hono: 4.12.18
+  hono: 4.12.21
   kysely: 0.28.17
   lodash: 4.18.1
   lodash-es: 4.18.1
@@ -2214,7 +2214,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -7786,8 +7786,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@7.0.2:
@@ -13108,9 +13108,9 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.18)':
+  '@hono/node-server@1.19.13(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@iconify/types@2.0.0': {}
 
@@ -13339,7 +13339,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.18)
+      '@hono/node-server': 1.19.13(hono@4.12.21)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -13349,7 +13349,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -19174,7 +19174,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   hosted-git-info@7.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ overrides:
   get-uri>basic-ftp: 5.3.0
   get-uri: 6.0.5
   glob@7.2.3>minimatch: 3.1.5
-  hono: 4.12.18
+  hono: 4.12.21
   kysely: 0.28.17
   lodash: 4.18.1
   lodash-es: 4.18.1


### PR DESCRIPTION
## Changelog
- Replaced the notification sheet test modal mock with a native `<dialog>`.
- Grouped related platform-admin users and payroll workspace state with reducers to clear the targeted React Doctor `prefer-useReducer` findings.
- Restored webapp test-suite health by updating app-search dialog mocks, notification catalog entries, and worker schedule form syncing.
- Includes existing `dev` changes for orphaned legacy time-correction approval filtering and the Hono security override.

## Verification
- `pnpm test` from `apps/webapp`: 630 files passed, 3,873 tests passed.
- `pnpm exec tsc --noEmit` from `apps/webapp`: no reported errors.
- `npx react-doctor@latest --verbose` from `apps/webapp`: original `prefer-html-dialog`, notification `prefer-tag-over-role`, and target `prefer-useReducer` findings are absent; broad pre-existing diagnostics remain.

## Notes
- React Doctor still reports unrelated existing issues for follow-up triage.