### PR TITLE
Refactor Redis client to enable offline queue and add tests

### DIFF
--- a/apps/webapp/src/app/api/notifications/stream/route.test.ts
+++ b/apps/webapp/src/app/api/notifications/stream/route.test.ts
@@ -150,6 +150,17 @@ describe("GET /api/notifications/stream", () => {
 		await reader.cancel();
 	});
 
+	it("cleans up Redis subscriptions when the stream is cancelled", async () => {
+		const response = await GET();
+		const reader = response.body?.getReader() as ReadableStreamDefaultReader<Uint8Array>;
+		await readEvent(reader);
+
+		await reader.cancel();
+
+		expect(mockState.subscriber.unsubscribe).toHaveBeenCalledWith("notifications:user-1");
+		expect(mockState.subscriber.disconnect).toHaveBeenCalled();
+	});
+
 	it("scopes polling fallback count updates to the active organization", async () => {
 		vi.useFakeTimers();
 		mockState.redis.status = "end";

--- a/apps/webapp/src/app/api/notifications/stream/route.ts
+++ b/apps/webapp/src/app/api/notifications/stream/route.ts
@@ -78,6 +78,8 @@ export async function GET() {
 		// Check if Redis is available
 		const redisAvailable = redis.status === "ready" || redis.status === "connecting";
 
+		let cleanupStream = () => {};
+
 		// Create a readable stream for SSE
 		const stream = new ReadableStream({
 			async start(controller) {
@@ -114,6 +116,7 @@ export async function GET() {
 						subscriber.disconnect();
 					}
 				};
+				cleanupStream = cleanup;
 
 				try {
 					// Send initial count
@@ -172,9 +175,9 @@ export async function GET() {
 					console.error("Error setting up notification stream:", error);
 					cleanup();
 				}
-
-				// Return cleanup function for when stream is closed
-				return cleanup;
+			},
+			cancel() {
+				cleanupStream();
 			},
 		});
 

--- a/apps/webapp/src/lib/redis.test.ts
+++ b/apps/webapp/src/lib/redis.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+	const Redis = vi.fn(function RedisMock(this: { on: () => unknown; status: string }) {
+		this.on = vi.fn(() => this);
+		this.status = "wait";
+		return this;
+	});
+
+	return { Redis };
+});
+
+vi.mock("ioredis", () => ({
+	default: mocks.Redis,
+}));
+
+vi.mock("@/env", () => ({
+	env: {
+		CI: "false",
+		NEXT_PHASE: undefined,
+		NODE_ENV: "production",
+		npm_lifecycle_event: undefined,
+		REDIS_HOST: "redis.internal",
+		REDIS_PORT: "6379",
+		REDIS_TLS: "false",
+	},
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	}),
+}));
+
+describe("Redis client configuration", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+		Reflect.deleteProperty(globalThis, "redis");
+		Reflect.deleteProperty(globalThis, "redisPub");
+	});
+
+	test("keeps the offline queue enabled for lazy Redis clients", async () => {
+		await import("./redis");
+
+		expect(mocks.Redis).toHaveBeenCalled();
+		expect(mocks.Redis.mock.calls[0]?.[0]).toMatchObject({
+			enableOfflineQueue: true,
+			lazyConnect: true,
+		});
+	});
+});

--- a/apps/webapp/src/lib/redis.ts
+++ b/apps/webapp/src/lib/redis.ts
@@ -67,7 +67,7 @@ function createRedisClient(): Redis {
 		},
 		lazyConnect: true,
 		enableReadyCheck: true,
-		enableOfflineQueue: false,
+		enableOfflineQueue: true,
 		// Reconnect automatically on connection loss
 		reconnectOnError(err) {
 			const targetErrors = ["READONLY", "ECONNRESET", "EPIPE"];


### PR DESCRIPTION
This pull request improves the reliability and test coverage of the notifications streaming API and the Redis client configuration. The main changes ensure that Redis subscriptions are properly cleaned up when a stream is cancelled, and that the Redis client is correctly configured and tested to support offline queueing for lazy connections.

**Notifications streaming cleanup and reliability:**

* Ensured that Redis subscriptions are unsubscribed and the connection is disconnected when the SSE stream is cancelled, by adding a proper cleanup mechanism in the `GET` handler and testing this behavior (`route.ts`, `route.test.ts`). [[1]](diffhunk://#diff-cf02cb26bcab3e1f6234582c7b3bddf462f3a2cd47a7cf2fd558e4d274172063R81-R82) [[2]](diffhunk://#diff-cf02cb26bcab3e1f6234582c7b3bddf462f3a2cd47a7cf2fd558e4d274172063R119) [[3]](diffhunk://#diff-cf02cb26bcab3e1f6234582c7b3bddf462f3a2cd47a7cf2fd558e4d274172063L175-R180) [[4]](diffhunk://#diff-133762d08fd24a6109347f5898c0241bbfd9ccccb731dc80cdb580a52d010c2fR153-R163)

**Redis client configuration and testing:**

* Changed the Redis client configuration to enable the offline queue for lazy clients, improving connection reliability (`redis.ts`).
* Added a dedicated test suite for the Redis client to verify that the offline queue is enabled and to mock external dependencies for isolation (`redis.test.ts`).…dd tests