### PR TITLE
Ship clock integrity and resilient Telegram delivery

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,6 +23,6 @@
 		"@types/react": "19.2.17",
 		"postcss": "8.5.16",
 		"tailwindcss": "^4.3.2",
-		"typescript": "^7.0.2"
+		"typescript": "^6.0.3"
 	}
 }

--- a/apps/extension/src/lib/api.ts
+++ b/apps/extension/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { storage, type QueuedAction } from "./storage";
+import type { ClockAction } from "./clock-action";
 import type { ClockStatus, Project, TimeEntry } from "@/types";
 
 export class NetworkError extends Error {
@@ -69,23 +70,19 @@ class ApiClient {
     return this.fetch<ClockStatus>("/api/time-entries/status");
   }
 
-  async clockIn(timestamp?: string): Promise<{ entry: TimeEntry }> {
+  async clockIn(action: ClockAction): Promise<{ entry: TimeEntry }> {
     return this.fetch<{ entry: TimeEntry }>("/api/time-entries", {
       method: "POST",
-      body: JSON.stringify({
-        type: "clock_in",
-        ...(timestamp && { timestamp }),
-      }),
+      body: JSON.stringify(action),
     });
   }
 
-  async clockOut(projectId?: string, timestamp?: string): Promise<{ entry: TimeEntry }> {
+  async clockOut(action: ClockAction, projectId?: string): Promise<{ entry: TimeEntry }> {
     return this.fetch<{ entry: TimeEntry }>("/api/time-entries", {
       method: "POST",
       body: JSON.stringify({
-        type: "clock_out",
+        ...action,
         ...(projectId && { projectId }),
-        ...(timestamp && { timestamp }),
       }),
     });
   }
@@ -98,9 +95,9 @@ class ApiClient {
   async processQueuedAction(action: QueuedAction): Promise<boolean> {
     try {
       if (action.type === "clock_in") {
-        await this.clockIn(action.timestamp);
+        await this.clockIn(action);
       } else {
-        await this.clockOut(action.projectId, action.timestamp);
+        await this.clockOut(action, action.projectId);
       }
       return true;
     } catch (error) {

--- a/apps/extension/src/lib/clock-action.test.ts
+++ b/apps/extension/src/lib/clock-action.test.ts
@@ -1,0 +1,48 @@
+import { DateTime } from "luxon";
+import { describe, expect, it } from "vitest";
+import { createClockAction, getActionTimezone } from "./clock-action";
+
+const fixedNow = DateTime.fromISO("2026-07-10T12:30:00.123Z", { zone: "utc" });
+
+function fakeIntl(timeZone: string) {
+  return {
+    DateTimeFormat: () => ({ resolvedOptions: () => ({ timeZone }) }),
+  } as Pick<typeof Intl, "DateTimeFormat">;
+}
+
+describe("extension clock action capture", () => {
+  it("captures an immutable UTC instant and timezone evidence at the clock interaction", () => {
+    expect(
+      createClockAction({
+        type: "clock_in",
+        now: fixedNow,
+        intlApi: fakeIntl("Asia/Kathmandu"),
+        actionId: "action-123",
+      }),
+    ).toEqual({
+      id: "action-123",
+      type: "clock_in",
+      timestamp: "2026-07-10T12:30:00.123Z",
+      browserTimezone: "Asia/Kathmandu",
+      utcOffsetMinutes: 345,
+    });
+  });
+
+  it("falls back to UTC evidence for an invalid device timezone without using the host timezone", () => {
+    expect(
+      createClockAction({
+        type: "clock_out",
+        now: fixedNow,
+        intlApi: fakeIntl("Not/AZone"),
+        actionId: "action-456",
+      }),
+    ).toEqual({
+      id: "action-456",
+      type: "clock_out",
+      timestamp: "2026-07-10T12:30:00.123Z",
+      browserTimezone: "UTC",
+      utcOffsetMinutes: 0,
+    });
+    expect(getActionTimezone(fakeIntl("Not/AZone"))).toBeNull();
+  });
+});

--- a/apps/extension/src/lib/clock-action.ts
+++ b/apps/extension/src/lib/clock-action.ts
@@ -1,0 +1,50 @@
+import { DateTime, IANAZone } from "luxon";
+
+type IntlApi = Pick<typeof Intl, "DateTimeFormat"> | null;
+
+interface ClockActionOptions {
+  type: "clock_in" | "clock_out";
+  now?: DateTime;
+  intlApi?: IntlApi;
+  actionId?: string;
+}
+
+export interface ClockAction {
+  id: string;
+  type: "clock_in" | "clock_out";
+  timestamp: string;
+  browserTimezone: string;
+  utcOffsetMinutes: number;
+}
+
+export function getActionTimezone(intlApi: IntlApi = Intl): string | null {
+  try {
+    const timezone = intlApi?.DateTimeFormat().resolvedOptions().timeZone;
+    return timezone && IANAZone.isValidZone(timezone) ? timezone : null;
+  } catch {
+    return null;
+  }
+}
+
+export function createClockAction({
+  type,
+  now = DateTime.utc(),
+  intlApi,
+  actionId = crypto.randomUUID(),
+}: ClockActionOptions): ClockAction {
+  const browserTimezone = getActionTimezone(intlApi) ?? "UTC";
+  const instant = now.toUTC();
+  const timestamp = instant.toISO({ suppressMilliseconds: false });
+
+  if (!timestamp) {
+    throw new Error("Unable to capture clock action instant");
+  }
+
+  return {
+    id: actionId,
+    type,
+    timestamp,
+    browserTimezone,
+    utcOffsetMinutes: instant.setZone(browserTimezone).offset,
+  };
+}

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -1,13 +1,11 @@
 import { DateTime } from "luxon";
 import { normalizeWebappUrl } from "./settings";
+import type { ClockAction } from "./clock-action";
 
 const DEFAULT_WEBAPP_URL = "http://localhost:3000";
 
-export interface QueuedAction {
-  id: string;
-  type: "clock_in" | "clock_out";
+export interface QueuedAction extends ClockAction {
   projectId?: string;
-  timestamp: string;
   createdAt: string;
 }
 
@@ -90,11 +88,10 @@ export const storage = {
     }
   },
 
-  async addToQueue(action: Omit<QueuedAction, "id" | "createdAt">): Promise<QueuedAction> {
+  async addToQueue(action: Omit<QueuedAction, "createdAt">): Promise<QueuedAction> {
     const queue = await this.getQueuedActions();
     const newAction: QueuedAction = {
       ...action,
-      id: crypto.randomUUID(),
       createdAt: DateTime.utc().toISO(),
     };
     queue.push(newAction);

--- a/apps/extension/src/popup/hooks/useClock.ts
+++ b/apps/extension/src/popup/hooks/useClock.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
-import { DateTime } from "luxon";
 import { api, NetworkError, AuthError } from "@/lib/api";
+import { createClockAction, type ClockAction } from "@/lib/clock-action";
 import { storage, type LastAction, type QueuedAction } from "@/lib/storage";
 import type { ClockStatus } from "@/types";
 
@@ -110,22 +110,22 @@ export function useClock() {
     setLastActionState(action);
   };
 
-  const queueClockIn = async (timestamp: string) => {
-    const optimisticState = { isClockedIn: true, startTime: timestamp };
-    await storage.addToQueue({ type: "clock_in", timestamp });
+  const queueClockIn = async (action: ClockAction) => {
+    const optimisticState = { isClockedIn: true, startTime: action.timestamp };
+    await storage.addToQueue(action);
     await storage.setOptimisticState(optimisticState);
-    await storeLastAction({ type: "clock_in", timestamp, syncState: "queued" });
+    await storeLastAction({ type: "clock_in", timestamp: action.timestamp, syncState: "queued" });
     queryClient.setQueryData(["clock-status"], optimisticStateToStatus(optimisticState));
-    return { entry: { id: "queued", type: "clock_in" as const, timestamp, employeeId: "" } };
+    return { entry: { id: "queued", type: "clock_in" as const, timestamp: action.timestamp, employeeId: "" } };
   };
 
-  const queueClockOut = async (projectId: string | undefined, timestamp: string) => {
+  const queueClockOut = async (projectId: string | undefined, action: ClockAction) => {
     const optimisticState = { isClockedIn: false, startTime: null };
-    await storage.addToQueue({ type: "clock_out", projectId, timestamp });
+    await storage.addToQueue({ ...action, projectId });
     await storage.setOptimisticState(optimisticState);
-    await storeLastAction({ type: "clock_out", timestamp, syncState: "queued" });
+    await storeLastAction({ type: "clock_out", timestamp: action.timestamp, syncState: "queued" });
     queryClient.setQueryData(["clock-status"], optimisticStateToStatus(optimisticState));
-    return { entry: { id: "queued", type: "clock_out" as const, timestamp, employeeId: "" } };
+    return { entry: { id: "queued", type: "clock_out" as const, timestamp: action.timestamp, employeeId: "" } };
   };
 
   const statusQuery = useQuery({
@@ -170,14 +170,14 @@ export function useClock() {
 
   const clockInMutation = useMutation({
     mutationFn: async () => {
-      const timestamp = DateTime.utc().toISO();
+      const action = createClockAction({ type: "clock_in" });
 
       if (!navigator.onLine) {
-        return queueClockIn(timestamp);
+        return queueClockIn(action);
       }
 
-      const result = await api.clockIn();
-      await storeLastAction({ type: "clock_in", timestamp, syncState: "synced" });
+      const result = await api.clockIn(action);
+      await storeLastAction({ type: "clock_in", timestamp: action.timestamp, syncState: "synced" });
 
       // Show notification
       chrome.runtime.sendMessage({
@@ -197,14 +197,14 @@ export function useClock() {
 
   const clockOutMutation = useMutation({
     mutationFn: async (projectId?: string) => {
-      const timestamp = DateTime.utc().toISO();
+      const action = createClockAction({ type: "clock_out" });
 
       if (!navigator.onLine) {
-        return queueClockOut(projectId, timestamp);
+        return queueClockOut(projectId, action);
       }
 
-      const result = await api.clockOut(projectId);
-      await storeLastAction({ type: "clock_out", timestamp, syncState: "synced" });
+      const result = await api.clockOut(action, projectId);
+      await storeLastAction({ type: "clock_out", timestamp: action.timestamp, syncState: "synced" });
 
       // Show notification
       chrome.runtime.sendMessage({

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -12,7 +12,7 @@
     "next": "16.2.10",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "typescript": "^7.0.2"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",

--- a/apps/mobile/src/features/home/clock-action.test.ts
+++ b/apps/mobile/src/features/home/clock-action.test.ts
@@ -1,0 +1,45 @@
+import { DateTime } from "luxon";
+import { describe, expect, it } from "vitest";
+import {
+	createMobileClockInAction,
+	createMobileClockOutAction,
+	getActionTimeTimezone,
+} from "./clock-action";
+
+const fixedNow = DateTime.fromISO("2026-07-10T12:30:00.123Z", { zone: "utc" });
+
+function fakeIntl(timeZone: string) {
+	return {
+		DateTimeFormat: () => ({ resolvedOptions: () => ({ timeZone }) }),
+	} as Pick<typeof Intl, "DateTimeFormat">;
+}
+
+describe("mobile clock action evidence", () => {
+	it("captures the instant, IANA timezone, and offset at the clock-in tap", () => {
+		expect(
+			createMobileClockInAction({
+				workLocationType: "home",
+				now: fixedNow,
+				intlApi: fakeIntl("Asia/Kathmandu"),
+			}),
+		).toEqual({
+			action: "clock_in",
+			workLocationType: "home",
+			timestamp: "2026-07-10T12:30:00.123Z",
+			browserTimezone: "Asia/Kathmandu",
+			utcOffsetMinutes: 345,
+		});
+	});
+
+	it("uses UTC evidence when the device timezone is unavailable", () => {
+		expect(
+			createMobileClockOutAction({ now: fixedNow, intlApi: fakeIntl("Not/AZone") }),
+		).toEqual({
+			action: "clock_out",
+			timestamp: "2026-07-10T12:30:00.123Z",
+			browserTimezone: "UTC",
+			utcOffsetMinutes: 0,
+		});
+		expect(getActionTimeTimezone(fakeIntl("Not/AZone"))).toBeNull();
+	});
+});

--- a/apps/mobile/src/features/home/clock-action.ts
+++ b/apps/mobile/src/features/home/clock-action.ts
@@ -1,0 +1,47 @@
+import { DateTime, IANAZone } from "luxon";
+import type { WorkLocationType } from "./use-home-query";
+
+type IntlApi = Pick<typeof Intl, "DateTimeFormat"> | null;
+
+interface ActionEvidenceOptions {
+	now?: DateTime;
+	intlApi?: IntlApi;
+}
+
+export function getActionTimeTimezone(intlApi: IntlApi = Intl): string | null {
+	try {
+		const timezone = intlApi?.DateTimeFormat().resolvedOptions().timeZone;
+		return timezone && IANAZone.isValidZone(timezone) ? timezone : null;
+	} catch {
+		return null;
+	}
+}
+
+function captureActionEvidence({ now = DateTime.utc(), intlApi }: ActionEvidenceOptions) {
+	const browserTimezone = getActionTimeTimezone(intlApi) ?? "UTC";
+	const instant = now.toUTC();
+
+	return {
+		timestamp: instant.toISO({ suppressMilliseconds: false }),
+		browserTimezone,
+		utcOffsetMinutes: instant.setZone(browserTimezone).offset,
+	};
+}
+
+export function createMobileClockInAction({
+	workLocationType,
+	...options
+}: ActionEvidenceOptions & { workLocationType: WorkLocationType }) {
+	return {
+		action: "clock_in" as const,
+		workLocationType,
+		...captureActionEvidence(options),
+	};
+}
+
+export function createMobileClockOutAction(options: ActionEvidenceOptions = {}) {
+	return {
+		action: "clock_out" as const,
+		...captureActionEvidence(options),
+	};
+}

--- a/apps/mobile/src/features/home/use-home-query.ts
+++ b/apps/mobile/src/features/home/use-home-query.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useMobileSession, type MobileSession } from "@/src/features/session/use-mobile-session";
 import { createMobileApiClient } from "@/src/lib/api/client";
+import { createMobileClockInAction, createMobileClockOutAction } from "./clock-action";
 
 export type WorkLocationType = "office" | "home" | "field" | "other";
 
@@ -59,9 +60,7 @@ export function useHomeQuery(sessionOverride?: MobileSession | null) {
 
   const clockMutation = useMutation({
     mutationFn: async (
-      action:
-        | { action: "clock_in"; workLocationType: WorkLocationType }
-        | { action: "clock_out" },
+      action: ReturnType<typeof createMobileClockInAction> | ReturnType<typeof createMobileClockOutAction>,
     ) => {
       if (!token) {
         throw new Error("No mobile session token");
@@ -80,8 +79,8 @@ export function useHomeQuery(sessionOverride?: MobileSession | null) {
     ...homeQuery,
     session,
     clockIn: (workLocationType: WorkLocationType) =>
-      clockMutation.mutateAsync({ action: "clock_in", workLocationType }),
-    clockOut: () => clockMutation.mutateAsync({ action: "clock_out" }),
+      clockMutation.mutateAsync(createMobileClockInAction({ workLocationType })),
+    clockOut: () => clockMutation.mutateAsync(createMobileClockOutAction()),
     isClockSubmitting: clockMutation.isPending,
   };
 }

--- a/apps/webapp/drizzle/0053_telegram_digest_delivery.sql
+++ b/apps/webapp/drizzle/0053_telegram_digest_delivery.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "telegram_digest_delivery" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"recipient_employee_id" uuid NOT NULL,
+	"recipient_user_id" text NOT NULL,
+	"platform" text NOT NULL,
+	"digest_type" text NOT NULL,
+	"logical_date" text NOT NULL,
+	"status" text DEFAULT 'sending' NOT NULL,
+	"attempted_at" timestamp DEFAULT now() NOT NULL,
+	"sent_at" timestamp,
+	"failed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "telegram_digest_delivery_status_check" CHECK ("status" IN ('sending', 'sent', 'failed'))
+);
+
+DO $$ BEGIN
+	ALTER TABLE "telegram_digest_delivery" ADD CONSTRAINT "telegram_digest_delivery_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+	ALTER TABLE "telegram_digest_delivery" ADD CONSTRAINT "telegram_digest_delivery_recipient_employee_id_employee_id_fk" FOREIGN KEY ("recipient_employee_id") REFERENCES "public"."employee"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+	ALTER TABLE "telegram_digest_delivery" ADD CONSTRAINT "telegram_digest_delivery_recipient_user_id_user_id_fk" FOREIGN KEY ("recipient_user_id") REFERENCES "public"."user"("id") ON DELETE cascade;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "telegramDigestDelivery_idempotency_unique_idx" ON "telegram_digest_delivery" USING btree ("organization_id", "recipient_employee_id", "recipient_user_id", "platform", "digest_type", "logical_date");
+CREATE INDEX IF NOT EXISTS "telegramDigestDelivery_organizationId_idx" ON "telegram_digest_delivery" USING btree ("organization_id");

--- a/apps/webapp/drizzle/meta/_journal.json
+++ b/apps/webapp/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1780773132903,
       "tag": "0052_time_entry_timezone_recovery",
       "breakpoints": true
+	},
+	{
+		"idx": 53,
+		"version": "7",
+		"when": 1781096400000,
+		"tag": "0053_telegram_digest_delivery",
+		"breakpoints": true
     }
   ]
 }

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -165,7 +165,7 @@
     "postcss": "8.5.16",
     "shadcn": "^4.13.0",
     "tsx": "^4.23.0",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "ultracite": "7.9.3",
     "vitest": "^4.1.10"
   },

--- a/apps/webapp/src/app/[locale]/(app)/time-tracking/actions/auth.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/time-tracking/actions/auth.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dbState = vi.hoisted(() => ({
 	findFirst: vi.fn(),
+	findMember: vi.fn(),
 	findUserSettings: vi.fn(),
 }));
 
@@ -14,6 +15,9 @@ vi.mock("@/db", () => ({
 		query: {
 			employee: {
 				findFirst: dbState.findFirst,
+			},
+			member: {
+				findFirst: dbState.findMember,
 			},
 			userSettings: {
 				findFirst: dbState.findUserSettings,
@@ -33,6 +37,14 @@ vi.mock("@/db/schema", () => ({
 	},
 }));
 
+vi.mock("@/db/auth-schema", () => ({
+	member: {
+		organizationId: "member.organizationId",
+		status: "member.status",
+		userId: "member.userId",
+	},
+}));
+
 vi.mock("@/lib/auth", () => ({
 	auth: {
 		api: {
@@ -48,6 +60,7 @@ vi.mock("next/headers", () => ({
 vi.mock("drizzle-orm", () => ({
 	and: vi.fn((...conditions: unknown[]) => ({ type: "and", conditions })),
 	eq: vi.fn((column: unknown, value: unknown) => ({ type: "eq", column, value })),
+	relations: vi.fn(() => ({})),
 }));
 
 import { getCurrentEmployee } from "./auth";
@@ -62,6 +75,7 @@ describe("getCurrentEmployee", () => {
 			user: { id: "user-1" },
 			session: { activeOrganizationId: "org-1" },
 		});
+		dbState.findMember.mockResolvedValue({ id: "member-1" });
 		dbState.findFirst
 			.mockResolvedValueOnce(undefined)
 			.mockResolvedValueOnce({ id: "employee-in-other-org", organizationId: "org-2" });

--- a/apps/webapp/src/app/[locale]/(app)/time-tracking/actions/auth.ts
+++ b/apps/webapp/src/app/[locale]/(app)/time-tracking/actions/auth.ts
@@ -3,6 +3,7 @@
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { db } from "@/db";
+import { member } from "@/db/auth-schema";
 import { employee, userSettings } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { DEFAULT_TIMEZONE } from "./shared";
@@ -24,15 +25,25 @@ async function getEmployeeForUser(
 		return null;
 	}
 
-	const employeeForActiveOrg = await db.query.employee.findFirst({
+	const [approvedMembership, employeeForActiveOrg] = await Promise.all([
+		db.query.member.findFirst({
+			columns: { id: true },
+			where: and(
+				eq(member.userId, userId),
+				eq(member.organizationId, activeOrganizationId),
+				eq(member.status, "approved"),
+			),
+		}),
+		db.query.employee.findFirst({
 		where: and(
 			eq(employee.userId, userId),
 			eq(employee.organizationId, activeOrganizationId),
 			eq(employee.isActive, true),
 		),
-	});
+		}),
+	]);
 
-	return employeeForActiveOrg ?? null;
+	return approvedMembership ? (employeeForActiveOrg ?? null) : null;
 }
 
 export async function getCurrentEmployee(): Promise<CurrentEmployee | null> {

--- a/apps/webapp/src/app/[locale]/layout.test.tsx
+++ b/apps/webapp/src/app/[locale]/layout.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { readFileSync } from "node:fs";
+import { renderToReadableStream } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import LocaleLayout from "./layout";
 
@@ -51,7 +52,19 @@ vi.mock("next/headers", () => ({
 }));
 
 vi.mock("next-intl", () => ({
-	NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	NextIntlClientProvider: ({
+	children,
+	locale,
+	messages,
+}: {
+	children: React.ReactNode;
+	locale: string;
+	messages: Record<string, string>;
+}) => (
+		<div data-next-intl-locale={locale} data-next-intl-messages={JSON.stringify(messages)}>
+			{children}
+		</div>
+	),
 }));
 
 vi.mock("next-intl/server", () => ({
@@ -63,7 +76,11 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/components/bprogress/bprogress", () => ({
-	BProgressBar: () => null,
+	BProgressBar: () => <div data-testid="application-shell" />,
+}));
+
+vi.mock("@/components/deployment-refresh", () => ({
+	DeploymentRefreshChecker: () => <div data-testid="deployment-refresh-checker" />,
 }));
 
 vi.mock("@/components/offline", () => ({
@@ -118,7 +135,19 @@ vi.mock("@/proxy", () => ({
 }));
 
 vi.mock("@/tolgee/client", () => ({
-	TolgeeNextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	TolgeeNextProvider: ({
+	children,
+	language,
+	staticData,
+}: {
+	children: React.ReactNode;
+	language: string;
+	staticData: Record<string, unknown>;
+}) => (
+		<div data-tolgee-language={language} data-tolgee-static-data={JSON.stringify(staticData)}>
+			{children}
+		</div>
+	),
 }));
 
 vi.mock("@/tolgee/shared", () => ({
@@ -158,5 +187,45 @@ describe("LocaleLayout", () => {
 
 		expect(source).not.toContain("PostHogConsentProvider");
 		expect(source).not.toContain('minHeight: "100vh"');
+	});
+
+	it("renders the translation-context fallback while route translations are pending", async () => {
+		let resolveHeaders: (headers: Headers) => void = () => {};
+		mockState.headers.mockImplementation(
+			() =>
+				new Promise<Headers>((resolve) => {
+					resolveHeaders = resolve;
+				}),
+		);
+
+		try {
+			const layout = await LocaleLayout({
+				children: <main data-testid="application-child">Auth content</main>,
+				params: Promise.resolve({ locale: "en" }),
+			});
+			const stream = await renderToReadableStream(layout);
+			const reader = stream.getReader();
+			const { value } = await reader.read();
+			resolveHeaders(new Headers({ "x-pathname": "/en/sign-in" }));
+			while (!(await reader.read()).done) {
+				// Consume the resolved translation branch so the stream ends without an abort.
+			}
+			const container = document.createElement("div");
+			container.innerHTML = new TextDecoder().decode(value);
+
+			const tolgeeProvider = container.querySelector('[data-tolgee-language="en"]');
+			const intlProvider = tolgeeProvider?.querySelector('[data-next-intl-locale="en"]');
+
+			expect(tolgeeProvider).not.toBeNull();
+			expect(tolgeeProvider?.getAttribute("data-tolgee-static-data")).toBe("{}");
+			expect(intlProvider).not.toBeNull();
+			expect(intlProvider?.getAttribute("data-next-intl-messages")).toBe('{"locale":"en"}');
+			expect(intlProvider?.querySelector('[data-testid="application-shell"]')).not.toBeNull();
+			expect(intlProvider?.querySelector('[data-testid="application-child"]')?.textContent).toBe(
+				"Auth content",
+			);
+		} finally {
+			mockState.headers.mockImplementation(async () => new Headers({ "x-pathname": "/en/sign-in" }));
+		}
 	});
 });

--- a/apps/webapp/src/app/[locale]/layout.tsx
+++ b/apps/webapp/src/app/[locale]/layout.tsx
@@ -1,7 +1,7 @@
 import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { Toaster } from "sonner";
 import { BProgressBar } from "@/components/bprogress/bprogress";
 import { DeploymentRefreshChecker } from "@/components/deployment-refresh";
@@ -26,6 +26,26 @@ export async function generateStaticParams() {
 	return ALL_LANGUAGES.map((locale) => ({ locale }));
 }
 
+type TranslationRecords = Awaited<ReturnType<typeof loadRouteTranslations>>;
+
+function TranslationProviders({
+	children,
+	locale,
+	records,
+}: {
+	children: ReactNode;
+	locale: string;
+	records: TranslationRecords;
+}) {
+	return (
+		<TolgeeNextProvider language={locale} staticData={records}>
+			<NextIntlClientProvider locale={locale} messages={{ locale }}>
+				{children}
+			</NextIntlClientProvider>
+		</TolgeeNextProvider>
+	);
+}
+
 // Separate component for loading translations to wrap in Suspense
 async function TranslationProvider({ locale, children }: { locale: string; children: ReactNode }) {
 	// Get the current pathname to determine which namespaces to load
@@ -40,11 +60,9 @@ async function TranslationProvider({ locale, children }: { locale: string; child
 	});
 
 	return (
-		<TolgeeNextProvider language={locale} staticData={records}>
-			<NextIntlClientProvider locale={locale} messages={{ locale }}>
-				{children}
-			</NextIntlClientProvider>
-		</TolgeeNextProvider>
+		<TranslationProviders locale={locale} records={records}>
+			{children}
+		</TranslationProviders>
 	);
 }
 
@@ -65,24 +83,36 @@ function TranslatedMeta() {
 	);
 }
 
+function ApplicationContent({ children }: { children: ReactNode }) {
+	return (
+		<QueryProvider>
+			<BProgressBar />
+			<TooltipProvider delayDuration={0}>
+				<OfflineBanner />
+				<SWUpdatePrompt />
+				<DeploymentRefreshChecker clientBuildHash={env.NEXT_PUBLIC_BUILD_HASH ?? "development"} />
+				{children}
+				<Toaster position="bottom-right" richColors />
+			</TooltipProvider>
+		</QueryProvider>
+	);
+}
+
 function AppProviders({ children, locale }: { children: ReactNode; locale: string }) {
 	return (
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<FontSizeProvider>
-				<TranslationProvider locale={locale}>
-					<QueryProvider>
-						<BProgressBar />
-						<TooltipProvider delayDuration={0}>
-							<OfflineBanner />
-							<SWUpdatePrompt />
-							<DeploymentRefreshChecker
-								clientBuildHash={env.NEXT_PUBLIC_BUILD_HASH ?? "development"}
-							/>
-							{children}
-							<Toaster position="bottom-right" richColors />
-						</TooltipProvider>
-					</QueryProvider>
-				</TranslationProvider>
+				<Suspense
+					fallback={
+						<TranslationProviders locale={locale} records={{}}>
+							<ApplicationContent>{children}</ApplicationContent>
+						</TranslationProviders>
+					}
+				>
+					<TranslationProvider locale={locale}>
+						<ApplicationContent>{children}</ApplicationContent>
+					</TranslationProvider>
+				</Suspense>
 			</FontSizeProvider>
 		</ThemeProvider>
 	);

--- a/apps/webapp/src/app/api/mobile/time-clock/route.test.ts
+++ b/apps/webapp/src/app/api/mobile/time-clock/route.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+function utcActionEvidence() {
+	return {
+		timestamp: new Date().toISOString(),
+		browserTimezone: "UTC",
+		utcOffsetMinutes: 0,
+	};
+}
+
 const mockState = vi.hoisted(() => ({
 	MobileApiError: class MobileApiError extends Error {
 		constructor(
@@ -12,7 +20,8 @@ const mockState = vi.hoisted(() => ({
 	requireMobileSessionContext: vi.fn(),
 	requireMobileEmployee: vi.fn(),
 	clockIn: vi.fn(),
-	clockOut: vi.fn(),
+		clockOut: vi.fn(),
+		requireActor: vi.fn(),
 }));
 
 vi.mock("@/app/api/mobile/shared", () => ({
@@ -24,6 +33,11 @@ vi.mock("@/app/api/mobile/shared", () => ({
 vi.mock("@/app/[locale]/(app)/time-tracking/actions/clocking", () => ({
 	clockIn: mockState.clockIn,
 	clockOut: mockState.clockOut,
+}));
+
+vi.mock("@/lib/time-tracking/clocking-service", () => ({
+	ClockingAccessError: class ClockingAccessError extends Error {},
+	clockingService: { requireActor: mockState.requireActor },
 }));
 
 const { POST } = await import("./route");
@@ -42,6 +56,11 @@ describe("POST /api/mobile/time-clock", () => {
 		mockState.requireMobileEmployee.mockResolvedValue({
 			id: "emp-1",
 			organizationId: "org-1",
+		});
+		mockState.requireActor.mockResolvedValue({
+			employee: { id: "emp-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
 		});
 	});
 
@@ -69,7 +88,7 @@ describe("POST /api/mobile/time-clock", () => {
 		const response = await POST(
 			new Request("https://app.example.com/api/mobile/time-clock", {
 				method: "POST",
-				body: JSON.stringify({ action: "clock_in", workLocationType: "remote" }),
+				body: JSON.stringify({ action: "clock_in", workLocationType: "remote", ...utcActionEvidence() }),
 				headers: {
 					"content-type": "application/json",
 				},
@@ -78,12 +97,14 @@ describe("POST /api/mobile/time-clock", () => {
 
 		expect(response.status).toBe(200);
 		expect(mockState.requireMobileEmployee).toHaveBeenCalledWith("user-1", "org-1");
-		expect(mockState.clockIn).toHaveBeenCalledWith("remote");
+		expect(mockState.clockIn).toHaveBeenCalledWith("remote", { browserTimezone: "UTC" });
 		expect(mockState.clockOut).not.toHaveBeenCalled();
 	});
 
 	it("passes explicit browser timezone to clock-in context", async () => {
 		mockState.clockIn.mockResolvedValue({ success: true, data: { id: "entry-1" } });
+		const timestamp = new Date().toISOString();
+		const utcOffsetMinutes = 120;
 
 		const response = await POST(
 			new Request("https://app.example.com/api/mobile/time-clock", {
@@ -91,7 +112,9 @@ describe("POST /api/mobile/time-clock", () => {
 				body: JSON.stringify({
 					action: "clock_in",
 					workLocationType: "remote",
+					timestamp,
 					browserTimezone: "Europe/Berlin",
+					utcOffsetMinutes,
 				}),
 				headers: {
 					"content-type": "application/json",
@@ -103,7 +126,9 @@ describe("POST /api/mobile/time-clock", () => {
 		expect(mockState.clockIn).toHaveBeenCalledWith("remote", { browserTimezone: "Europe/Berlin" });
 	});
 
-	it("does not treat generic timezone as browser provenance", async () => {
+	it("accepts current UTC action evidence and keeps the server clock authoritative", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-10T12:30:00.000Z"));
 		mockState.clockIn.mockResolvedValue({ success: true, data: { id: "entry-1" } });
 
 		const response = await POST(
@@ -112,6 +137,107 @@ describe("POST /api/mobile/time-clock", () => {
 				body: JSON.stringify({
 					action: "clock_in",
 					workLocationType: "remote",
+					timestamp: "2026-07-10T12:30:00.000Z",
+					browserTimezone: "UTC",
+					utcOffsetMinutes: 0,
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mockState.clockIn).toHaveBeenCalledWith("remote", { browserTimezone: "UTC" });
+		vi.useRealTimers();
+	});
+
+	it("rejects action evidence with an invalid timezone before clocking", async () => {
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_out",
+					timestamp: new Date().toISOString(),
+					browserTimezone: "Not/AZone",
+					utcOffsetMinutes: 0,
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.clockOut).not.toHaveBeenCalled();
+	});
+
+	it("rejects an offset that does not match the supplied timezone at the action instant", async () => {
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_out",
+					timestamp: new Date().toISOString(),
+					browserTimezone: "Asia/Kathmandu",
+					utcOffsetMinutes: 0,
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.clockOut).not.toHaveBeenCalled();
+	});
+
+	it("rejects action evidence more than five minutes in the future", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-10T12:30:00.000Z"));
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_out",
+					timestamp: "2026-07-10T12:35:00.001Z",
+					browserTimezone: "UTC",
+					utcOffsetMinutes: 0,
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.clockOut).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it("rejects action evidence more than five minutes in the past", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-10T12:30:00.000Z"));
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_out",
+					timestamp: "2026-07-10T12:24:59.999Z",
+					browserTimezone: "UTC",
+					utcOffsetMinutes: 0,
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.clockOut).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it("rejects a generic timezone field that is not action evidence", async () => {
+		mockState.clockIn.mockResolvedValue({ success: true, data: { id: "entry-1" } });
+
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_in",
+					workLocationType: "remote",
+					...utcActionEvidence(),
 					timezone: "Europe/Berlin",
 				}),
 				headers: {
@@ -120,8 +246,8 @@ describe("POST /api/mobile/time-clock", () => {
 			}),
 		);
 
-		expect(response.status).toBe(200);
-		expect(mockState.clockIn).toHaveBeenCalledWith("remote");
+		expect(response.status).toBe(400);
+		expect(mockState.clockIn).not.toHaveBeenCalled();
 	});
 
 	it("rejects obsolete field work location when clocking in", async () => {
@@ -139,6 +265,25 @@ describe("POST /api/mobile/time-clock", () => {
 		expect(mockState.clockIn).not.toHaveBeenCalled();
 	});
 
+	it("rejects client-supplied employee and organization identifiers", async () => {
+		const response = await POST(
+			new Request("https://app.example.com/api/mobile/time-clock", {
+				method: "POST",
+				body: JSON.stringify({
+					action: "clock_in",
+					employeeId: "employee-foreign",
+					organizationId: "org-foreign",
+					workLocationType: "remote",
+				}),
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(mockState.requireActor).not.toHaveBeenCalled();
+		expect(mockState.clockIn).not.toHaveBeenCalled();
+	});
+
 	it("returns 403 when the user has no employee record in the active organization", async () => {
 		mockState.requireMobileEmployee.mockRejectedValue(
 			new mockState.MobileApiError(403, "Employee record required for the active organization"),
@@ -147,7 +292,7 @@ describe("POST /api/mobile/time-clock", () => {
 		const response = await POST(
 			new Request("https://app.example.com/api/mobile/time-clock", {
 				method: "POST",
-				body: JSON.stringify({ action: "clock_out" }),
+				body: JSON.stringify({ action: "clock_out", ...utcActionEvidence() }),
 				headers: {
 					"content-type": "application/json",
 				},
@@ -184,7 +329,7 @@ describe("POST /api/mobile/time-clock", () => {
 		const response = await POST(
 			new Request("https://app.example.com/api/mobile/time-clock", {
 				method: "POST",
-				body: JSON.stringify({ action: "clock_out" }),
+				body: JSON.stringify({ action: "clock_out", ...utcActionEvidence() }),
 				headers: {
 					"content-type": "application/json",
 				},
@@ -193,7 +338,9 @@ describe("POST /api/mobile/time-clock", () => {
 
 		expect(response.status).toBe(200);
 		expect(mockState.requireMobileEmployee).toHaveBeenCalledWith("user-1", "org-1");
-		expect(mockState.clockOut).toHaveBeenCalledWith();
+		expect(mockState.clockOut).toHaveBeenCalledWith(undefined, undefined, {
+			browserTimezone: "UTC",
+		});
 		expect(mockState.clockIn).not.toHaveBeenCalled();
 	});
 });

--- a/apps/webapp/src/app/api/mobile/time-clock/route.ts
+++ b/apps/webapp/src/app/api/mobile/time-clock/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { DateTime } from "luxon";
 import { z } from "zod";
 import { clockIn, clockOut } from "@/app/[locale]/(app)/time-tracking/actions/clocking";
 import {
@@ -8,10 +9,14 @@ import {
 } from "@/app/api/mobile/shared";
 import { isValidIanaTimezone } from "@/lib/time-tracking/timezone-capture";
 import { WORK_LOCATION_TYPES } from "@/lib/time-tracking/work-location";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
-const timezoneFields = {
-	browserTimezone: z.string().optional(),
-	timezone: z.string().optional(),
+const MAX_ACTION_SKEW_MILLISECONDS = 5 * 60 * 1000;
+
+const actionEvidenceFields = {
+	timestamp: z.string().datetime({ offset: true }),
+	browserTimezone: z.string(),
+	utcOffsetMinutes: z.number().int(),
 };
 
 const mobileTimeClockSchema = z.discriminatedUnion("action", [
@@ -20,12 +25,12 @@ const mobileTimeClockSchema = z.discriminatedUnion("action", [
 		workLocationType: z.enum(WORK_LOCATION_TYPES, {
 			error: "workLocationType is required for clock_in",
 		}),
-		...timezoneFields,
-	}),
+		...actionEvidenceFields,
+	}).strict(),
 	z.object({
 		action: z.literal("clock_out"),
-		...timezoneFields,
-	}),
+		...actionEvidenceFields,
+	}).strict(),
 ]);
 
 export async function POST(request: Request) {
@@ -51,19 +56,36 @@ export async function POST(request: Request) {
 			);
 		}
 
+		await clockingService.requireActor({
+			userId: session.user.id,
+			activeOrganizationId,
+		});
 		await requireMobileEmployee(session.user.id, activeOrganizationId);
-		const browserTimezone = isValidIanaTimezone(parsedBody.data.browserTimezone)
-			? parsedBody.data.browserTimezone
-			: undefined;
+		const actionInstant = DateTime.fromISO(parsedBody.data.timestamp, { setZone: true });
+		if (!actionInstant.isValid || actionInstant.offset !== 0) {
+			return NextResponse.json({ error: "timestamp must be a UTC instant" }, { status: 400 });
+		}
+		if (!isValidIanaTimezone(parsedBody.data.browserTimezone)) {
+			return NextResponse.json({ error: "Invalid browser timezone" }, { status: 400 });
+		}
+		if (
+			Math.abs(DateTime.utc().diff(actionInstant, "milliseconds").milliseconds) >
+			MAX_ACTION_SKEW_MILLISECONDS
+		) {
+			return NextResponse.json({ error: "Clock action timestamp is outside the allowed skew" }, { status: 400 });
+		}
+		if (actionInstant.setZone(parsedBody.data.browserTimezone).offset !== parsedBody.data.utcOffsetMinutes) {
+			return NextResponse.json({ error: "Timezone offset does not match the action instant" }, { status: 400 });
+		}
 
 		const result =
 			parsedBody.data.action === "clock_in"
-				? browserTimezone
-					? await clockIn(parsedBody.data.workLocationType, { browserTimezone })
-					: await clockIn(parsedBody.data.workLocationType)
-				: browserTimezone
-					? await clockOut(undefined, undefined, { browserTimezone })
-					: await clockOut();
+				? await clockIn(parsedBody.data.workLocationType, {
+						browserTimezone: parsedBody.data.browserTimezone,
+					})
+				: await clockOut(undefined, undefined, {
+						browserTimezone: parsedBody.data.browserTimezone,
+					});
 
 		if (!result.success) {
 			return NextResponse.json(
@@ -74,6 +96,9 @@ export async function POST(request: Request) {
 
 		return NextResponse.json(result);
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		if (error instanceof MobileApiError) {
 			return NextResponse.json({ error: error.message }, { status: error.status });
 		}

--- a/apps/webapp/src/app/api/time-entries/[entryId]/route.ts
+++ b/apps/webapp/src/app/api/time-entries/[entryId]/route.ts
@@ -9,6 +9,7 @@ import { getAbility } from "@/lib/auth-helpers";
 import { ForbiddenError, toHttpError } from "@/lib/authorization";
 import { runtime } from "@/lib/effect/runtime";
 import { TimeEntryService } from "@/lib/effect/services/time-entry.service";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 interface RouteParams {
 	params: Promise<{ entryId: string }>;
@@ -33,6 +34,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		// Get current user's employee record for the active organization ONLY
 		const [currentEmployee] = await db
@@ -100,6 +102,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 			},
 		});
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		console.error("Error fetching time entry:", error);
 
 		if (error instanceof Error && error.message.includes("NotFoundError")) {

--- a/apps/webapp/src/app/api/time-entries/clock-out-on-behalf/route.test.ts
+++ b/apps/webapp/src/app/api/time-entries/clock-out-on-behalf/route.test.ts
@@ -39,6 +39,7 @@ const mockState = vi.hoisted(() => {
 		markEmployeeWorkBalanceDirty: vi.fn(),
 		limit,
 		requireBillingForMutation: vi.fn(),
+		requireActor: vi.fn(),
 		resolveFallbackTimezoneCapture: vi.fn(),
 		select,
 		transaction,
@@ -130,6 +131,11 @@ vi.mock("@/lib/time-tracking/timezone-capture", () => ({
 	resolveFallbackTimezoneCapture: mockState.resolveFallbackTimezoneCapture,
 }));
 
+vi.mock("@/lib/time-tracking/clocking-service", () => ({
+	ClockingAccessError: class ClockingAccessError extends Error {},
+	clockingService: { requireActor: mockState.requireActor },
+}));
+
 vi.mock("@/app/[locale]/(app)/time-tracking/actions/entry-helpers", () => ({
 	createTimeEntry: mockState.createTimeEntry,
 }));
@@ -219,6 +225,11 @@ describe("POST /api/time-entries/clock-out-on-behalf", () => {
 		mockState.txLimit.mockResolvedValue([runningPeriod]);
 		mockState.getAbility.mockResolvedValue({ can: vi.fn(() => true) });
 		mockState.requireBillingForMutation.mockResolvedValue({ canAccess: true });
+		mockState.requireActor.mockResolvedValue({
+			employee: actorEmployee,
+			organizationId: "org-1",
+			userId: "actor-user-1",
+		});
 		mockState.isBillingMutationAllowed.mockReturnValue(true);
 		mockState.createBillingForbiddenResponse.mockImplementation((access) =>
 			Response.json({ error: "billing_required", reason: access.reason }, { status: 402 }),

--- a/apps/webapp/src/app/api/time-entries/clock-out-on-behalf/route.ts
+++ b/apps/webapp/src/app/api/time-entries/clock-out-on-behalf/route.ts
@@ -24,6 +24,7 @@ import {
 	resolveFallbackTimezoneCapture,
 } from "@/lib/time-tracking/timezone-capture";
 import { markEmployeeWorkBalanceDirty } from "@/lib/work-balance/service";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 class TimeEntryConflictError extends Error {
 	constructor(message: string) {
@@ -69,6 +70,7 @@ export async function POST(request: NextRequest) {
 		if (!organizationId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: organizationId });
 
 		const [actorEmployee] = await db
 			.select()
@@ -254,6 +256,9 @@ export async function POST(request: NextRequest) {
 
 		return NextResponse.json({ entry: result.entry }, { status: 201 });
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		if (error instanceof TimeEntryConflictError) {
 			return NextResponse.json({ error: error.message }, { status: 409 });
 		}

--- a/apps/webapp/src/app/api/time-entries/corrections/route.test.ts
+++ b/apps/webapp/src/app/api/time-entries/corrections/route.test.ts
@@ -28,6 +28,7 @@ const mockState = vi.hoisted(() => {
 		markEmployeeWorkBalanceDirty: vi.fn(),
 		resolveCorrectionApprovalManager: vi.fn(),
 		runPromise: vi.fn(),
+		requireActor: vi.fn(),
 		select,
 		transaction: vi.fn(),
 		where,
@@ -133,6 +134,11 @@ vi.mock("@/lib/work-balance/service", () => ({
 	markEmployeeWorkBalanceDirty: mockState.markEmployeeWorkBalanceDirty,
 }));
 
+vi.mock("@/lib/time-tracking/clocking-service", () => ({
+	ClockingAccessError: class ClockingAccessError extends Error {},
+	clockingService: { requireActor: mockState.requireActor },
+}));
+
 vi.mock("drizzle-orm", () => ({
 	and: (...conditions: unknown[]) => ({ conditions, type: "and" }),
 	eq: (column: unknown, value: unknown) => ({ column, type: "eq", value }),
@@ -229,6 +235,11 @@ describe("GET /api/time-entries/corrections", () => {
 			session: { activeOrganizationId: "org-1" },
 			user: { id: "user-1" },
 		});
+		mockState.requireActor.mockResolvedValue({
+			employee: { id: "employee-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
+		});
 		mockState.limit.mockResolvedValue([
 			{
 				id: "employee-1",
@@ -304,6 +315,11 @@ describe("POST /api/time-entries/corrections", () => {
 		mockState.getSession.mockResolvedValue({
 			session: { activeOrganizationId: "org-1" },
 			user: { id: "user-1" },
+		});
+		mockState.requireActor.mockResolvedValue({
+			employee: { id: "employee-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
 		});
 		mockState.canApproveFor.mockResolvedValue(false);
 		mockState.getUserTimezone.mockResolvedValue("Europe/Berlin");

--- a/apps/webapp/src/app/api/time-entries/corrections/route.ts
+++ b/apps/webapp/src/app/api/time-entries/corrections/route.ts
@@ -23,6 +23,7 @@ import {
 	resolveTimeEntryTimezoneCapture,
 } from "@/lib/time-tracking/timezone-capture";
 import { markEmployeeWorkBalanceDirty } from "@/lib/work-balance/service";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 const RFC3339_WITH_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
@@ -108,6 +109,7 @@ export async function POST(request: NextRequest) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		const body = await request.json();
 		const { replacesEntryId, timestamp, notes, timezone } = body;
@@ -365,6 +367,9 @@ export async function POST(request: NextRequest) {
 			{ status: 201 },
 		);
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		const domainError = getCorrectionDomainError(error);
 		if (domainError instanceof ConflictError) {
 			return NextResponse.json(
@@ -411,6 +416,7 @@ export async function GET(request: NextRequest) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		const searchParams = request.nextUrl.searchParams;
 		const employeeId = searchParams.get("employeeId");
@@ -507,6 +513,9 @@ export async function GET(request: NextRequest) {
 
 		return NextResponse.json({ corrections });
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		console.error("Error fetching corrections:", error);
 		return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 	}

--- a/apps/webapp/src/app/api/time-entries/route.test.ts
+++ b/apps/webapp/src/app/api/time-entries/route.test.ts
@@ -44,6 +44,7 @@ const mockState = vi.hoisted(() => {
 		isBillingMutationAllowed: vi.fn(),
 		limit,
 		requireBillingForMutation: vi.fn(),
+		requireActor: vi.fn(),
 		runPromise: vi.fn(),
 		select,
 		transaction,
@@ -162,6 +163,11 @@ vi.mock("@/lib/effect/services/time-entry.service", () => ({
 	TimeEntryService: Symbol("TimeEntryService"),
 }));
 
+vi.mock("@/lib/time-tracking/clocking-service", () => ({
+	ClockingAccessError: class ClockingAccessError extends Error {},
+	clockingService: { requireActor: mockState.requireActor },
+}));
+
 vi.mock("@/app/[locale]/(app)/time-tracking/actions/entry-helpers", () => ({
 	createTimeEntry: mockState.createTimeEntry,
 	validateProjectAssignment: mockState.validateProjectAssignment,
@@ -218,6 +224,11 @@ describe("GET /api/time-entries", () => {
 		}));
 		mockState.getAbility.mockResolvedValue({
 			can: vi.fn(() => true),
+		});
+		mockState.requireActor.mockResolvedValue({
+			employee: { id: "employee-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
 		});
 		mockState.limit.mockResolvedValue([
 			{
@@ -344,6 +355,7 @@ describe("POST /api/time-entries", () => {
 		mockState.values.mockReset();
 		mockState.validateProjectAssignment.mockReset();
 		mockState.requireBillingForMutation.mockReset();
+		mockState.requireActor.mockReset();
 		mockState.isBillingMutationAllowed.mockReset();
 		mockState.createBillingForbiddenResponse.mockReset();
 		mockState.employeeHasAccessToCategory.mockReset();
@@ -371,6 +383,11 @@ describe("POST /api/time-entries", () => {
 		mockState.updateReturning.mockResolvedValue([{ id: "period-1" }]);
 		mockState.validateProjectAssignment.mockResolvedValue({ isValid: true });
 		mockState.requireBillingForMutation.mockResolvedValue({ canAccess: true });
+		mockState.requireActor.mockResolvedValue({
+			employee: { id: "employee-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
+		});
 		mockState.isBillingMutationAllowed.mockReturnValue(true);
 		mockState.createBillingForbiddenResponse.mockImplementation((access) =>
 			Response.json(
@@ -426,12 +443,7 @@ describe("POST /api/time-entries", () => {
 		);
 	});
 
-	it("uses the captured organization for offline sync requests", async () => {
-		mockState.limit.mockReset();
-		mockState.limit.mockResolvedValueOnce([
-			{ id: "employee-2", organizationId: "org-2", teamId: "team-2" },
-		]);
-
+	it("rejects client-supplied organization ids instead of switching the active organization", async () => {
 		const response = await POST(
 			new Request("https://z8.test/api/time-entries", {
 				body: JSON.stringify({
@@ -443,18 +455,26 @@ describe("POST /api/time-entries", () => {
 			}) as never,
 		);
 
-		expect(response.status).toBe(201);
-		expect(mockState.requireBillingForMutation).toHaveBeenCalledWith("org-2");
-		expect(mockState.txExecute).toHaveBeenCalledWith(
-			expect.objectContaining({ values: ["org-2:employee-2"] }),
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "organizationId is server-derived" });
+		expect(mockState.createTimeEntry).not.toHaveBeenCalled();
+	});
+
+	it("rejects client-supplied employee ids instead of allowing on-behalf clocking", async () => {
+		const response = await POST(
+			new Request("https://z8.test/api/time-entries", {
+				body: JSON.stringify({
+					employeeId: "employee-foreign",
+					type: "clock_in",
+					timestamp: "2026-05-04T09:00:00.000Z",
+				}),
+				method: "POST",
+			}) as never,
 		);
-		expect(mockState.createTimeEntry).toHaveBeenCalledWith(
-			expect.objectContaining({ employeeId: "employee-2", organizationId: "org-2" }),
-			expect.anything(),
-		);
-		expect(mockState.values).toHaveBeenCalledWith(
-			expect.objectContaining({ employeeId: "employee-2", organizationId: "org-2" }),
-		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "employeeId is server-derived" });
+		expect(mockState.createTimeEntry).not.toHaveBeenCalled();
 	});
 
 	it("acquires a per-employee transaction lock before active period lookup", async () => {

--- a/apps/webapp/src/app/api/time-entries/route.ts
+++ b/apps/webapp/src/app/api/time-entries/route.ts
@@ -30,6 +30,7 @@ import {
 	resolveTimeEntryTimezoneCapture,
 } from "@/lib/time-tracking/timezone-capture";
 import { isWorkLocationType } from "@/lib/time-tracking/work-location";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 class TimeEntryConflictError extends Error {
 	constructor(message: string) {
@@ -81,6 +82,10 @@ export async function GET(request: NextRequest) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({
+			userId: session.user.id,
+			activeOrganizationId: activeOrgId,
+		});
 
 		const [currentEmployee] = await db
 			.select()
@@ -198,6 +203,9 @@ export async function POST(request: NextRequest) {
 		if (!session?.user) {
 			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 		}
+		if (body && typeof body === "object" && "employeeId" in body) {
+			return NextResponse.json({ error: "employeeId is server-derived" }, { status: 400 });
+		}
 
 		const {
 			type,
@@ -226,14 +234,19 @@ export async function POST(request: NextRequest) {
 			return NextResponse.json({ error: "Invalid work location type" }, { status: 400 });
 		}
 
-		// Offline sync sends the organization captured when the event happened.
 		const activeOrgId = session.session.activeOrganizationId;
-		const requestedOrgId =
-			typeof organizationId === "string" && organizationId ? organizationId : activeOrgId;
+		if (organizationId !== undefined) {
+			return NextResponse.json({ error: "organizationId is server-derived" }, { status: 400 });
+		}
+		const requestedOrgId = activeOrgId;
 
 		if (!requestedOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({
+			userId: session.user.id,
+			activeOrganizationId: requestedOrgId,
+		});
 
 		const [currentEmployee] = await db
 			.select()
@@ -404,6 +417,9 @@ export async function POST(request: NextRequest) {
 
 		return NextResponse.json({ entry }, { status: 201 });
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		if (error instanceof TimeEntryConflictError) {
 			return NextResponse.json({ error: error.message }, { status: 409 });
 		}

--- a/apps/webapp/src/app/api/time-entries/status/route.ts
+++ b/apps/webapp/src/app/api/time-entries/status/route.ts
@@ -4,6 +4,7 @@ import { connection, NextResponse } from "next/server";
 import { db } from "@/db";
 import { employee, workPeriod } from "@/db/schema";
 import { auth } from "@/lib/auth";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 /**
  * GET /api/time-entries/status
@@ -44,13 +45,9 @@ export async function GET() {
 		// Get employee record for the active organization
 		const activeOrgId = session.session.activeOrganizationId;
 		if (!activeOrgId) {
-			return NextResponse.json({
-				hasEmployee: false,
-				employeeId: null,
-				isClockedIn: false,
-				activeWorkPeriod: null,
-			});
+			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		const emp = await db.query.employee.findFirst({
 			where: and(
@@ -91,7 +88,10 @@ export async function GET() {
 		};
 
 		return NextResponse.json(response);
-	} catch (_error) {
+	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 	}
 }

--- a/apps/webapp/src/app/api/time-entries/verify/route.ts
+++ b/apps/webapp/src/app/api/time-entries/verify/route.ts
@@ -9,6 +9,7 @@ import { getAbility } from "@/lib/auth-helpers";
 import { ForbiddenError, toHttpError } from "@/lib/authorization";
 import { runtime } from "@/lib/effect/runtime";
 import { TimeEntryService } from "@/lib/effect/services/time-entry.service";
+import { ClockingAccessError, clockingService } from "@/lib/time-tracking/clocking-service";
 
 /**
  * POST /api/time-entries/verify
@@ -27,6 +28,7 @@ export async function POST(request: NextRequest) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		const body = await request.json();
 		const { employeeId } = body;
@@ -95,6 +97,9 @@ export async function POST(request: NextRequest) {
 			verifiedAt: new Date().toISOString(),
 		});
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		console.error("Error verifying time entry chain:", error);
 		return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 	}
@@ -117,6 +122,7 @@ export async function GET(request: NextRequest) {
 		if (!activeOrgId) {
 			return NextResponse.json({ error: "No active organization" }, { status: 400 });
 		}
+		await clockingService.requireActor({ userId: session.user.id, activeOrganizationId: activeOrgId });
 
 		const searchParams = request.nextUrl.searchParams;
 		const employeeId = searchParams.get("employeeId");
@@ -169,6 +175,9 @@ export async function GET(request: NextRequest) {
 			generatedAt: new Date().toISOString(),
 		});
 	} catch (error) {
+		if (error instanceof ClockingAccessError) {
+			return NextResponse.json({ error: error.message }, { status: 403 });
+		}
 		console.error("Error getting chain hash:", error);
 		return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 	}

--- a/apps/webapp/src/components/font-size-preference-utils.ts
+++ b/apps/webapp/src/components/font-size-preference-utils.ts
@@ -30,10 +30,15 @@ function readStoredFontSize(storage: Storage | undefined): FontSizePreference {
 }
 
 function writeStoredFontSize(storage: Storage | undefined, value: FontSizePreference) {
+	if (!storage) {
+		return false;
+	}
+
 	try {
-		storage?.setItem(FONT_SIZE_STORAGE_KEY, value);
+		storage.setItem(FONT_SIZE_STORAGE_KEY, value);
+		return true;
 	} catch {
-		// Keep the current session updated even when persistence is blocked.
+		return false;
 	}
 }
 

--- a/apps/webapp/src/components/font-size-preference.test.tsx
+++ b/apps/webapp/src/components/font-size-preference.test.tsx
@@ -23,38 +23,16 @@ function Consumer() {
 	);
 }
 
-function createStorageMock(): Storage {
-	const store = new Map<string, string>();
-
-	return {
-		length: 0,
-		clear() {
-			store.clear();
-			this.length = 0;
-		},
-		getItem(key: string) {
-			return store.get(key) ?? null;
-		},
-		key(index: number) {
-			return Array.from(store.keys())[index] ?? null;
-		},
-		removeItem(key: string) {
-			store.delete(key);
-			this.length = store.size;
-		},
-		setItem(key: string, value: string) {
-			store.set(key, value);
-			this.length = store.size;
-		},
-	};
-}
+const storageFrame = document.createElement("iframe");
+document.body.append(storageFrame);
+const eventStorage = storageFrame.contentWindow!.localStorage;
 
 beforeEach(() => {
 	Object.defineProperty(window, "localStorage", {
 		configurable: true,
-		value: createStorageMock(),
+		value: eventStorage,
 	});
-	localStorage.clear();
+	eventStorage.clear();
 	document.documentElement.removeAttribute("data-font-size");
 });
 
@@ -113,6 +91,29 @@ describe("font size preference helpers", () => {
 });
 
 describe("FontSizeProvider", () => {
+	it("updates when the stored preference changes in another tab", async () => {
+		render(
+			<FontSizeProvider>
+				<Consumer />
+			</FontSizeProvider>,
+		);
+
+		await screen.findByText("Current: default");
+		localStorage.setItem(FONT_SIZE_STORAGE_KEY, "comfortable");
+		act(() => {
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: FONT_SIZE_STORAGE_KEY,
+					newValue: "comfortable",
+					storageArea: localStorage,
+				}),
+			);
+		});
+
+		expect(await screen.findByText("Current: comfortable")).toBeTruthy();
+		expect(document.documentElement.dataset.fontSize).toBe("comfortable");
+	});
+
 	it("loads stored preference and updates the document", async () => {
 		localStorage.setItem(FONT_SIZE_STORAGE_KEY, "comfortable");
 
@@ -142,6 +143,112 @@ describe("FontSizeProvider", () => {
 		expect(screen.getByText("Current: large")).toBeTruthy();
 		expect(localStorage.getItem(FONT_SIZE_STORAGE_KEY)).toBe("large");
 		expect(document.documentElement.dataset.fontSize).toBe("large");
+	});
+
+	it("keeps the selected preference when storage writes throw", async () => {
+		const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+		const storage = {
+			getItem: vi.fn(() => null),
+			setItem: vi.fn(() => {
+				throw new DOMException("blocked", "SecurityError");
+			}),
+		} as unknown as Storage;
+
+		Object.defineProperty(window, "localStorage", {
+			configurable: true,
+			value: storage,
+		});
+
+		try {
+			render(
+				<FontSizeProvider>
+					<Consumer />
+				</FontSizeProvider>,
+			);
+
+			expect(await screen.findByText("Current: default")).toBeTruthy();
+
+			act(() => {
+				screen.getByRole("button", { name: "Set large" }).click();
+			});
+
+			expect(screen.getByText("Current: large")).toBeTruthy();
+			expect(document.documentElement.dataset.fontSize).toBe("large");
+		} finally {
+			if (localStorageDescriptor) {
+				Object.defineProperty(window, "localStorage", localStorageDescriptor);
+			}
+
+			act(() => {
+				window.dispatchEvent(
+					new StorageEvent("storage", {
+						key: FONT_SIZE_STORAGE_KEY,
+						storageArea: eventStorage,
+					}),
+				);
+			});
+		}
+	});
+
+	it("ignores unrelated storage events while using the in-memory preference", async () => {
+		const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+		const storage = eventStorage;
+		const storagePrototype = storageFrame.contentWindow!.Storage.prototype;
+		const setItemDescriptor = Object.getOwnPropertyDescriptor(storagePrototype, "setItem")!;
+
+		Object.defineProperty(storagePrototype, "setItem", {
+			configurable: true,
+			value() {
+				throw new DOMException("blocked", "SecurityError");
+			},
+		});
+
+		Object.defineProperty(window, "localStorage", {
+			configurable: true,
+			value: storage,
+		});
+
+		try {
+			render(
+				<FontSizeProvider>
+					<Consumer />
+				</FontSizeProvider>,
+			);
+
+			act(() => {
+				screen.getByRole("button", { name: "Set large" }).click();
+			});
+
+			expect(screen.getByText("Current: large")).toBeTruthy();
+			expect(storage.getItem(FONT_SIZE_STORAGE_KEY)).toBeNull();
+
+			act(() => {
+				window.dispatchEvent(
+					new StorageEvent("storage", {
+						key: "unrelated-preference",
+						storageArea: storage,
+					}),
+				);
+			});
+
+			expect(screen.getByText("Current: large")).toBeTruthy();
+			expect(document.documentElement.dataset.fontSize).toBe("large");
+		} finally {
+			Object.defineProperty(storagePrototype, "setItem", setItemDescriptor);
+
+			if (localStorageDescriptor) {
+				Object.defineProperty(window, "localStorage", localStorageDescriptor);
+			}
+
+			act(() => {
+				window.dispatchEvent(
+					new StorageEvent("storage", {
+						key: FONT_SIZE_STORAGE_KEY,
+						storageArea: eventStorage,
+					}),
+				);
+			});
+		}
 	});
 
 	it("keeps working when localStorage access throws", async () => {

--- a/apps/webapp/src/components/font-size-preference.tsx
+++ b/apps/webapp/src/components/font-size-preference.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { createContext, use, useEffect, useState } from "react";
+import { createContext, use, useEffect, useSyncExternalStore } from "react";
 import {
 	applyFontSizePreference,
+	FONT_SIZE_STORAGE_KEY,
 	type FontSizePreference,
 	readStoredFontSize,
 	writeStoredFontSize,
@@ -23,9 +24,58 @@ function getLocalStorage(): Storage | undefined {
 	}
 }
 
+const FONT_SIZE_CHANGE_EVENT = "z8-font-size-change";
+let inMemoryFontSize: FontSizePreference = "default";
+let usesInMemoryFontSize = false;
+
+function subscribeToFontSizePreference(onStoreChange: () => void) {
+	const onStorageChange = (event: StorageEvent) => {
+		if (event.key !== FONT_SIZE_STORAGE_KEY && event.key !== null) {
+			return;
+		}
+
+		const storage = getLocalStorage();
+
+		if (event.storageArea && event.storageArea !== storage) {
+			return;
+		}
+
+		usesInMemoryFontSize = false;
+		onStoreChange();
+	};
+
+	window.addEventListener("storage", onStorageChange);
+	window.addEventListener(FONT_SIZE_CHANGE_EVENT, onStoreChange);
+
+	return () => {
+		window.removeEventListener("storage", onStorageChange);
+		window.removeEventListener(FONT_SIZE_CHANGE_EVENT, onStoreChange);
+	};
+}
+
+function getClientFontSizePreference() {
+	if (usesInMemoryFontSize) {
+		return inMemoryFontSize;
+	}
+
+	const storage = getLocalStorage();
+
+	if (storage) {
+		return readStoredFontSize(storage);
+	}
+
+	return "default";
+}
+
+function getServerFontSizePreference(): FontSizePreference {
+	return "default";
+}
+
 export function FontSizeProvider({ children }: { children: React.ReactNode }) {
-	const [fontSize, setFontSizeState] = useState<FontSizePreference>(() =>
-		readStoredFontSize(getLocalStorage()),
+	const fontSize = useSyncExternalStore(
+		subscribeToFontSizePreference,
+		getClientFontSizePreference,
+		getServerFontSizePreference,
 	);
 
 	useEffect(() => {
@@ -33,8 +83,10 @@ export function FontSizeProvider({ children }: { children: React.ReactNode }) {
 	}, [fontSize]);
 
 	const setFontSize = (value: FontSizePreference) => {
-		setFontSizeState(value);
-		writeStoredFontSize(getLocalStorage(), value);
+		inMemoryFontSize = value;
+		const storage = getLocalStorage();
+		usesInMemoryFontSize = !writeStoredFontSize(storage, value);
+		window.dispatchEvent(new Event(FONT_SIZE_CHANGE_EVENT));
 		applyFontSizePreference(value);
 	};
 

--- a/apps/webapp/src/db/schema/relations.ts
+++ b/apps/webapp/src/db/schema/relations.ts
@@ -2842,6 +2842,7 @@ import {
 	telegramApprovalMessage,
 	telegramBotConfig,
 	telegramConversation,
+	telegramDigestDelivery,
 	telegramEscalation,
 	telegramLinkCode,
 	telegramUserMapping,
@@ -2876,6 +2877,21 @@ export const telegramConversationRelations = relations(telegramConversation, ({ 
 	}),
 	user: one(user, {
 		fields: [telegramConversation.userId],
+		references: [user.id],
+	}),
+}));
+
+export const telegramDigestDeliveryRelations = relations(telegramDigestDelivery, ({ one }) => ({
+	organization: one(organization, {
+		fields: [telegramDigestDelivery.organizationId],
+		references: [organization.id],
+	}),
+	recipientEmployee: one(employee, {
+		fields: [telegramDigestDelivery.recipientEmployeeId],
+		references: [employee.id],
+	}),
+	recipientUser: one(user, {
+		fields: [telegramDigestDelivery.recipientUserId],
 		references: [user.id],
 	}),
 }));

--- a/apps/webapp/src/db/schema/telegram-integration.ts
+++ b/apps/webapp/src/db/schema/telegram-integration.ts
@@ -165,6 +165,49 @@ export const telegramConversation = pgTable(
 );
 
 /**
+ * Durable idempotency ledger for Telegram daily digest deliveries.
+ * A recipient-local logical date is used so a scheduled bot timezone never
+ * changes which daily digest a recipient receives.
+ */
+export const telegramDigestDelivery = pgTable(
+	"telegram_digest_delivery",
+	{
+		id: uuid("id").defaultRandom().primaryKey(),
+		organizationId: text("organization_id")
+			.notNull()
+			.references(() => organization.id, { onDelete: "cascade" }),
+		recipientEmployeeId: uuid("recipient_employee_id")
+			.notNull()
+			.references(() => employee.id, { onDelete: "cascade" }),
+		recipientUserId: text("recipient_user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		platform: text("platform").notNull(),
+		digestType: text("digest_type").notNull(),
+		logicalDate: text("logical_date").notNull(),
+		status: text("status").default("sending").notNull(),
+		attemptedAt: timestamp("attempted_at").defaultNow().notNull(),
+		sentAt: timestamp("sent_at"),
+		failedAt: timestamp("failed_at"),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+		updatedAt: timestamp("updated_at")
+			.$onUpdate(() => currentTimestamp())
+			.notNull(),
+	},
+	(table) => [
+		uniqueIndex("telegramDigestDelivery_idempotency_unique_idx").on(
+			table.organizationId,
+			table.recipientEmployeeId,
+			table.recipientUserId,
+			table.platform,
+			table.digestType,
+			table.logicalDate,
+		),
+		index("telegramDigestDelivery_organizationId_idx").on(table.organizationId),
+	],
+);
+
+/**
  * Link codes for connecting Telegram accounts to Z8.
  * User generates a code in Z8 settings, sends /link CODE to the bot.
  */

--- a/apps/webapp/src/lib/bot-platform/digest-settings.test.ts
+++ b/apps/webapp/src/lib/bot-platform/digest-settings.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { parseDigestSettings } from "./digest-settings";
+
+describe("parseDigestSettings", () => {
+	it.each(["00:00", "23:59"])("accepts the %s wall-clock time", (time) => {
+		expect(parseDigestSettings({ time, timezone: "Asia/Kathmandu" })).toEqual({
+			time,
+			timezone: "Asia/Kathmandu",
+		});
+	});
+
+	it.each(["9:30", "24:00", "09:30:00"])("rejects invalid time %s", (time) => {
+		expect(() => parseDigestSettings({ time, timezone: "UTC" })).toThrow("digest time");
+	});
+
+	it("rejects an invalid schedule timezone", () => {
+		expect(() => parseDigestSettings({ time: "09:30", timezone: "Mars/Olympus" })).toThrow(
+			"digest timezone",
+		);
+	});
+});

--- a/apps/webapp/src/lib/bot-platform/digest-settings.ts
+++ b/apps/webapp/src/lib/bot-platform/digest-settings.ts
@@ -1,0 +1,20 @@
+import { DateTime } from "luxon";
+
+export interface DigestSettings {
+	time: string;
+	timezone: string;
+}
+
+const DIGEST_TIME = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+export function parseDigestSettings(input: DigestSettings): DigestSettings {
+	if (!DIGEST_TIME.test(input.time)) {
+		throw new Error("Invalid digest time");
+	}
+
+	if (!DateTime.fromMillis(0, { zone: input.timezone }).isValid) {
+		throw new Error("Invalid digest timezone");
+	}
+
+	return input;
+}

--- a/apps/webapp/src/lib/bot-platform/temporal-guardrails.test.ts
+++ b/apps/webapp/src/lib/bot-platform/temporal-guardrails.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const migratedSources = [
+	"../telegram/approval-handler.ts",
+	"../telegram/formatters.ts",
+	"../telegram/jobs/daily-digest.ts",
+	"../telegram/jobs/digest-schedule.ts",
+	"../notifications/recipient-display-context.ts",
+	"../notifications/telegram-channel.ts",
+	"../teams/jobs/daily-digest.ts",
+];
+
+async function readMigratedSources(): Promise<string> {
+	return Promise.all(
+		migratedSources.map((source) => readFile(path.resolve(directory, source), "utf8")),
+	).then((sources) => sources.join("\n"));
+}
+
+function expectLuxonConstructorsToSpecifyZone(source: string): void {
+	const constructors = source.matchAll(/DateTime\.from(?:ISO|JSDate|Object)\(([\s\S]*?)\);/g);
+
+	for (const luxonCall of constructors) {
+		expect(luxonCall[1]).toContain("zone:");
+	}
+}
+
+describe("migrated bot temporal guardrails", () => {
+	it("does not derive display values from the host zone", async () => {
+		const source = await readMigratedSources();
+
+		expect(source).not.toMatch(/DateTime\.(?:local|now)\s*\(/);
+		expectLuxonConstructorsToSpecifyZone(source);
+		expect(source).not.toMatch(/new Date\(\s*["'`]\d{4}-\d{2}-\d{2}["'`]\s*\)/);
+	});
+});

--- a/apps/webapp/src/lib/notifications/outbound-localization.ts
+++ b/apps/webapp/src/lib/notifications/outbound-localization.ts
@@ -22,6 +22,7 @@ interface LocalizeOutboundNotificationParams {
 	title: string;
 	message: string;
 	metadata?: Record<string, unknown> | string | null;
+	locale?: string;
 }
 
 interface LocalizedOutboundNotification {
@@ -101,10 +102,13 @@ export async function localizeOutboundNotification({
 	title,
 	message,
 	metadata,
+	locale: explicitLocale,
 }: LocalizeOutboundNotificationParams): Promise<LocalizedOutboundNotification> {
-	let locale = FALLBACK_LOCALE;
+	let locale = explicitLocale ?? FALLBACK_LOCALE;
 	try {
-		locale = await resolveRecipientNotificationLocale({ userId, organizationId });
+		if (!explicitLocale) {
+			locale = await resolveRecipientNotificationLocale({ userId, organizationId });
+		}
 	} catch (error) {
 		logger.warn(
 			{ err: error, userId, organizationId, locale: FALLBACK_LOCALE },

--- a/apps/webapp/src/lib/notifications/recipient-display-context.test.ts
+++ b/apps/webapp/src/lib/notifications/recipient-display-context.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { employeeFindFirstMock, userSettingsFindFirstMock } = vi.hoisted(() => ({
+	employeeFindFirstMock: vi.fn(),
+	userSettingsFindFirstMock: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+	db: {
+		query: {
+			employee: { findFirst: employeeFindFirstMock },
+			userSettings: { findFirst: userSettingsFindFirstMock },
+		},
+	},
+}));
+
+vi.mock("@/db/schema", () => ({
+	employee: {
+		isActive: "employee.isActive",
+		organizationId: "employee.organizationId",
+		userId: "employee.userId",
+	},
+	userSettings: { userId: "userSettings.userId" },
+}));
+
+describe("resolveRecipientDisplayContext", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("rejects a recipient without active membership in the requested organization", async () => {
+		employeeFindFirstMock.mockResolvedValue(undefined);
+		const { resolveRecipientDisplayContext } = await import("./recipient-display-context");
+
+		await expect(
+			resolveRecipientDisplayContext({ userId: "user-in-org-b", organizationId: "org-a" }),
+		).resolves.toBeNull();
+		expect(userSettingsFindFirstMock).not.toHaveBeenCalled();
+	});
+
+	it("returns the recipient's saved display context after scoped membership verification", async () => {
+		employeeFindFirstMock.mockResolvedValue({ id: "employee-a" });
+		userSettingsFindFirstMock.mockResolvedValue({
+			locale: "de",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+		const { resolveRecipientDisplayContext } = await import("./recipient-display-context");
+
+		await expect(
+			resolveRecipientDisplayContext({ userId: "user-a", organizationId: "org-a" }),
+		).resolves.toEqual({ locale: "de", timeFormat: "24h", timezone: "Europe/Berlin" });
+	});
+
+	it("falls back to safe display defaults for missing or invalid recipient settings", async () => {
+		employeeFindFirstMock.mockResolvedValue({ id: "employee-a" });
+		userSettingsFindFirstMock.mockResolvedValue({
+			locale: null,
+			timeFormat: null,
+			timezone: "Mars/Olympus",
+		});
+		const { resolveRecipientDisplayContext } = await import("./recipient-display-context");
+
+		await expect(
+			resolveRecipientDisplayContext({ userId: "user-a", organizationId: "org-a" }),
+		).resolves.toEqual({ locale: "en", timeFormat: "24h", timezone: "UTC" });
+	});
+});

--- a/apps/webapp/src/lib/notifications/recipient-display-context.ts
+++ b/apps/webapp/src/lib/notifications/recipient-display-context.ts
@@ -1,0 +1,45 @@
+import { and, eq } from "drizzle-orm";
+import { DateTime } from "luxon";
+import { db } from "@/db";
+import { employee, userSettings } from "@/db/schema";
+import { DEFAULT_LANGUAGE } from "@/tolgee/shared";
+
+export interface RecipientDisplayContext {
+	timezone: string;
+	locale: string;
+	timeFormat: "12h" | "24h";
+}
+
+function isValidTimezone(timezone: string): boolean {
+	return DateTime.fromMillis(0, { zone: timezone }).isValid;
+}
+
+/**
+ * Resolves display preferences only after proving the recipient belongs to the
+ * notification's organization. This prevents global user preferences leaking
+ * across tenants into outbound messages.
+ */
+export async function resolveRecipientDisplayContext(input: {
+	userId: string;
+	organizationId: string;
+}): Promise<RecipientDisplayContext | null> {
+	const recipient = await db.query.employee.findFirst({
+		where: and(
+			eq(employee.userId, input.userId),
+			eq(employee.organizationId, input.organizationId),
+			eq(employee.isActive, true),
+		),
+		columns: { id: true },
+	});
+	if (!recipient) return null;
+
+	const settings = await db.query.userSettings.findFirst({
+		where: eq(userSettings.userId, input.userId),
+		columns: { locale: true, timeFormat: true, timezone: true },
+	});
+	return {
+		locale: settings?.locale ?? DEFAULT_LANGUAGE,
+		timeFormat: settings?.timeFormat === "12h" ? "12h" : "24h",
+		timezone: settings && isValidTimezone(settings.timezone) ? settings.timezone : "UTC",
+	};
+}

--- a/apps/webapp/src/lib/notifications/telegram-channel.test.ts
+++ b/apps/webapp/src/lib/notifications/telegram-channel.test.ts
@@ -6,6 +6,7 @@ const {
 	errorMock,
 	getBotConfigMock,
 	getChatIdMock,
+	resolveRecipientDisplayContextMock,
 	sendApprovalMessageMock,
 	sendMessageMock,
 } = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const {
 	errorMock: vi.fn(),
 	getBotConfigMock: vi.fn(),
 	getChatIdMock: vi.fn(),
+	resolveRecipientDisplayContextMock: vi.fn(),
 	sendApprovalMessageMock: vi.fn(),
 	sendMessageMock: vi.fn(),
 }));
@@ -53,6 +55,10 @@ vi.mock("./outbound-localization", () => ({
 	localizeOutboundNotification: vi.fn(),
 }));
 
+vi.mock("./recipient-display-context", () => ({
+	resolveRecipientDisplayContext: resolveRecipientDisplayContextMock,
+}));
+
 const localizeOutboundNotificationMock = vi.mocked(localizeOutboundNotification);
 
 describe("sendTelegramNotification", () => {
@@ -60,6 +66,11 @@ describe("sendTelegramNotification", () => {
 		vi.clearAllMocks();
 		getBotConfigMock.mockResolvedValue({ botToken: "bot-token" });
 		getChatIdMock.mockResolvedValue("chat-123");
+		resolveRecipientDisplayContextMock.mockResolvedValue({
+			locale: "de",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
 		sendMessageMock.mockResolvedValue({ ok: true });
 		localizeOutboundNotificationMock.mockResolvedValue({
 			locale: "de",
@@ -94,6 +105,7 @@ describe("sendTelegramNotification", () => {
 			title: "Added to team",
 			message: "You were added to the Ops (EU) team.",
 			metadata,
+			locale: "de",
 		});
 		expect(sendMessageMock).toHaveBeenCalledWith("bot-token", {
 			chat_id: "chat-123",

--- a/apps/webapp/src/lib/notifications/telegram-channel.ts
+++ b/apps/webapp/src/lib/notifications/telegram-channel.ts
@@ -10,6 +10,7 @@ import { db } from "@/db";
 import { approvalRequest, employee } from "@/db/schema";
 import { createLogger } from "@/lib/logger";
 import { localizeOutboundNotification } from "./outbound-localization";
+import { resolveRecipientDisplayContext } from "./recipient-display-context";
 import type { NotificationType } from "./types";
 
 const logger = createLogger("TelegramChannel");
@@ -54,6 +55,17 @@ export async function sendTelegramNotification(params: TelegramNotificationParam
 
 		const botConfig = await getBotConfigByOrganization(params.organizationId);
 		if (!botConfig) return;
+		const display = await resolveRecipientDisplayContext({
+			userId: params.userId,
+			organizationId: params.organizationId,
+		});
+		if (!display) {
+			logger.warn(
+				{ userId: params.userId, organizationId: params.organizationId },
+				"Telegram notification recipient has no scoped display context",
+			);
+			return;
+		}
 
 		// Handle approval-related notifications specially
 		if (params.type === "approval_request_submitted" && params.entityType === "approval_request") {
@@ -97,6 +109,7 @@ export async function sendTelegramNotification(params: TelegramNotificationParam
 			title: params.title,
 			message: params.message,
 			metadata: params.metadata,
+			locale: display.locale,
 		});
 		let text = `*${escapeMarkdownV2(localized.title)}*\n\n${escapeMarkdownV2(localized.message)}`;
 		if (params.actionUrl) {

--- a/apps/webapp/src/lib/teams/jobs/daily-digest.ts
+++ b/apps/webapp/src/lib/teams/jobs/daily-digest.ts
@@ -75,7 +75,7 @@ export async function shouldSkipDigestForManager(
 	organizationId: string,
 	timezone: string,
 ): Promise<boolean> {
-	const now = DateTime.now().setZone(timezone);
+	const now = DateTime.utc().setZone(timezone);
 	const todayStr = now.toISODate();
 	if (!todayStr) return false;
 

--- a/apps/webapp/src/lib/teams/jobs/daily-digest.ts
+++ b/apps/webapp/src/lib/teams/jobs/daily-digest.ts
@@ -22,12 +22,7 @@ import {
 	workPeriod,
 } from "@/db/schema";
 import { env } from "@/env";
-import {
-	fmtTime,
-	fmtWeekdayShortDate,
-	getBotTranslate,
-	getUserLocale,
-} from "@/lib/bot-platform/i18n";
+import { fmtWeekdayShortDate, getBotTranslate, getUserLocale } from "@/lib/bot-platform/i18n";
 import { createLogger } from "@/lib/logger";
 import { DEFAULT_LANGUAGE } from "@/tolgee/shared";
 import { sendAdaptiveCard } from "../bot-adapter";
@@ -43,6 +38,14 @@ export interface DailyDigestResult {
 	tenantsProcessed: number;
 	digestsSent: number;
 	errors: string[];
+}
+
+export interface DailyDigestBuildInput {
+	managerId: string;
+	organizationId: string;
+	logicalDate: string;
+	display: { timezone: string; locale: string; timeFormat: "12h" | "24h" };
+	now: string;
 }
 
 /**
@@ -109,7 +112,7 @@ async function processTenantDigest(tenant: {
 	digestTimezone: string;
 }): Promise<number> {
 	// Check if it's time to send the digest
-	const now = DateTime.now().setZone(tenant.digestTimezone);
+	const now = DateTime.utc().setZone(tenant.digestTimezone);
 	const [digestHour, digestMinute] = tenant.digestTime.split(":").map(Number);
 
 	// Only send if within the 15-minute window of the digest time
@@ -179,7 +182,10 @@ async function processTenantDigest(tenant: {
 				await sendAdaptiveCard(
 					conv.conversationReference,
 					card,
-					`Daily Digest - ${digestData.date.toLocaleDateString()}`,
+					`Daily Digest - ${DateTime.fromJSDate(digestData.date, { zone: "utc" })
+						.setZone(tenant.digestTimezone)
+						.setLocale(userLocale)
+						.toLocaleString(DateTime.DATE_MED)}`,
 				);
 
 				return true;
@@ -203,15 +209,41 @@ async function processTenantDigest(tenant: {
 /**
  * Build digest data for a specific manager
  */
-export async function buildDigestDataForManager(
+export function buildDigestDataForManager(input: DailyDigestBuildInput): Promise<DailyDigestData>;
+export function buildDigestDataForManager(
 	managerId: string,
 	organizationId: string,
 	timezone: string,
-	locale: string = DEFAULT_LANGUAGE,
+	locale?: string,
+): Promise<DailyDigestData>;
+export async function buildDigestDataForManager(
+	inputOrManagerId: DailyDigestBuildInput | string,
+	legacyOrganizationId?: string,
+	legacyTimezone?: string,
+	legacyLocale: string = DEFAULT_LANGUAGE,
 ): Promise<DailyDigestData> {
-	const now = DateTime.now().setZone(timezone);
-	const todayStr = now.toISODate();
-	const tomorrowStr = now.plus({ days: 1 }).toISODate();
+	const input: DailyDigestBuildInput =
+		typeof inputOrManagerId === "string"
+			? {
+					display: {
+						locale: legacyLocale,
+						timeFormat: "24h",
+						timezone: legacyTimezone!,
+					},
+					logicalDate: DateTime.utc().setZone(legacyTimezone).toISODate()!,
+					managerId: inputOrManagerId,
+					now: new Date().toISOString(),
+					organizationId: legacyOrganizationId!,
+				}
+			: inputOrManagerId;
+	const timezone = input.display.timezone;
+	const locale = input.display.locale;
+	const managerId = input.managerId;
+	const organizationId = input.organizationId;
+	const now = DateTime.fromISO(input.now, { zone: "utc" }).setZone(timezone);
+	const today = DateTime.fromISO(input.logicalDate, { zone: timezone });
+	const todayStr = today.toISODate();
+	const tomorrowStr = today.plus({ days: 1 }).toISODate();
 
 	// =========================================
 	// Phase 1: All independent queries in parallel
@@ -371,17 +403,27 @@ export async function buildDigestDataForManager(
 		employeesOut = absences.map((a) => ({
 			name: a.employeeName || "Unknown",
 			category: a.categoryName || "Leave",
-			returnDate: fmtWeekdayShortDate(DateTime.fromISO(a.endDate).plus({ days: 1 }), locale),
+			returnDate: fmtWeekdayShortDate(
+				DateTime.fromISO(a.endDate, { zone: "utc" }).plus({ days: 1 }),
+				locale,
+			),
 		}));
 
 		activeWorkPeriods = activeWorkPeriodsResult;
 		employeesClockedIn = activeWorkPeriods.map((e) => {
-			const clockInTime = DateTime.fromJSDate(e.startTime).setZone(timezone);
+			const clockInTime = DateTime.fromJSDate(e.startTime, { zone: "utc" }).setZone(timezone);
 			const duration = now.diff(clockInTime, ["hours", "minutes"]);
 
 			return {
 				name: e.employeeName || "Unknown",
-				clockedInAt: fmtTime(clockInTime, locale),
+				clockedInAt: clockInTime.toLocaleString(
+					{
+						hour: "2-digit",
+						minute: "2-digit",
+						hourCycle: input.display.timeFormat === "12h" ? "h12" : "h23",
+					},
+					{ locale },
+				),
 				durationSoFar: `${Math.floor(duration.hours)}h ${Math.floor(duration.minutes % 60)}m`,
 			};
 		});
@@ -477,7 +519,7 @@ export async function buildDigestDataForManager(
 	}
 
 	return {
-		date: now.toJSDate(),
+		date: today.toJSDate(),
 		timezone,
 		pendingApprovals: pendingApprovals.length,
 		employeesOut,

--- a/apps/webapp/src/lib/telegram/approval-handler.test.ts
+++ b/apps/webapp/src/lib/telegram/approval-handler.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { approvalFindFirstMock, employeeFindFirstMock, getChatIdForUserMock, sendMessageMock } =
+	vi.hoisted(() => ({
+		approvalFindFirstMock: vi.fn(),
+		employeeFindFirstMock: vi.fn(),
+		getChatIdForUserMock: vi.fn(),
+		sendMessageMock: vi.fn(),
+	}));
+
+vi.mock("@/db", () => ({
+	db: {
+		query: {
+			approvalRequest: { findFirst: approvalFindFirstMock },
+			employee: { findFirst: employeeFindFirstMock },
+		},
+		insert: vi.fn(),
+	},
+}));
+
+vi.mock("@/db/schema", () => ({
+	approvalRequest: { id: "approvalRequest.id", organizationId: "approvalRequest.organizationId" },
+	employee: {
+		id: "employee.id",
+		organizationId: "employee.organizationId",
+		userId: "employee.userId",
+	},
+	telegramApprovalMessage: {},
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+vi.mock("@/lib/bot-platform/i18n", () => ({
+	getBotTranslate: vi.fn(),
+	getUserLocale: vi.fn(),
+}));
+vi.mock("@/lib/bot-platform/approval-decision", () => ({ decideBotApproval: vi.fn() }));
+vi.mock("@/lib/notifications/recipient-display-context", () => ({
+	resolveRecipientDisplayContext: vi.fn(),
+}));
+vi.mock("./api", () => ({ editMessageText: vi.fn(), sendMessage: sendMessageMock }));
+vi.mock("./conversation-manager", () => ({ getChatIdForUser: getChatIdForUserMock }));
+vi.mock("./formatters", () => ({
+	buildApprovalMessage: vi.fn(),
+	buildResolvedApprovalMessage: vi.fn(),
+	escapeMarkdownV2: vi.fn(),
+}));
+vi.mock("./user-resolver", () => ({ resolveTelegramUser: vi.fn() }));
+
+describe("sendApprovalMessageToManager", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("does not send when the approver is outside the approval organization", async () => {
+		employeeFindFirstMock.mockResolvedValue(undefined);
+		const { sendApprovalMessageToManager } = await import("./approval-handler");
+
+		await sendApprovalMessageToManager("approval-in-org-b", "approver-in-org-b", "org-a", "token");
+
+		expect(approvalFindFirstMock).not.toHaveBeenCalled();
+		expect(getChatIdForUserMock).not.toHaveBeenCalled();
+		expect(sendMessageMock).not.toHaveBeenCalled();
+	});
+
+	it("does not send an approval from another organization", async () => {
+		employeeFindFirstMock.mockResolvedValue({ userId: "manager-in-org-a" });
+		approvalFindFirstMock.mockResolvedValue(undefined);
+		const { sendApprovalMessageToManager } = await import("./approval-handler");
+
+		await sendApprovalMessageToManager("approval-in-org-b", "approver-in-org-a", "org-a", "token");
+
+		expect(approvalFindFirstMock).toHaveBeenCalledOnce();
+		expect(getChatIdForUserMock).not.toHaveBeenCalled();
+		expect(sendMessageMock).not.toHaveBeenCalled();
+	});
+});

--- a/apps/webapp/src/lib/telegram/approval-handler.ts
+++ b/apps/webapp/src/lib/telegram/approval-handler.ts
@@ -11,6 +11,7 @@ import { approvalRequest, employee, telegramApprovalMessage } from "@/db/schema"
 import { decideBotApproval } from "@/lib/bot-platform/approval-decision";
 import { getBotTranslate, getUserLocale } from "@/lib/bot-platform/i18n";
 import { createLogger } from "@/lib/logger";
+import { resolveRecipientDisplayContext } from "@/lib/notifications/recipient-display-context";
 import { editMessageText, sendMessage } from "./api";
 import { getChatIdForUser } from "./conversation-manager";
 import { buildApprovalMessage, buildResolvedApprovalMessage, escapeMarkdownV2 } from "./formatters";
@@ -105,40 +106,52 @@ export async function handleApprovalCallback(
 
 		// Get approver name
 		const approverEmployee = await db.query.employee.findFirst({
-			where: eq(employee.id, userResult.user.employeeId),
+			where: and(
+				eq(employee.id, userResult.user.employeeId),
+				eq(employee.organizationId, bot.organizationId),
+			),
 			with: { user: { columns: { name: true } } },
 		});
+		if (!approverEmployee) return;
 		const approverName = approverEmployee?.user?.name || "Unknown";
 
 		// Build original card data for resolved message
-		const cardData = await buildApprovalCardData(approval);
+		const cardData = await buildApprovalCardData(approval, bot.organizationId);
 
 		// Update the message to show resolved status
 		if (query.message && cardData) {
-			const locale = await getUserLocale(userResult.user.userId);
-			const t = await getBotTranslate(locale);
-			const resolvedText = buildResolvedApprovalMessage(
-				cardData,
-				{
-					action: newStatus,
-					approverName,
-					resolvedAt: new Date(),
-				},
-				t,
-				locale,
-			);
-
-			await editMessageText(bot.botToken, {
-				chat_id: query.message.chat.id,
-				message_id: query.message.message_id,
-				text: resolvedText,
-				parse_mode: "MarkdownV2",
+			const display = await resolveRecipientDisplayContext({
+				userId: userResult.user.userId,
+				organizationId: bot.organizationId,
 			});
+			if (display) {
+				const t = await getBotTranslate(display.locale);
+				const resolvedText = buildResolvedApprovalMessage(
+					cardData,
+					{
+						action: newStatus,
+						approverName,
+						resolvedAt: new Date(),
+					},
+					t,
+					display,
+				);
+
+				await editMessageText(bot.botToken, {
+					chat_id: query.message.chat.id,
+					message_id: query.message.message_id,
+					text: resolvedText,
+					parse_mode: "MarkdownV2",
+				});
+			}
 		}
 
 		// Update approval message record
 		const msgRecord = await db.query.telegramApprovalMessage.findFirst({
-			where: eq(telegramApprovalMessage.approvalRequestId, approvalId),
+			where: and(
+				eq(telegramApprovalMessage.approvalRequestId, approvalId),
+				eq(telegramApprovalMessage.organizationId, bot.organizationId),
+			),
 		});
 
 		if (msgRecord) {
@@ -148,7 +161,12 @@ export async function handleApprovalCallback(
 					respondedAt: new Date(),
 					status: newStatus,
 				})
-				.where(eq(telegramApprovalMessage.id, msgRecord.id));
+				.where(
+					and(
+						eq(telegramApprovalMessage.id, msgRecord.id),
+						eq(telegramApprovalMessage.organizationId, bot.organizationId),
+					),
+				);
 		}
 	} catch (error) {
 		logger.error({ error, approvalId, action }, "Failed to process approval action");
@@ -177,16 +195,12 @@ export async function sendApprovalMessageToManager(
 			return;
 		}
 
-		// Get chat ID for the approver
-		const chatId = await getChatIdForUser(approverEmployee.userId, organizationId);
-		if (!chatId) {
-			logger.debug({ approverId, organizationId }, "No Telegram chat for approver");
-			return;
-		}
-
 		// Get approval details
 		const approval = await db.query.approvalRequest.findFirst({
-			where: eq(approvalRequest.id, approvalId),
+			where: and(
+				eq(approvalRequest.id, approvalId),
+				eq(approvalRequest.organizationId, organizationId),
+			),
 		});
 
 		if (!approval) {
@@ -194,17 +208,28 @@ export async function sendApprovalMessageToManager(
 			return;
 		}
 
+		// Resolve the recipient only after proving this approval belongs to the organization.
+		const chatId = await getChatIdForUser(approverEmployee.userId, organizationId);
+		if (!chatId) {
+			logger.debug({ approverId, organizationId }, "No Telegram chat for approver");
+			return;
+		}
+
 		// Build card data
-		const cardData = await buildApprovalCardData(approval);
+		const cardData = await buildApprovalCardData(approval, organizationId);
 		if (!cardData) {
 			logger.warn({ approvalId }, "Could not build card data");
 			return;
 		}
 
 		// Build message with inline keyboard (use recipient's locale)
-		const recipientLocale = await getUserLocale(approverEmployee.userId);
-		const t = await getBotTranslate(recipientLocale);
-		const { text, keyboard } = buildApprovalMessage(cardData, t, recipientLocale);
+		const display = await resolveRecipientDisplayContext({
+			userId: approverEmployee.userId,
+			organizationId,
+		});
+		if (!display) return;
+		const t = await getBotTranslate(display.locale);
+		const { text, keyboard } = buildApprovalMessage(cardData, t, display);
 
 		// Send message
 		const sentMessage = await sendMessage(botToken, {
@@ -240,9 +265,10 @@ export async function sendApprovalMessageToManager(
  */
 async function buildApprovalCardData(
 	approval: typeof approvalRequest.$inferSelect,
+	organizationId: string,
 ): Promise<ApprovalCardData | null> {
 	const requester = await db.query.employee.findFirst({
-		where: eq(employee.id, approval.requestedBy),
+		where: and(eq(employee.id, approval.requestedBy), eq(employee.organizationId, organizationId)),
 		with: { user: { columns: { name: true, email: true } } },
 	});
 
@@ -259,7 +285,10 @@ async function buildApprovalCardData(
 	if (approval.entityType === "absence_entry") {
 		const { absenceEntry } = await import("@/db/schema");
 		const absence = await db.query.absenceEntry.findFirst({
-			where: eq(absenceEntry.id, approval.entityId),
+			where: and(
+				eq(absenceEntry.id, approval.entityId),
+				eq(absenceEntry.organizationId, organizationId),
+			),
 			with: { category: { columns: { name: true } } },
 		});
 

--- a/apps/webapp/src/lib/telegram/formatters.test.ts
+++ b/apps/webapp/src/lib/telegram/formatters.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildApprovalMessage } from "./formatters";
+
+const translate = (_key: string, defaultValue: string) => defaultValue;
+
+const approval = {
+	approvalId: "approval-1",
+	createdAt: new Date("2026-07-10T14:00:00.000Z"),
+	endDate: "2026-07-11",
+	entityType: "absence_entry" as const,
+	requesterName: "Avery",
+	startDate: "2026-07-10",
+};
+
+describe("buildApprovalMessage", () => {
+	afterEach(() => vi.unstubAllEnvs());
+
+	it("formats the same submitted instant in each recipient's explicit timezone", () => {
+		const berlin = buildApprovalMessage(approval, translate, {
+			locale: "en-US",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+		const newYork = buildApprovalMessage(approval, translate, {
+			locale: "en-US",
+			timeFormat: "12h",
+			timezone: "America/New_York",
+		});
+
+		expect(berlin.text).toContain("Jul 10, 16:00");
+		expect(newYork.text).toContain("Jul 10, 10:00 AM");
+	});
+
+	it("does not use the host timezone when recipient context is explicit", () => {
+		vi.stubEnv("TZ", "UTC");
+		const utcHost = buildApprovalMessage(approval, translate, {
+			locale: "en-US",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+		vi.stubEnv("TZ", "America/Los_Angeles");
+		const losAngelesHost = buildApprovalMessage(approval, translate, {
+			locale: "en-US",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+
+		expect(losAngelesHost.text).toBe(utcHost.text);
+	});
+
+	it("treats absence dates as logical dates rather than instants", () => {
+		const message = buildApprovalMessage(approval, translate, {
+			locale: "en-US",
+			timeFormat: "12h",
+			timezone: "America/New_York",
+		});
+
+		expect(message.text).toContain("Jul 10 \\- Jul 11");
+	});
+});

--- a/apps/webapp/src/lib/telegram/formatters.ts
+++ b/apps/webapp/src/lib/telegram/formatters.ts
@@ -7,7 +7,8 @@
 
 import { DateTime } from "luxon";
 import type { BotTranslateFn } from "@/lib/bot-platform/i18n";
-import { fmtFullDate, fmtShortDate, fmtShortDateTime } from "@/lib/bot-platform/i18n";
+import { fmtFullDate, fmtShortDate } from "@/lib/bot-platform/i18n";
+import type { RecipientDisplayContext } from "@/lib/notifications/recipient-display-context";
 import { DEFAULT_LANGUAGE } from "@/tolgee/shared";
 import type {
 	ApprovalCallbackData,
@@ -102,8 +103,8 @@ export function markdownToHtml(text: string): string {
  */
 export function buildApprovalMessage(
 	data: ApprovalCardData,
-	t?: BotTranslateFn,
-	locale: string = DEFAULT_LANGUAGE,
+	t: BotTranslateFn | undefined,
+	display: RecipientDisplayContext,
 ): {
 	text: string;
 	keyboard: TelegramInlineKeyboardMarkup;
@@ -120,8 +121,8 @@ export function buildApprovalMessage(
 		const category = data.absenceCategory || (t ? t("bot.approval.leave", "Leave") : "Leave");
 		lines.push(`${t ? t("bot.approval.type", "Type") : "Type"}: ${escapeMarkdownV2(category)}`);
 		if (data.startDate && data.endDate) {
-			const start = fmtShortDate(DateTime.fromISO(data.startDate), locale);
-			const end = fmtShortDate(DateTime.fromISO(data.endDate), locale);
+			const start = fmtShortDate(DateTime.fromISO(data.startDate, { zone: "utc" }), display.locale);
+			const end = fmtShortDate(DateTime.fromISO(data.endDate, { zone: "utc" }), display.locale);
 			lines.push(
 				`${t ? t("bot.approval.period", "Period") : "Period"}: ${escapeMarkdownV2(start)} \\- ${escapeMarkdownV2(end)}`,
 			);
@@ -138,7 +139,7 @@ export function buildApprovalMessage(
 		);
 	}
 
-	const submitted = fmtShortDateTime(DateTime.fromJSDate(data.createdAt), locale);
+	const submitted = formatInstant(data.createdAt, display);
 	lines.push(
 		`${t ? t("bot.approval.submitted", "Submitted") : "Submitted"}: ${escapeMarkdownV2(submitted)}`,
 	);
@@ -175,8 +176,8 @@ export function buildApprovalMessage(
 export function buildResolvedApprovalMessage(
 	data: ApprovalCardData,
 	resolved: ApprovalResolvedData,
-	t?: BotTranslateFn,
-	locale: string = DEFAULT_LANGUAGE,
+	t: BotTranslateFn | undefined,
+	display: RecipientDisplayContext,
 ): string {
 	const lines: string[] = [];
 	const icon = resolved.action === "approved" ? "\u2705" : "\u274C";
@@ -199,8 +200,8 @@ export function buildResolvedApprovalMessage(
 		const category = data.absenceCategory || (t ? t("bot.approval.leave", "Leave") : "Leave");
 		lines.push(`${t ? t("bot.approval.type", "Type") : "Type"}: ${escapeMarkdownV2(category)}`);
 		if (data.startDate && data.endDate) {
-			const start = fmtShortDate(DateTime.fromISO(data.startDate), locale);
-			const end = fmtShortDate(DateTime.fromISO(data.endDate), locale);
+			const start = fmtShortDate(DateTime.fromISO(data.startDate, { zone: "utc" }), display.locale);
+			const end = fmtShortDate(DateTime.fromISO(data.endDate, { zone: "utc" }), display.locale);
 			lines.push(
 				`${t ? t("bot.approval.period", "Period") : "Period"}: ${escapeMarkdownV2(start)} \\- ${escapeMarkdownV2(end)}`,
 			);
@@ -211,10 +212,23 @@ export function buildResolvedApprovalMessage(
 	lines.push(
 		`${bold(status)} ${t ? t("bot.approval.by", "by") : "by"} ${escapeMarkdownV2(resolved.approverName)}`,
 	);
-	const resolvedAt = fmtShortDateTime(DateTime.fromJSDate(resolved.resolvedAt), locale);
+	const resolvedAt = formatInstant(resolved.resolvedAt, display);
 	lines.push(`${t ? t("bot.approval.at", "at") : "at"} ${escapeMarkdownV2(resolvedAt)}`);
 
 	return lines.join("\n");
+}
+
+function formatInstant(instant: Date, display: RecipientDisplayContext): string {
+	return DateTime.fromJSDate(instant, { zone: "utc" })
+		.setZone(display.timezone)
+		.setLocale(display.locale)
+		.toLocaleString({
+			month: "short",
+			day: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+			hourCycle: display.timeFormat === "12h" ? "h12" : "h23",
+		});
 }
 
 // ============================================
@@ -232,7 +246,10 @@ export function buildDailyDigestMessage(
 	locale: string = DEFAULT_LANGUAGE,
 ): string {
 	const lines: string[] = [];
-	const dateFormatted = fmtFullDate(DateTime.fromJSDate(data.date).setZone(data.timezone), locale);
+	const dateFormatted = fmtFullDate(
+		DateTime.fromJSDate(data.date, { zone: "utc" }).setZone(data.timezone),
+		locale,
+	);
 
 	lines.push(
 		bold(

--- a/apps/webapp/src/lib/telegram/jobs/daily-digest.test.ts
+++ b/apps/webapp/src/lib/telegram/jobs/daily-digest.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+	buildDigestDataForManagerMock,
+	getBotTranslateMock,
+	getOrganizationPrivateConversationsMock,
+	claimTelegramDigestDeliveryMock,
+	markTelegramDigestDeliveryFailedMock,
+	markTelegramDigestDeliverySentMock,
+	resolveRecipientDisplayContextMock,
+	sendMessageMock,
+} = vi.hoisted(() => ({
+	buildDigestDataForManagerMock: vi.fn(),
+	getBotTranslateMock: vi.fn(),
+	getOrganizationPrivateConversationsMock: vi.fn(),
+	claimTelegramDigestDeliveryMock: vi.fn(),
+	markTelegramDigestDeliveryFailedMock: vi.fn(),
+	markTelegramDigestDeliverySentMock: vi.fn(),
+	resolveRecipientDisplayContextMock: vi.fn(),
+	sendMessageMock: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+	db: {
+		query: {
+			employee: { findFirst: vi.fn() },
+			employeeManagers: { findFirst: vi.fn() },
+		},
+	},
+}));
+vi.mock("@/db/schema", () => ({ employee: {}, employeeManagers: {} }));
+vi.mock("@/env", () => ({ env: {} }));
+vi.mock("@/lib/bot-platform/i18n", () => ({ getBotTranslate: getBotTranslateMock }));
+vi.mock("@/lib/logger", () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn() }) }));
+vi.mock("@/lib/notifications/recipient-display-context", () => ({
+	resolveRecipientDisplayContext: resolveRecipientDisplayContextMock,
+}));
+vi.mock("@/lib/teams/jobs/daily-digest", () => ({
+	buildDigestDataForManager: buildDigestDataForManagerMock,
+}));
+vi.mock("../api", () => ({ sendMessage: sendMessageMock }));
+vi.mock("../bot-config", () => ({ getAllActiveBotConfigs: vi.fn() }));
+vi.mock("../conversation-manager", () => ({
+	getOrganizationPrivateConversations: getOrganizationPrivateConversationsMock,
+}));
+vi.mock("../formatters", () => ({ buildDailyDigestMessage: vi.fn(() => "digest") }));
+vi.mock("./digest-delivery-ledger", () => ({
+	claimTelegramDigestDelivery: claimTelegramDigestDeliveryMock,
+	markTelegramDigestDeliveryFailed: markTelegramDigestDeliveryFailedMock,
+	markTelegramDigestDeliverySent: markTelegramDigestDeliverySentMock,
+}));
+
+describe("processTelegramBotDigest", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getOrganizationPrivateConversationsMock.mockResolvedValue([
+			{ chatId: "chat-berlin", userId: "manager-berlin" },
+			{ chatId: "chat-new-york", userId: "manager-new-york" },
+		]);
+		resolveRecipientDisplayContextMock
+			.mockResolvedValueOnce({ locale: "de", timeFormat: "24h", timezone: "Europe/Berlin" })
+			.mockResolvedValueOnce({
+				locale: "en-US",
+				timeFormat: "12h",
+				timezone: "America/New_York",
+			});
+		buildDigestDataForManagerMock.mockResolvedValue({});
+		getBotTranslateMock.mockResolvedValue(() => "digest");
+		sendMessageMock.mockResolvedValue({});
+		claimTelegramDigestDeliveryMock.mockResolvedValue(true);
+		markTelegramDigestDeliverySentMock.mockResolvedValue(undefined);
+		markTelegramDigestDeliveryFailedMock.mockResolvedValue(undefined);
+	});
+
+	it("sends once when concurrent runs compete for the same recipient digest", async () => {
+		const { db } = await import("@/db");
+		vi.mocked(db.query.employee.findFirst).mockResolvedValue({ id: "employee-berlin" });
+		vi.mocked(db.query.employeeManagers.findFirst).mockResolvedValue({ id: "managed-employee" });
+		getOrganizationPrivateConversationsMock.mockResolvedValue([
+			{ chatId: "chat-berlin", userId: "manager-berlin" },
+		]);
+		resolveRecipientDisplayContextMock.mockResolvedValue({
+			locale: "de",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+		claimTelegramDigestDeliveryMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		const { processTelegramBotDigest } = await import("./daily-digest");
+		const bot = {
+			botToken: "token",
+			digestTime: "02:00",
+			digestTimezone: "Europe/Berlin",
+			organizationId: "org-a",
+		};
+
+		const [first, second] = await Promise.all([
+			processTelegramBotDigest(bot, new Date("2026-07-10T00:05:00.000Z")),
+			processTelegramBotDigest(bot, new Date("2026-07-10T00:05:00.000Z")),
+		]);
+
+		expect(first + second).toBe(1);
+		expect(sendMessageMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("retries a failed delivery claim", async () => {
+		const { db } = await import("@/db");
+		vi.mocked(db.query.employee.findFirst).mockResolvedValue({ id: "employee-berlin" });
+		vi.mocked(db.query.employeeManagers.findFirst).mockResolvedValue({ id: "managed-employee" });
+		getOrganizationPrivateConversationsMock.mockResolvedValue([
+			{ chatId: "chat-berlin", userId: "manager-berlin" },
+		]);
+		resolveRecipientDisplayContextMock.mockResolvedValue({
+			locale: "de",
+			timeFormat: "24h",
+			timezone: "Europe/Berlin",
+		});
+		const { processTelegramBotDigest } = await import("./daily-digest");
+		const bot = {
+			botToken: "token",
+			digestTime: "02:00",
+			digestTimezone: "Europe/Berlin",
+			organizationId: "org-a",
+		};
+
+		sendMessageMock.mockRejectedValueOnce(new Error("network"));
+		expect(await processTelegramBotDigest(bot, new Date("2026-07-10T00:05:00.000Z"))).toBe(0);
+		expect(markTelegramDigestDeliveryFailedMock).toHaveBeenCalledTimes(1);
+
+		sendMessageMock.mockResolvedValueOnce({});
+		expect(await processTelegramBotDigest(bot, new Date("2026-07-10T00:05:00.000Z"))).toBe(1);
+		expect(sendMessageMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("uses separate delivery keys for recipient-local UTC and Honolulu dates", async () => {
+		const { db } = await import("@/db");
+		vi.mocked(db.query.employee.findFirst)
+			.mockResolvedValueOnce({ id: "employee-utc" })
+			.mockResolvedValueOnce({ id: "employee-honolulu" });
+		vi.mocked(db.query.employeeManagers.findFirst).mockResolvedValue({ id: "managed-employee" });
+		getOrganizationPrivateConversationsMock.mockResolvedValue([
+			{ chatId: "chat-utc", userId: "manager-utc" },
+			{ chatId: "chat-honolulu", userId: "manager-honolulu" },
+		]);
+		resolveRecipientDisplayContextMock
+			.mockResolvedValueOnce({ locale: "en", timeFormat: "24h", timezone: "UTC" })
+			.mockResolvedValueOnce({ locale: "en", timeFormat: "24h", timezone: "Pacific/Honolulu" });
+		const { processTelegramBotDigest } = await import("./daily-digest");
+
+		await processTelegramBotDigest(
+			{
+				botToken: "token",
+				digestTime: "02:00",
+				digestTimezone: "Europe/Berlin",
+				organizationId: "org-a",
+			},
+			new Date("2026-07-10T00:05:00.000Z"),
+		);
+
+		expect(claimTelegramDigestDeliveryMock).toHaveBeenCalledWith(
+			expect.objectContaining({ logicalDate: "2026-07-10", organizationId: "org-a" }),
+		);
+		expect(claimTelegramDigestDeliveryMock).toHaveBeenCalledWith(
+			expect.objectContaining({ logicalDate: "2026-07-09", organizationId: "org-a" }),
+		);
+	});
+
+	it("keeps otherwise matching delivery keys scoped to their organization", async () => {
+		const { db } = await import("@/db");
+		vi.mocked(db.query.employee.findFirst).mockResolvedValue({ id: "employee-manager" });
+		vi.mocked(db.query.employeeManagers.findFirst).mockResolvedValue({ id: "managed-employee" });
+		getOrganizationPrivateConversationsMock.mockResolvedValue([
+			{ chatId: "chat-manager", userId: "manager-user" },
+		]);
+		resolveRecipientDisplayContextMock.mockResolvedValue({
+			locale: "en",
+			timeFormat: "24h",
+			timezone: "UTC",
+		});
+		const { processTelegramBotDigest } = await import("./daily-digest");
+
+		await processTelegramBotDigest(
+			{
+				botToken: "token",
+				digestTime: "02:00",
+				digestTimezone: "Europe/Berlin",
+				organizationId: "org-a",
+			},
+			new Date("2026-07-10T00:05:00.000Z"),
+		);
+		await processTelegramBotDigest(
+			{
+				botToken: "token",
+				digestTime: "02:00",
+				digestTimezone: "Europe/Berlin",
+				organizationId: "org-b",
+			},
+			new Date("2026-07-10T00:05:00.000Z"),
+		);
+
+		expect(claimTelegramDigestDeliveryMock).toHaveBeenCalledWith(
+			expect.objectContaining({ organizationId: "org-a" }),
+		);
+		expect(claimTelegramDigestDeliveryMock).toHaveBeenCalledWith(
+			expect.objectContaining({ organizationId: "org-b" }),
+		);
+	});
+
+	it("uses one schedule occurrence while building recipient-specific content", async () => {
+		const { db } = await import("@/db");
+		vi.mocked(db.query.employee.findFirst)
+			.mockResolvedValueOnce({ id: "employee-berlin" })
+			.mockResolvedValueOnce({ id: "employee-new-york" });
+		vi.mocked(db.query.employeeManagers.findFirst).mockResolvedValue({ id: "managed-employee" });
+		const { processTelegramBotDigest } = await import("./daily-digest");
+
+		const sent = await processTelegramBotDigest(
+			{
+				botToken: "token",
+				digestTime: "02:00",
+				digestTimezone: "Europe/Berlin",
+				organizationId: "org-a",
+			},
+			new Date("2026-07-10T00:05:00.000Z"),
+		);
+
+		expect(sent).toBe(2);
+		expect(buildDigestDataForManagerMock).toHaveBeenCalledWith({
+			display: { locale: "de", timeFormat: "24h", timezone: "Europe/Berlin" },
+			logicalDate: "2026-07-10",
+			managerId: "employee-berlin",
+			now: "2026-07-10T00:05:00.000Z",
+			organizationId: "org-a",
+		});
+		expect(buildDigestDataForManagerMock).toHaveBeenCalledWith({
+			display: { locale: "en-US", timeFormat: "12h", timezone: "America/New_York" },
+			logicalDate: "2026-07-09",
+			managerId: "employee-new-york",
+			now: "2026-07-10T00:05:00.000Z",
+			organizationId: "org-a",
+		});
+	});
+});

--- a/apps/webapp/src/lib/telegram/jobs/daily-digest.ts
+++ b/apps/webapp/src/lib/telegram/jobs/daily-digest.ts
@@ -10,13 +10,20 @@ import { DateTime } from "luxon";
 import { db } from "@/db";
 import { employee, employeeManagers } from "@/db/schema";
 import { env } from "@/env";
-import { getBotTranslate, getUserLocale } from "@/lib/bot-platform/i18n";
+import { getBotTranslate } from "@/lib/bot-platform/i18n";
 import type { DailyDigestData } from "@/lib/bot-platform/types";
 import { createLogger } from "@/lib/logger";
+import { resolveRecipientDisplayContext } from "@/lib/notifications/recipient-display-context";
 import { sendMessage } from "../api";
 import { getAllActiveBotConfigs } from "../bot-config";
 import { getOrganizationPrivateConversations } from "../conversation-manager";
 import { buildDailyDigestMessage } from "../formatters";
+import {
+	claimTelegramDigestDelivery,
+	markTelegramDigestDeliveryFailed,
+	markTelegramDigestDeliverySent,
+} from "./digest-delivery-ledger";
+import { evaluateDigestOccurrence } from "./digest-schedule";
 
 const logger = createLogger("TelegramDailyDigest");
 
@@ -43,7 +50,7 @@ export async function runTelegramDailyDigestJob(): Promise<TelegramDailyDigestRe
 		const botResults = await Promise.all(
 			digestEnabledBots.map(async (bot) => {
 				try {
-					return { sent: await processBotDigest(bot), error: undefined };
+					return { sent: await processTelegramBotDigest(bot), error: undefined };
 				} catch (error) {
 					const errorMsg = `Failed to process digest for org ${bot.organizationId}: ${error instanceof Error ? error.message : String(error)}`;
 					logger.error({ error, organizationId: bot.organizationId }, errorMsg);
@@ -75,23 +82,22 @@ export async function runTelegramDailyDigestJob(): Promise<TelegramDailyDigestRe
 	}
 }
 
-async function processBotDigest(bot: {
-	organizationId: string;
-	botToken: string;
-	digestTime: string;
-	digestTimezone: string;
-}): Promise<number> {
-	// Check if it's time to send
-	const now = DateTime.now().setZone(bot.digestTimezone);
-	const [digestHour, digestMinute] = bot.digestTime.split(":").map(Number);
-	const digestTime = now.set({
-		hour: digestHour,
-		minute: digestMinute,
-		second: 0,
+export async function processTelegramBotDigest(
+	bot: {
+		organizationId: string;
+		botToken: string;
+		digestTime: string;
+		digestTimezone: string;
+	},
+	now: Date = new Date(),
+): Promise<number> {
+	const occurrence = evaluateDigestOccurrence({
+		now,
+		time: bot.digestTime,
+		timezone: bot.digestTimezone,
+		windowMinutes: 15,
 	});
-	const minutesSinceDigestTime = now.diff(digestTime, "minutes").minutes;
-
-	if (minutesSinceDigestTime < 0 || minutesSinceDigestTime >= 15) {
+	if (!occurrence.due) {
 		return 0;
 	}
 
@@ -121,23 +127,46 @@ async function processBotDigest(bot: {
 
 				if (!manages) return false;
 
-				// Build Telegram-formatted message (use recipient's locale)
-				const userLocale = await getUserLocale(conv.userId);
-				const digestData: DailyDigestData = await buildDigestDataForManager(
-					emp.id,
-					bot.organizationId,
-					bot.digestTimezone,
-					userLocale,
-				);
-
-				const t = await getBotTranslate(userLocale);
-				const messageText = buildDailyDigestMessage(digestData, appUrl, t, userLocale);
-
-				await sendMessage(bot.botToken, {
-					chat_id: conv.chatId,
-					text: messageText,
-					parse_mode: "MarkdownV2",
+				const display = await resolveRecipientDisplayContext({
+					userId: conv.userId,
+					organizationId: bot.organizationId,
 				});
+				if (!display) return false;
+
+				const recipientDate = DateTime.fromJSDate(now, { zone: "utc" })
+					.setZone(display.timezone)
+					.toISODate()!;
+				const delivery = {
+					organizationId: bot.organizationId,
+					recipientEmployeeId: emp.id,
+					recipientUserId: conv.userId,
+					logicalDate: recipientDate,
+				};
+				if (!(await claimTelegramDigestDelivery(delivery))) return false;
+
+				try {
+					const digestData: DailyDigestData = await buildDigestDataForManager({
+						display,
+						logicalDate: recipientDate,
+						managerId: emp.id,
+						now: now.toISOString(),
+						organizationId: bot.organizationId,
+					});
+
+					const t = await getBotTranslate(display.locale);
+					const messageText = buildDailyDigestMessage(digestData, appUrl, t, display.locale);
+
+					await sendMessage(bot.botToken, {
+						chat_id: conv.chatId,
+						text: messageText,
+						parse_mode: "MarkdownV2",
+					});
+				} catch (error) {
+					await markTelegramDigestDeliveryFailed(delivery);
+					throw error;
+				}
+
+				await markTelegramDigestDeliverySent(delivery);
 
 				return true;
 			} catch (error) {

--- a/apps/webapp/src/lib/telegram/jobs/digest-delivery-ledger.test.ts
+++ b/apps/webapp/src/lib/telegram/jobs/digest-delivery-ledger.test.ts
@@ -1,0 +1,26 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const ledgerPath = new URL("./digest-delivery-ledger.ts", import.meta.url);
+
+describe("Telegram digest delivery ledger", () => {
+	it("atomically claims only a new or failed recipient-local digest", async () => {
+		const source = await readFile(ledgerPath, "utf8");
+
+		expect(source).toContain(
+			'ON CONFLICT ("organization_id", "recipient_employee_id", "recipient_user_id", "platform", "digest_type", "logical_date")',
+		);
+		expect(source).toContain('WHERE "telegram_digest_delivery"."status" = \'failed\'');
+		expect(source).toContain('RETURNING "id"');
+	});
+
+	it("keeps recipients, tenants, and recipient-local dates in the delivery key", async () => {
+		const source = await readFile(ledgerPath, "utf8");
+
+		expect(source).toContain("organizationId: string");
+		expect(source).toContain("recipientEmployeeId: string");
+		expect(source).toContain("recipientUserId: string");
+		expect(source).toContain("logicalDate: string");
+		expect(source).not.toContain("digestTimezone");
+	});
+});

--- a/apps/webapp/src/lib/telegram/jobs/digest-delivery-ledger.ts
+++ b/apps/webapp/src/lib/telegram/jobs/digest-delivery-ledger.ts
@@ -1,0 +1,67 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+
+export interface TelegramDigestDeliveryKey {
+	organizationId: string;
+	recipientEmployeeId: string;
+	recipientUserId: string;
+	logicalDate: string;
+}
+
+const platform = "telegram";
+const digestType = "daily";
+
+/**
+ * Claims a delivery in one database statement. Only a new row or a prior
+ * failed attempt can transition to sending, so overlapping workers cannot
+ * send the same recipient-local digest twice.
+ */
+export async function claimTelegramDigestDelivery(
+	key: TelegramDigestDeliveryKey,
+): Promise<boolean> {
+	const result = await db.execute(sql`
+		INSERT INTO "telegram_digest_delivery" (
+			"organization_id", "recipient_employee_id", "recipient_user_id", "platform", "digest_type", "logical_date", "status", "attempted_at", "created_at", "updated_at"
+		) VALUES (
+			${key.organizationId}, ${key.recipientEmployeeId}, ${key.recipientUserId}, ${platform}, ${digestType}, ${key.logicalDate}, 'sending', NOW(), NOW(), NOW()
+		)
+		ON CONFLICT ("organization_id", "recipient_employee_id", "recipient_user_id", "platform", "digest_type", "logical_date")
+		DO UPDATE SET "status" = 'sending', "attempted_at" = NOW(), "failed_at" = NULL, "updated_at" = NOW()
+		WHERE "telegram_digest_delivery"."status" = 'failed'
+		RETURNING "id"
+	`);
+
+	return result.rows.length === 1;
+}
+
+export async function markTelegramDigestDeliverySent(
+	key: TelegramDigestDeliveryKey,
+): Promise<void> {
+	await db.execute(sql`
+		UPDATE "telegram_digest_delivery"
+		SET "status" = 'sent', "sent_at" = NOW(), "updated_at" = NOW()
+		WHERE "organization_id" = ${key.organizationId}
+			AND "recipient_employee_id" = ${key.recipientEmployeeId}
+			AND "recipient_user_id" = ${key.recipientUserId}
+			AND "platform" = ${platform}
+			AND "digest_type" = ${digestType}
+			AND "logical_date" = ${key.logicalDate}
+			AND "status" = 'sending'
+	`);
+}
+
+export async function markTelegramDigestDeliveryFailed(
+	key: TelegramDigestDeliveryKey,
+): Promise<void> {
+	await db.execute(sql`
+		UPDATE "telegram_digest_delivery"
+		SET "status" = 'failed', "failed_at" = NOW(), "updated_at" = NOW()
+		WHERE "organization_id" = ${key.organizationId}
+			AND "recipient_employee_id" = ${key.recipientEmployeeId}
+			AND "recipient_user_id" = ${key.recipientUserId}
+			AND "platform" = ${platform}
+			AND "digest_type" = ${digestType}
+			AND "logical_date" = ${key.logicalDate}
+			AND "status" = 'sending'
+	`);
+}

--- a/apps/webapp/src/lib/telegram/jobs/digest-schedule.test.ts
+++ b/apps/webapp/src/lib/telegram/jobs/digest-schedule.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { evaluateDigestOccurrence } from "./digest-schedule";
+
+describe("evaluateDigestOccurrence", () => {
+	it("uses the schedule timezone to derive the due instant", () => {
+		const occurrence = evaluateDigestOccurrence({
+			now: new Date("2026-07-10T07:05:00.000Z"),
+			time: "09:00",
+			timezone: "Europe/Berlin",
+			windowMinutes: 15,
+		});
+
+		expect(occurrence).toEqual({
+			due: true,
+			logicalDate: "2026-07-10",
+			scheduledInstant: "2026-07-10T07:00:00.000Z",
+		});
+	});
+
+	it("materializes a spring gap at the first valid wall-clock instant", () => {
+		const occurrence = evaluateDigestOccurrence({
+			now: new Date("2026-03-29T01:35:00.000Z"),
+			time: "02:30",
+			timezone: "Europe/Berlin",
+			windowMinutes: 15,
+		});
+
+		expect(occurrence.scheduledInstant).toBe("2026-03-29T01:30:00.000Z");
+		expect(occurrence.due).toBe(true);
+	});
+
+	it("chooses the earlier occurrence during a fall fold", () => {
+		const occurrence = evaluateDigestOccurrence({
+			now: new Date("2026-10-25T00:35:00.000Z"),
+			time: "02:30",
+			timezone: "Europe/Berlin",
+			windowMinutes: 15,
+		});
+
+		expect(occurrence.scheduledInstant).toBe("2026-10-25T00:30:00.000Z");
+		expect(occurrence.due).toBe(true);
+	});
+});

--- a/apps/webapp/src/lib/telegram/jobs/digest-schedule.ts
+++ b/apps/webapp/src/lib/telegram/jobs/digest-schedule.ts
@@ -1,0 +1,40 @@
+import { DateTime } from "luxon";
+import { parseDigestSettings } from "@/lib/bot-platform/digest-settings";
+
+export interface DigestOccurrence {
+	due: boolean;
+	logicalDate: string;
+	scheduledInstant: string;
+}
+
+export function evaluateDigestOccurrence(input: {
+	now: Date;
+	time: string;
+	timezone: string;
+	windowMinutes: number;
+}): DigestOccurrence {
+	const settings = parseDigestSettings({ time: input.time, timezone: input.timezone });
+	const now = DateTime.fromJSDate(input.now, { zone: "utc" });
+	const scheduleNow = now.setZone(settings.timezone);
+	const [hour, minute] = settings.time.split(":").map(Number);
+	const requested = DateTime.fromObject(
+		{
+			year: scheduleNow.year,
+			month: scheduleNow.month,
+			day: scheduleNow.day,
+			hour,
+			minute,
+			second: 0,
+			millisecond: 0,
+		},
+		{ zone: settings.timezone },
+	);
+	const scheduled = requested.getPossibleOffsets().sort((a, b) => a.toMillis() - b.toMillis())[0]!;
+	const minutesSinceSchedule = now.diff(scheduled.toUTC(), "minutes").minutes;
+
+	return {
+		due: minutesSinceSchedule >= 0 && minutesSinceSchedule < input.windowMinutes,
+		logicalDate: scheduleNow.toISODate()!,
+		scheduledInstant: scheduled.toUTC().toISO()!,
+	};
+}

--- a/apps/webapp/src/lib/time-tracking/clocking-service.test.ts
+++ b/apps/webapp/src/lib/time-tracking/clocking-service.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createClockingService } from "./clocking-service";
+
+describe("clocking service", () => {
+	it("derives the employee and organization from an approved active membership", async () => {
+		const service = createClockingService({
+			findActiveEmployee: async (userId, organizationId) =>
+				userId === "user-1" && organizationId === "org-1"
+					? { id: "employee-1", organizationId: "org-1" }
+					: null,
+			findApprovedMembership: async (userId, organizationId) =>
+				userId === "user-1" && organizationId === "org-1",
+		});
+
+		await expect(service.requireActor({ userId: "user-1", activeOrganizationId: "org-1" })).resolves.toEqual({
+			employee: { id: "employee-1", organizationId: "org-1" },
+			organizationId: "org-1",
+			userId: "user-1",
+		});
+	});
+
+	it("rejects a session without an approved membership before resolving an employee", async () => {
+		const findActiveEmployee = async () => ({ id: "employee-1", organizationId: "org-1" });
+		const service = createClockingService({
+			findActiveEmployee,
+			findApprovedMembership: async () => false,
+		});
+
+		await expect(service.requireActor({ userId: "user-1", activeOrganizationId: "org-1" })).rejects.toMatchObject({
+			code: "active_membership_required",
+		});
+	});
+
+	it("does not accept a membership or employee from a different organization", async () => {
+		const service = createClockingService({
+			findActiveEmployee: async () => ({ id: "employee-org-2", organizationId: "org-2" }),
+			findApprovedMembership: async () => true,
+		});
+
+		await expect(service.requireActor({ userId: "user-1", activeOrganizationId: "org-1" })).rejects.toMatchObject({
+			code: "employee_required",
+		});
+	});
+});

--- a/apps/webapp/src/lib/time-tracking/clocking-service.ts
+++ b/apps/webapp/src/lib/time-tracking/clocking-service.ts
@@ -1,0 +1,67 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { member } from "@/db/auth-schema";
+import { employee } from "@/db/schema";
+
+type ClockingEmployee = Pick<typeof employee.$inferSelect, "id" | "organizationId">;
+
+export class ClockingAccessError extends Error {
+	constructor(readonly code: "active_membership_required" | "employee_required") {
+		super(
+			code === "active_membership_required"
+				? "Approved active organization membership required"
+				: "Active employee record required for the organization",
+		);
+	}
+}
+
+export function createClockingService(dependencies: {
+	findApprovedMembership: (userId: string, organizationId: string) => Promise<boolean>;
+	findActiveEmployee: (userId: string, organizationId: string) => Promise<ClockingEmployee | null>;
+}) {
+	return {
+		async requireActor(input: { userId: string; activeOrganizationId: string | null | undefined }) {
+			if (!input.activeOrganizationId) {
+				throw new ClockingAccessError("active_membership_required");
+			}
+
+			const organizationId = input.activeOrganizationId;
+			if (!(await dependencies.findApprovedMembership(input.userId, organizationId))) {
+				throw new ClockingAccessError("active_membership_required");
+			}
+
+			const employeeRecord = await dependencies.findActiveEmployee(input.userId, organizationId);
+			if (!employeeRecord || employeeRecord.organizationId !== organizationId) {
+				throw new ClockingAccessError("employee_required");
+			}
+
+			return { employee: employeeRecord, organizationId, userId: input.userId };
+		},
+	};
+}
+
+export const clockingService = createClockingService({
+	async findApprovedMembership(userId, organizationId) {
+		const membership = await db.query.member.findFirst({
+			columns: { id: true },
+			where: and(
+				eq(member.userId, userId),
+				eq(member.organizationId, organizationId),
+				eq(member.status, "approved"),
+			),
+		});
+		return Boolean(membership);
+	},
+	async findActiveEmployee(userId, organizationId) {
+		return (
+			(await db.query.employee.findFirst({
+			columns: { id: true, organizationId: true },
+			where: and(
+				eq(employee.userId, userId),
+				eq(employee.organizationId, organizationId),
+				eq(employee.isActive, true),
+			),
+			})) ?? null
+		);
+	},
+});

--- a/apps/webapp/src/lib/time-tracking/timezone-capture.test.ts
+++ b/apps/webapp/src/lib/time-tracking/timezone-capture.test.ts
@@ -10,6 +10,10 @@ import {
 
 describe("timezone capture utilities", () => {
 	it("derives offsets for the exact timestamp", () => {
+		expect(getUtcOffsetMinutesForZone(new Date("2026-05-29T12:00:00.000Z"), "UTC")).toBe(0);
+		expect(
+			getUtcOffsetMinutesForZone(new Date("2026-05-29T12:00:00.000Z"), "Pacific/Honolulu"),
+		).toBe(-600);
 		expect(getUtcOffsetMinutesForZone(new Date("2026-05-29T08:00:00.000Z"), "Europe/Berlin")).toBe(
 			120,
 		);

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -123,10 +123,51 @@ test("Next.js runtime Dockerfiles start without pnpm dependency status checks", 
 	}
 });
 
+test("font size preferences provide a static server snapshot", async () => {
+  const contents = await fs.readFile(
+    new URL("../../apps/webapp/src/components/font-size-preference.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    contents,
+    /(?:function\s+getServerFontSizePreference\s*\([^)]*\)(?:\s*:\s*[^{}=]+)?|(?:const|let|var)\s+getServerFontSizePreference\s*=\s*\([^)]*\)(?:\s*:\s*[^{}=]+)?\s*=>)\s*\{\s*return "default";\s*\}/s,
+  );
+  assert.match(
+    contents,
+    /useSyncExternalStore\(\s*[^,]+\s*,\s*[^,]+\s*,\s*getServerFontSizePreference\s*,?\s*\)/s,
+  );
+});
+
 test("docs runtime Dockerfile starts Next.js on the Kubernetes service port", async () => {
 	const contents = await fs.readFile(new URL("../Dockerfile.docs", import.meta.url), "utf8");
 
 	assert.match(contents, /CMD \["node", "node_modules\/next\/dist\/bin\/next", "start", "-p", "3001"\]/);
+});
+
+test("docs uses a TypeScript version compatible with its Next.js build", async () => {
+	const packageJson = JSON.parse(
+		await fs.readFile(new URL("../../apps/docs/package.json", import.meta.url), "utf8"),
+	);
+
+	assert.ok(
+		Number.parseInt(packageJson.devDependencies.typescript.replace(/^[~^]/, ""), 10) < 7,
+		"Next.js 16.2 resolves typescript/lib/typescript.js, which TypeScript 7 no longer ships",
+	);
+});
+
+test("marketing and webapp use TypeScript versions compatible with their Next.js builds", async () => {
+	for (const app of ["marketing", "webapp"]) {
+		const packageJson = JSON.parse(
+			await fs.readFile(new URL(`../../apps/${app}/package.json`, import.meta.url), "utf8"),
+		);
+		const typescript = packageJson.dependencies.typescript ?? packageJson.devDependencies.typescript;
+
+		assert.ok(
+			Number.parseInt(typescript.replace(/^[~^]/, ""), 10) < 7,
+			`${app} must use TypeScript 6.x until its Next.js version supports TypeScript 7`,
+		);
+	}
 });
 
 test("collectTarget lists traced worker runtime files and packages", async () => {

--- a/docs/superpowers/plans/2026-07-10-webapp-font-preference-ppr.md
+++ b/docs/superpowers/plans/2026-07-10-webapp-font-preference-ppr.md
@@ -1,0 +1,145 @@
+# Webapp Font Preference PPR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve persisted font-size preferences without accessing browser storage during Next.js Cache Components prerendering.
+
+**Architecture:** `FontSizeProvider` will use `useSyncExternalStore`, supplying a constant server snapshot and a browser-storage client snapshot. The store subscribes to native cross-tab storage events and a private event for same-tab writes, while the existing document-attribute effect remains responsible for applying the selected font size.
+
+**Tech Stack:** React 19, `useSyncExternalStore`, Vitest, Next.js 16 Cache Components, pnpm, Turborepo.
+
+---
+
+### Task 1: Add Failing PPR Regression Tests
+
+**Files:**
+- Modify: `apps/webapp/src/components/font-size-preference.test.tsx:115-178`
+- Modify: `docker/scripts/prepare-target-runtime.test.mjs:126-155`
+
+- [ ] **Step 1: Add a failing external-preference synchronization test**
+
+Add this test inside the existing `describe("FontSizeProvider", ...)` block:
+
+```tsx
+	it("updates when the stored preference changes in another tab", async () => {
+		render(
+			<FontSizeProvider>
+				<Consumer />
+			</FontSizeProvider>,
+		);
+
+		await screen.findByText("Current: default");
+		localStorage.setItem(FONT_SIZE_STORAGE_KEY, "comfortable");
+		window.dispatchEvent(new StorageEvent("storage", { key: FONT_SIZE_STORAGE_KEY }));
+
+		expect(await screen.findByText("Current: comfortable")).toBeTruthy();
+		expect(document.documentElement.dataset.fontSize).toBe("comfortable");
+	});
+```
+
+- [ ] **Step 2: Add a failing source-contract test for the server snapshot**
+
+Add this test after the Next.js runtime Dockerfile tests:
+
+```js
+test("font size preferences provide a static server snapshot", async () => {
+	const contents = await fs.readFile(
+		new URL("../../apps/webapp/src/components/font-size-preference.tsx", import.meta.url),
+		"utf8",
+	);
+
+	assert.match(contents, /useSyncExternalStore\(/);
+	assert.match(contents, /function getServerFontSizePreference\(\): FontSizePreference \{\s*return "default";/s);
+});
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `pnpm --filter webapp exec vitest run src/components/font-size-preference.test.tsx`
+
+Expected: FAIL because the current state-based provider does not subscribe to `storage` events.
+
+Run: `pnpm node --test docker/scripts/prepare-target-runtime.test.mjs`
+
+Expected: FAIL because the current provider has no `useSyncExternalStore` server snapshot.
+
+### Task 2: Implement the Server-Safe Font Preference Store
+
+**Files:**
+- Modify: `apps/webapp/src/components/font-size-preference.tsx:1-57`
+- Test: `apps/webapp/src/components/font-size-preference.test.tsx:115-178`
+- Test: `docker/scripts/prepare-target-runtime.test.mjs:126-155`
+
+- [ ] **Step 1: Replace state initialization with a server-safe external store**
+
+In `apps/webapp/src/components/font-size-preference.tsx`, import `useSyncExternalStore`, then add these module-level store functions after `getLocalStorage`:
+
+```tsx
+const FONT_SIZE_CHANGE_EVENT = "z8-font-size-change";
+
+function subscribeToFontSizePreference(onStoreChange: () => void) {
+	window.addEventListener("storage", onStoreChange);
+	window.addEventListener(FONT_SIZE_CHANGE_EVENT, onStoreChange);
+
+	return () => {
+		window.removeEventListener("storage", onStoreChange);
+		window.removeEventListener(FONT_SIZE_CHANGE_EVENT, onStoreChange);
+	};
+}
+
+function getClientFontSizePreference() {
+	return readStoredFontSize(getLocalStorage());
+}
+
+function getServerFontSizePreference(): FontSizePreference {
+	return "default";
+}
+```
+
+Replace the lazy `useState` initializer with:
+
+```tsx
+	const fontSize = useSyncExternalStore(
+		subscribeToFontSizePreference,
+		getClientFontSizePreference,
+		getServerFontSizePreference,
+	);
+```
+
+Replace `setFontSize` with:
+
+```tsx
+	const setFontSize = (value: FontSizePreference) => {
+		writeStoredFontSize(getLocalStorage(), value);
+		window.dispatchEvent(new Event(FONT_SIZE_CHANGE_EVENT));
+		applyFontSizePreference(value);
+	};
+```
+
+Keep the existing effect that calls `applyFontSizePreference(fontSize)` so the post-hydration browser snapshot updates the document attribute.
+
+- [ ] **Step 2: Run the focused component test to verify it passes**
+
+Run: `pnpm --filter webapp exec vitest run src/components/font-size-preference.test.tsx`
+
+Expected: PASS with 11 tests, including the external-preference synchronization test.
+
+- [ ] **Step 3: Run all Docker regression tests**
+
+Run: `pnpm node --test docker/scripts/prepare-target-runtime.test.mjs`
+
+Expected: PASS with the existing Docker tests and the new font-size server-snapshot test.
+
+- [ ] **Step 4: Run the CI-equivalent webapp build**
+
+Run:
+
+```bash
+pnpm exec turbo prune webapp --docker --out-dir /tmp/opencode/webapp-ppr-verify
+pnpm --dir /tmp/opencode/webapp-ppr-verify/full install --lockfile-only
+pnpm --dir /tmp/opencode/webapp-ppr-verify/full install --frozen-lockfile
+SKIP_ENV_VALIDATION=1 pnpm --dir /tmp/opencode/webapp-ppr-verify/full --filter webapp run generate-licenses
+CI=true SKIP_ENV_VALIDATION=1 NEXT_DEPLOYMENT_ID=verification BUILD_HASH=verification NEXT_PUBLIC_BUILD_HASH=verification pnpm --dir /tmp/opencode/webapp-ppr-verify/full --filter webapp exec next build
+```
+
+Expected: The build completes static page generation without an `Uncached data was accessed outside of <Suspense>` error from `font-size-preference.tsx`.

--- a/docs/superpowers/plans/2026-07-10-webapp-translation-ppr.md
+++ b/docs/superpowers/plans/2026-07-10-webapp-translation-ppr.md
@@ -1,0 +1,156 @@
+# Webapp Translation PPR Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream request-derived route translations behind Suspense while retaining translation context for the prerendered application shell.
+
+**Architecture:** The locale layout will separate provider nesting from request-dependent record loading. `TranslationProvider` continues to derive records from `headers()`, but is rendered inside Suspense; the fallback uses the same provider nesting with empty records and the same application content.
+
+**Tech Stack:** Next.js 16 Cache Components, React 19 Suspense, next-intl, Tolgee, Vitest, pnpm, Turborepo.
+
+---
+
+### Task 1: Add a Failing Translation PPR Contract Test
+
+**Files:**
+- Modify: `apps/webapp/src/app/[locale]/layout.test.tsx:133-162`
+
+- [ ] **Step 1: Write the failing source-contract test**
+
+Add this test inside `describe("LocaleLayout", ...)`:
+
+```tsx
+	it("streams request-derived translations with a base-provider fallback", () => {
+		const source = readFileSync("src/app/[locale]/layout.tsx", "utf8");
+
+		expect(source).toContain('import { Suspense, type ReactNode } from "react";');
+		expect(source).toContain("function TranslationProviders(");
+		expect(source).toContain("<Suspense");
+		expect(source).toContain("records={{}}");
+	});
+```
+
+- [ ] **Step 2: Run the layout test to verify it fails**
+
+Run: `pnpm --filter webapp exec vitest run 'src/app/[locale]/layout.test.tsx'`
+
+Expected: FAIL because the layout does not import `Suspense`, has no reusable `TranslationProviders` component, and directly renders the header-dependent provider.
+
+### Task 2: Stream Route Translations Behind Suspense
+
+**Files:**
+- Modify: `apps/webapp/src/app/[locale]/layout.tsx:1-89`
+- Test: `apps/webapp/src/app/[locale]/layout.test.tsx:133-175`
+
+- [ ] **Step 1: Extract shared provider nesting**
+
+Replace the React type-only import with:
+
+```tsx
+import { Suspense, type ReactNode } from "react";
+```
+
+Add these types and component before `TranslationProvider`:
+
+```tsx
+type TranslationRecords = Awaited<ReturnType<typeof loadRouteTranslations>>;
+
+function TranslationProviders({
+	children,
+	locale,
+	records,
+}: {
+	children: ReactNode;
+	locale: string;
+	records: TranslationRecords;
+}) {
+	return (
+		<TolgeeNextProvider language={locale} staticData={records}>
+			<NextIntlClientProvider locale={locale} messages={{ locale }}>
+				{children}
+			</NextIntlClientProvider>
+		</TolgeeNextProvider>
+	);
+}
+```
+
+Change `TranslationProvider` to return `TranslationProviders` with its loaded `records`:
+
+```tsx
+	return (
+		<TranslationProviders locale={locale} records={records}>
+			{children}
+		</TranslationProviders>
+	);
+```
+
+- [ ] **Step 2: Extract the shared application content**
+
+Add this component before `AppProviders` so the loaded and fallback translation providers wrap identical content:
+
+```tsx
+function ApplicationContent({ children }: { children: ReactNode }) {
+	return (
+		<QueryProvider>
+			<BProgressBar />
+			<TooltipProvider delayDuration={0}>
+				<OfflineBanner />
+				<SWUpdatePrompt />
+				<DeploymentRefreshChecker clientBuildHash={env.NEXT_PUBLIC_BUILD_HASH ?? "development"} />
+				{children}
+				<Toaster position="bottom-right" richColors />
+			</TooltipProvider>
+		</QueryProvider>
+	);
+}
+```
+
+- [ ] **Step 3: Add the Suspense boundary in `AppProviders`**
+
+Replace the direct `TranslationProvider` nesting with:
+
+```tsx
+				<Suspense
+					fallback={
+						<TranslationProviders locale={locale} records={{}}>
+							<ApplicationContent>{children}</ApplicationContent>
+						</TranslationProviders>
+					}
+				>
+					<TranslationProvider locale={locale}>
+						<ApplicationContent>{children}</ApplicationContent>
+					</TranslationProvider>
+				</Suspense>
+```
+
+Keep the existing outer `ThemeProvider` and `FontSizeProvider` unchanged.
+
+- [ ] **Step 4: Run the layout test to verify it passes**
+
+Run: `pnpm --filter webapp exec vitest run 'src/app/[locale]/layout.test.tsx'`
+
+Expected: PASS with the existing layout tests and the new translation PPR contract test.
+
+- [ ] **Step 5: Run the font and Docker regressions**
+
+Run: `pnpm --filter webapp exec vitest run src/components/font-size-preference.test.tsx`
+
+Expected: PASS with 13 tests.
+
+Run: `pnpm node --test docker/scripts/prepare-target-runtime.test.mjs`
+
+Expected: PASS with 22 tests.
+
+- [ ] **Step 6: Run the CI-equivalent pruned webapp build**
+
+Run:
+
+```bash
+pnpm exec turbo prune webapp --docker --out-dir /tmp/opencode/webapp-translation-ppr-verify
+pnpm --dir /tmp/opencode/webapp-translation-ppr-verify/full install --lockfile-only
+pnpm --dir /tmp/opencode/webapp-translation-ppr-verify/full install --frozen-lockfile
+SKIP_ENV_VALIDATION=1 pnpm --dir /tmp/opencode/webapp-translation-ppr-verify/full --filter webapp run generate-licenses
+CI=true SKIP_ENV_VALIDATION=1 NEXT_DEPLOYMENT_ID=verification BUILD_HASH=verification NEXT_PUBLIC_BUILD_HASH=verification pnpm --dir /tmp/opencode/webapp-translation-ppr-verify/full --filter webapp exec next build
+```
+
+Expected: The build completes static page generation without `Uncached data was accessed outside of <Suspense>` errors from `TranslationProvider` or `FontSizeProvider`.

--- a/docs/superpowers/specs/2026-07-10-webapp-font-preference-ppr-design.md
+++ b/docs/superpowers/specs/2026-07-10-webapp-font-preference-ppr-design.md
@@ -1,0 +1,32 @@
+# Webapp Font Preference PPR Design
+
+## Goal
+
+Allow the webapp to prerender with Next.js Cache Components while retaining each user's font-size preference after hydration.
+
+## Problem
+
+`FontSizeProvider` currently reads `localStorage` in its lazy state initializer. Next.js treats that browser-only value as uncached runtime data during prerendering, so static page generation fails outside a Suspense boundary.
+
+## Design
+
+Use `useSyncExternalStore` in `FontSizeProvider`.
+
+- The server snapshot is always the `default` font size and never accesses browser APIs.
+- The client snapshot reads the stored preference from `localStorage` after hydration.
+- The subscription listens for native `storage` events and a private in-tab font-size change event.
+- `setFontSize` persists the preference, dispatches the in-tab event, and applies the document attribute.
+- The existing effect applies the current store value to the document element.
+
+This preserves static rendering with the default font size. After hydration, the saved value is applied; a brief default-size flash is acceptable.
+
+## Testing
+
+- Add component tests for the default server snapshot and same-tab preference updates.
+- Run the font preference test file.
+- Run the Docker regression test suite that guards Next.js and TypeScript compatibility.
+- Run the CI-equivalent pruned webapp build with the Dockerfile's required build environment.
+
+## Scope
+
+Only `FontSizeProvider` and its tests change. Theme preferences, route rendering, and deployment configuration are not modified.

--- a/docs/superpowers/specs/2026-07-10-webapp-translation-ppr-design.md
+++ b/docs/superpowers/specs/2026-07-10-webapp-translation-ppr-design.md
@@ -1,0 +1,33 @@
+# Webapp Translation PPR Design
+
+## Goal
+
+Allow route-specific translation loading to use request headers without blocking Next.js Cache Components prerendering.
+
+## Problem
+
+`TranslationProvider` awaits `headers()` to select route namespaces. It is rendered directly in the locale layout, so Cache Components rejects the uncached request dependency during static generation.
+
+## Design
+
+Extract the shared `TolgeeNextProvider` and `NextIntlClientProvider` nesting into `TranslationProviders`.
+
+- `TranslationProvider` remains async and loads route-specific records from the pathname request header.
+- `AppProviders` wraps `TranslationProvider` in `Suspense`.
+- The fallback renders `TranslationProviders` with an empty records object.
+- The fallback preserves translation context and leaves the static application shell visible while route-specific records stream.
+
+## Behavior
+
+The shell may briefly use translation fallbacks until route-specific records arrive. It must not render without a translation provider or delay all app content behind a loading-only fallback.
+
+## Testing
+
+- Add a layout source-contract test covering the Suspense boundary and base-provider fallback.
+- Retain existing locale layout tests.
+- Run the layout test and Docker regression suite.
+- Run the CI-equivalent pruned webapp build and confirm static generation has no uncached font-preference or translation-provider access.
+
+## Scope
+
+Only the locale layout and its tests change. Translation namespace selection, route configuration, and provider libraries remain unchanged.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,13 +137,13 @@ importers:
         version: 3.44.0(react@19.2.7)
       fumadocs-core:
         specifier: ^16.11.1
-        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.1.0
-        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^16.11.1
-        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
+        version: 16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       next:
         specifier: 16.2.10
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -170,8 +170,8 @@ importers:
         specifier: ^4.3.2
         version: 4.3.2
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
 
   apps/extension:
     dependencies:
@@ -252,8 +252,8 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.3
@@ -477,7 +477,7 @@ importers:
         version: 7.19.0
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
-        version: 0.13.11(typescript@7.0.2)(zod@4.4.3)
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       '@tabler/icons-react':
         specifier: ^3.44.0
         version: 3.44.0(react@19.2.7)
@@ -615,7 +615,7 @@ importers:
         version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: ^4.13.1
-        version: 4.13.1(@swc/helpers@0.5.21)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+        version: 4.13.1(@swc/helpers@0.5.21)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -793,19 +793,19 @@ importers:
         version: 8.5.15
       shadcn:
         specifier: ^4.13.0
-        version: 4.13.0(typescript@7.0.2)
+        version: 4.13.0(typescript@6.0.3)
       tsx:
         specifier: ^4.23.0
         version: 4.23.0
       typescript:
-        specifier: ^7.0.2
-        version: 7.0.2
+        specifier: ^6.0.3
+        version: 6.0.3
       ultracite:
         specifier: 7.9.3
-        version: 7.9.3(eslint@10.4.1(jiti@2.7.0))(oxlint@1.69.0)(typescript@7.0.2)
+        version: 7.9.3(eslint@10.4.1(jiti@2.7.0))(oxlint@1.69.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -12205,6 +12205,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -17764,16 +17769,16 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@t3-oss/env-core@0.13.11(typescript@7.0.2)(zod@4.4.3)':
+  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(zod@4.4.3)':
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
       zod: 4.4.3
 
-  '@t3-oss/env-nextjs@0.13.11(typescript@7.0.2)(zod@4.4.3)':
+  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
-      '@t3-oss/env-core': 0.13.11(typescript@7.0.2)(zod@4.4.3)
+      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(zod@4.4.3)
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
       zod: 4.4.3
 
   '@tabler/icons-react@3.44.0(react@19.2.7)':
@@ -18642,12 +18647,12 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/project-service@8.63.0(typescript@7.0.2)':
+  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18656,35 +18661,35 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
 
-  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@7.0.2)':
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
     dependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@7.0.2)':
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@7.0.2)
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@7.0.2)
-      typescript: 7.0.2
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.4.1(jiti@2.7.0))(typescript@7.0.2)':
+  '@typescript-eslint/utils@8.63.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18914,6 +18919,15 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@26.1.1)(typescript@6.0.3)
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -19418,7 +19432,7 @@ snapshots:
       pg: 8.22.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -19972,6 +19986,15 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
@@ -21283,7 +21306,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -21316,14 +21339,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
+  fumadocs-mdx@15.1.0(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       github-slugger: 2.0.0
       js-yaml: 5.2.1
       mdast-util-mdx: 3.0.0
@@ -21347,7 +21370,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
+  fumadocs-ui@16.11.1(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@fumadocs/tailwind': 0.1.0(tailwindcss@4.3.2)
@@ -21363,7 +21386,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
       cnfast: 0.0.8
-      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.11.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.23.0(react@19.2.7))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.23.0(react@19.2.7)
       motion: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -23186,6 +23209,32 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
+  msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.1)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.8.0
+      until-async: 3.0.2
+      yargs: 17.7.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@26.1.1)
@@ -23244,7 +23293,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.1: {}
 
-  next-intl@4.13.1(@swc/helpers@0.5.21)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@7.0.2):
+  next-intl@4.13.1(@swc/helpers@0.5.21)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.11
       '@parcel/watcher': 2.5.6
@@ -23257,7 +23306,7 @@ snapshots:
       react: 19.2.7
       use-intl: 4.13.1(react@19.2.7)
     optionalDependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -24919,6 +24968,46 @@ snapshots:
 
   sf-symbols-typescript@2.2.0: {}
 
+  shadcn@4.13.0(typescript@6.0.3):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@dotenvx/dotenvx': 1.75.1
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@types/validate-npm-package-name': 4.0.2
+      browserslist: 4.28.5
+      commander: 14.0.3
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      dedent: 1.7.2
+      deepmerge: 4.3.1
+      diff: 8.0.4
+      execa: 9.6.1
+      fast-glob: 3.3.3
+      fs-extra: 11.3.6
+      fuzzysort: 3.1.0
+      kleur: 4.1.5
+      open: 11.0.0
+      ora: 8.2.0
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.4
+      prompts: 2.4.2
+      recast: 0.23.12
+      stringify-object: 5.0.0
+      tailwind-merge: 3.6.0
+      ts-morph: 26.0.0
+      tsconfig-paths: 4.2.0
+      undici: 7.24.0
+      validate-npm-package-name: 7.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - babel-plugin-macros
+      - supports-color
+      - typescript
+
   shadcn@4.13.0(typescript@7.0.2):
     dependencies:
       '@babel/core': 7.29.7
@@ -25472,9 +25561,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@7.0.2):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 7.0.2
+      typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
 
@@ -25548,6 +25637,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -25577,10 +25668,10 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
-  ultracite@7.9.3(eslint@10.4.1(jiti@2.7.0))(oxlint@1.69.0)(typescript@7.0.2):
+  ultracite@7.9.3(eslint@10.4.1(jiti@2.7.0))(oxlint@1.69.0)(typescript@6.0.3):
     dependencies:
       '@clack/prompts': 1.7.0
-      '@typescript-eslint/utils': 8.63.0(eslint@10.4.1(jiti@2.7.0))(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       commander: 15.0.0
       cross-spawn: 7.0.6
       deepmerge: 4.3.1
@@ -25809,6 +25900,37 @@ snapshots:
       terser: 5.49.0
       tsx: 4.23.0
       yaml: 2.9.0
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.9.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Changelog
- Restore Docs, Marketing, and Webapp production builds by pinning Next-compatible TypeScript and making browser preferences and translations PPR-safe.
- Capture and validate immutable clock-action evidence across the extension, mobile client, and time-entry APIs.
- Make Telegram digests idempotent, recipient-localized, and organization-scoped.

## Verification
- `pnpm test`
- Pruned CI-equivalent Webapp production build
- `git diff --check`