### PR TITLE
Time, Trust & Polish: Temporal-safe workforce release

### DIFF
--- a/docker/scripts/prepare-target-runtime.mjs
+++ b/docker/scripts/prepare-target-runtime.mjs
@@ -241,6 +241,7 @@ async function writeTargetPackage(target) {
   const targetPackage = {
     name: `@z8-target/${target}`,
     private: true,
+    type: "module",
     packageManager: rootPackage.packageManager,
     dependencies: Object.fromEntries(dependencyEntries),
   };

--- a/docker/scripts/prepare-target-runtime.test.mjs
+++ b/docker/scripts/prepare-target-runtime.test.mjs
@@ -201,6 +201,11 @@ test("generated migrated runtime manifests include temporal-polyfill without the
 		]);
 		const packageJson = JSON.parse(packageJsonText);
 
+		assert.equal(
+			packageJson.type,
+			"module",
+			`${target} must execute traced TypeScript as ESM for import-only packages`,
+		);
 		assert.equal(packageJson.dependencies["temporal-polyfill"], "1.0.1");
 		assert.match(lockfile, /temporal-polyfill@1\.0\.1:/);
 		assert.doesNotMatch(packageJsonText, /@js-temporal\/polyfill/);

--- a/docker/targets/db-seed/package.json
+++ b/docker/targets/db-seed/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@z8-target/db-seed",
 	"private": true,
+	"type": "module",
 	"packageManager": "pnpm@11.11.0",
 	"dependencies": {
 		"@opentelemetry/api": "^1.9.1",

--- a/docker/targets/migration/package.json
+++ b/docker/targets/migration/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@z8-target/migration",
 	"private": true,
+	"type": "module",
 	"packageManager": "pnpm@11.11.0",
 	"dependencies": {
 		"@t3-oss/env-nextjs": "^0.13.11",

--- a/docker/targets/worker/package.json
+++ b/docker/targets/worker/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@z8-target/worker",
 	"private": true,
+	"type": "module",
 	"packageManager": "pnpm@11.11.0",
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1083.0",


### PR DESCRIPTION
## Changelog

- Establish Temporal-first date and time foundations with explicit organization, employee, and event timezone context across time tracking, calendars, scheduling, reports, approvals, mobile, and the browser extension.
- Make Telegram and team digest delivery timezone-safe, recipient-localized, idempotent, and concurrency-tested.
- Improve authentication, prerendering, locale hydration, calendar controls, accessibility, and deployment refresh behavior.
- Break large login, navigation, calendar, billing, onboarding, policy, holiday, employee, approval, and enterprise surfaces into smaller maintainable modules.
- Run trimmed worker, migration, and database-seed TypeScript runtimes as ESM so import-only dependencies such as `temporal-polyfill` resolve correctly in Node 26 worker images.

## Why

This release tightens the meaning and capture of workforce time across timezone boundaries, removes several hydration and production-build hazards, and makes high-change UI areas easier to maintain. The final worker fix addresses a CommonJS/ESM mismatch in generated Docker runtime manifests that prevented the worker image from starting.

## Impact

- Timekeeping operations retain explicit local evidence while canonical instants remain UTC.
- Calendar, scheduling, report, and notification behavior follows the relevant employee or organization timezone instead of the viewer or host timezone.
- Worker, migration, and seed containers can load ESM-only runtime packages.
- Key application surfaces have smaller component boundaries and more focused regression coverage.

## Validation

- `pnpm test` — 23 Docker runtime tests, 719 webapp test files / 4,582 tests, 14 mobile test files / 46 tests, and 3 extension test files / 12 tests passed.
- `docker build -f docker/Dockerfile.worker -t z8-worker:latest .`
- `docker run --rm --entrypoint tsx z8-worker:latest src/lib/datetime/temporal-core.ts`
- Generated worker, migration, and database-seed manifests pass drift checks.
