### PR TITLE
Fix and document access error classification in payroll

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+	AuthenticationError,
+	AuthorizationError,
+	DatabaseError,
+	ValidationError,
+} from "@/lib/effect/errors";
+import { CanonicalCutoverNotReadyError } from "@/lib/time-record/migration/cutover-state";
+import { mapPayrollWorkspaceActionError } from "./action-errors";
+
+const t = (_key: string, fallback: string) => fallback;
+
+describe("mapPayrollWorkspaceActionError", () => {
+	it("classifies incomplete canonical payroll data as a conflict", () => {
+		const result = mapPayrollWorkspaceActionError(
+			new CanonicalCutoverNotReadyError("org-1"),
+			t,
+		);
+
+		expect(result).toMatchObject({
+			_tag: "ConflictError",
+			conflictType: "canonical_payroll_data_not_ready",
+			message: "Payroll data is temporarily unavailable",
+		});
+		expect(result._tag).not.toBe("ValidationError");
+	});
+
+	it("preserves authentication, authorization, and validation failures", () => {
+		const authentication = new AuthenticationError({ message: "Sign in" });
+		const authorization = new AuthorizationError({ message: "Denied" });
+		const validation = new ValidationError({ message: "Bad request" });
+
+		expect(mapPayrollWorkspaceActionError(authentication, t)).toBe(authentication);
+		expect(mapPayrollWorkspaceActionError(authorization, t)).toBe(authorization);
+		expect(mapPayrollWorkspaceActionError(validation, t)).toBe(validation);
+	});
+
+	it("keeps unexpected causes in a server-side database error", () => {
+		const cause = new Error("query failed");
+		const result = mapPayrollWorkspaceActionError(cause, t);
+
+		expect(result).toBeInstanceOf(DatabaseError);
+		expect(result).toMatchObject({
+			_tag: "DatabaseError",
+			message: "Payroll workspace action failed",
+			operation: "payroll_workspace_action",
+			cause,
+		});
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
@@ -30,8 +30,12 @@ describe("mapPayrollWorkspaceActionError", () => {
 		const authorization = new AuthorizationError({ message: "Denied" });
 		const validation = new ValidationError({ message: "Bad request" });
 
-		expect(mapPayrollWorkspaceActionError(authentication, t)).toBe(authentication);
-		expect(mapPayrollWorkspaceActionError(authorization, t)).toBe(authorization);
+		expect(mapPayrollWorkspaceActionError(authentication, t)).toBe(
+			authentication,
+		);
+		expect(mapPayrollWorkspaceActionError(authorization, t)).toBe(
+			authorization,
+		);
 		expect(mapPayrollWorkspaceActionError(validation, t)).toBe(validation);
 	});
 

--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
@@ -1,0 +1,46 @@
+import {
+	type AnyAppError,
+	AuthenticationError,
+	AuthorizationError,
+	ConflictError,
+	DatabaseError,
+	ValidationError,
+} from "@/lib/effect/errors";
+import { CanonicalCutoverNotReadyError } from "@/lib/time-record/migration/cutover-state";
+
+export type PayrollErrorTranslator = (key: string, fallback: string) => string;
+
+export function mapPayrollWorkspaceActionError(
+	error: unknown,
+	t: PayrollErrorTranslator,
+): AnyAppError {
+	if (isKnownPayrollActionError(error)) {
+		return error;
+	}
+
+	if (error instanceof CanonicalCutoverNotReadyError) {
+		return new ConflictError({
+			message: t(
+				"payroll.errors.dataTemporarilyUnavailable",
+				"Payroll data is temporarily unavailable",
+			),
+			conflictType: "canonical_payroll_data_not_ready",
+		});
+	}
+
+	return new DatabaseError({
+		message: t("payroll.errors.actionFailed", "Payroll workspace action failed"),
+		operation: "payroll_workspace_action",
+		cause: error,
+	});
+}
+
+function isKnownPayrollActionError(error: unknown): error is AnyAppError {
+	return (
+		error instanceof AuthenticationError ||
+		error instanceof AuthorizationError ||
+		error instanceof ConflictError ||
+		error instanceof DatabaseError ||
+		error instanceof ValidationError
+	);
+}

--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
@@ -29,7 +29,10 @@ export function mapPayrollWorkspaceActionError(
 	}
 
 	return new DatabaseError({
-		message: t("payroll.errors.actionFailed", "Payroll workspace action failed"),
+		message: t(
+			"payroll.errors.actionFailed",
+			"Payroll workspace action failed",
+		),
 		operation: "payroll_workspace_action",
 		cause: error,
 	});

--- a/apps/webapp/src/app/[locale]/(app)/payroll/actions.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/actions.ts
@@ -23,6 +23,7 @@ import {
 import { getPayrollWorkspaceSummary } from "@/lib/payroll-workspace/summary";
 import type { PayrollWorkspaceSummary } from "@/lib/payroll-workspace/types";
 import { getTranslate } from "@/tolgee/server";
+import { mapPayrollWorkspaceActionError } from "./action-errors";
 import { resolveScopedPayrollEmployeeIdsForAction } from "./action-helpers";
 
 type PayrollTranslate = Awaited<ReturnType<typeof getTranslate>>;
@@ -355,23 +356,7 @@ async function runPayrollWorkspaceAction<T>(
 	return runServerActionSafe(
 		Effect.tryPromise({
 			try: () => action(t),
-			catch: (error) => {
-				if (isAppError(error)) return error;
-
-				return new ValidationError({
-					message: t("payroll.errors.actionFailed", "Payroll workspace action failed"),
-				});
-			},
+			catch: (error) => mapPayrollWorkspaceActionError(error, t),
 		}),
-	);
-}
-
-function isAppError(
-	error: unknown,
-): error is ValidationError | AuthenticationError | AuthorizationError {
-	return (
-		error instanceof ValidationError ||
-		error instanceof AuthenticationError ||
-		error instanceof AuthorizationError
 	);
 }

--- a/apps/webapp/src/app/[locale]/(app)/payroll/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/page.tsx
@@ -1,12 +1,12 @@
 import { DateTime } from "luxon";
 import { connection } from "next/server";
 import { PayrollWorkspace } from "@/components/payroll/payroll-workspace";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getTranslate } from "@/tolgee/server";
 import {
 	getConfiguredPayrollExportFormatsAction,
 	getPayrollWorkspaceSummaryAction,
 } from "./actions";
+import { PayrollFailureState } from "./payroll-failure-state";
 
 export default async function PayrollPage() {
 	await connection();
@@ -27,27 +27,7 @@ export default async function PayrollPage() {
 	]);
 
 	if (!summaryResult.success) {
-		return (
-			<div className="@container/main flex flex-1 items-center justify-center p-6">
-				<Card className="max-w-md text-center">
-					<CardHeader>
-						<CardTitle>{t("payroll.accessDenied.title", "No payroll access")}</CardTitle>
-						<CardDescription>
-							{t(
-								"payroll.accessDenied.description",
-								"You do not have access to payroll data for the active organization.",
-							)}
-						</CardDescription>
-					</CardHeader>
-					<CardContent className="text-muted-foreground text-sm">
-						{t(
-							"payroll.accessDenied.help",
-							"Ask an organization administrator to assign payroll access if you need this workspace.",
-						)}
-					</CardContent>
-				</Card>
-			</div>
-		);
+		return <PayrollFailureState code={summaryResult.code} t={t} />;
 	}
 
 	return (

--- a/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PayrollFailureState } from "./payroll-failure-state";
+
+const t = (_key: string, fallback: string) => fallback;
+
+describe("PayrollFailureState", () => {
+	it.each(["AuthenticationError", "AuthorizationError"])(
+		"renders access denied for %s",
+		(code) => {
+			render(<PayrollFailureState code={code} t={t} />);
+
+			expect(screen.getByText("No payroll access")).toBeTruthy();
+			expect(screen.queryByText("Payroll temporarily unavailable")).toBeNull();
+		},
+	);
+
+	it.each(["ConflictError", "DatabaseError", "UNKNOWN_ERROR", undefined])(
+		"renders temporary unavailability for operational code %s",
+		(code) => {
+			render(<PayrollFailureState code={code} t={t} />);
+
+			expect(screen.getByText("Payroll temporarily unavailable")).toBeTruthy();
+			expect(screen.queryByText("No payroll access")).toBeNull();
+		},
+	);
+});

--- a/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx
@@ -7,23 +7,25 @@ import { PayrollFailureState } from "./payroll-failure-state";
 const t = (_key: string, fallback: string) => fallback;
 
 describe("PayrollFailureState", () => {
-	it.each(["AuthenticationError", "AuthorizationError"])(
-		"renders access denied for %s",
-		(code) => {
-			render(<PayrollFailureState code={code} t={t} />);
+	it.each([
+		"AuthenticationError",
+		"AuthorizationError",
+	])("renders access denied for %s", (code) => {
+		render(<PayrollFailureState code={code} t={t} />);
 
-			expect(screen.getByText("No payroll access")).toBeTruthy();
-			expect(screen.queryByText("Payroll temporarily unavailable")).toBeNull();
-		},
-	);
+		expect(screen.getByText("No payroll access")).toBeTruthy();
+		expect(screen.queryByText("Payroll temporarily unavailable")).toBeNull();
+	});
 
-	it.each(["ConflictError", "DatabaseError", "UNKNOWN_ERROR", undefined])(
-		"renders temporary unavailability for operational code %s",
-		(code) => {
-			render(<PayrollFailureState code={code} t={t} />);
+	it.each([
+		"ConflictError",
+		"DatabaseError",
+		"UNKNOWN_ERROR",
+		undefined,
+	])("renders temporary unavailability for operational code %s", (code) => {
+		render(<PayrollFailureState code={code} t={t} />);
 
-			expect(screen.getByText("Payroll temporarily unavailable")).toBeTruthy();
-			expect(screen.queryByText("No payroll access")).toBeNull();
-		},
-	);
+		expect(screen.getByText("Payroll temporarily unavailable")).toBeTruthy();
+		expect(screen.queryByText("No payroll access")).toBeNull();
+	});
 });

--- a/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx
@@ -1,6 +1,15 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
 
-export type PayrollFailureTranslator = (key: string, fallback: string) => string;
+export type PayrollFailureTranslator = (
+	key: string,
+	fallback: string,
+) => string;
 
 export function PayrollFailureState({
 	code,
@@ -9,7 +18,8 @@ export function PayrollFailureState({
 	code?: string;
 	t: PayrollFailureTranslator;
 }) {
-	const accessDenied = code === "AuthenticationError" || code === "AuthorizationError";
+	const accessDenied =
+		code === "AuthenticationError" || code === "AuthorizationError";
 	const title = accessDenied
 		? t("payroll.accessDenied.title", "No payroll access")
 		: t("payroll.unavailable.title", "Payroll temporarily unavailable");
@@ -18,7 +28,10 @@ export function PayrollFailureState({
 				"payroll.accessDenied.description",
 				"You do not have access to payroll data for the active organization.",
 			)
-		: t("payroll.unavailable.description", "Payroll data could not be prepared safely.");
+		: t(
+				"payroll.unavailable.description",
+				"Payroll data could not be prepared safely.",
+			);
 	const help = accessDenied
 		? t(
 				"payroll.accessDenied.help",
@@ -36,7 +49,9 @@ export function PayrollFailureState({
 					<CardTitle>{title}</CardTitle>
 					<CardDescription>{description}</CardDescription>
 				</CardHeader>
-				<CardContent className="text-muted-foreground text-sm">{help}</CardContent>
+				<CardContent className="text-muted-foreground text-sm">
+					{help}
+				</CardContent>
 			</Card>
 		</div>
 	);

--- a/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export type PayrollFailureTranslator = (key: string, fallback: string) => string;
+
+export function PayrollFailureState({
+	code,
+	t,
+}: {
+	code?: string;
+	t: PayrollFailureTranslator;
+}) {
+	const accessDenied = code === "AuthenticationError" || code === "AuthorizationError";
+	const title = accessDenied
+		? t("payroll.accessDenied.title", "No payroll access")
+		: t("payroll.unavailable.title", "Payroll temporarily unavailable");
+	const description = accessDenied
+		? t(
+				"payroll.accessDenied.description",
+				"You do not have access to payroll data for the active organization.",
+			)
+		: t("payroll.unavailable.description", "Payroll data could not be prepared safely.");
+	const help = accessDenied
+		? t(
+				"payroll.accessDenied.help",
+				"Ask an organization administrator to assign payroll access if you need this workspace.",
+			)
+		: t(
+				"payroll.unavailable.help",
+				"Please try again later. If the problem continues, contact an organization administrator.",
+			);
+
+	return (
+		<div className="@container/main flex flex-1 items-center justify-center p-6">
+			<Card className="max-w-md text-center">
+				<CardHeader>
+					<CardTitle>{title}</CardTitle>
+					<CardDescription>{description}</CardDescription>
+				</CardHeader>
+				<CardContent className="text-muted-foreground text-sm">{help}</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
@@ -100,9 +100,11 @@ describe("assertCanonicalCutoverReady", () => {
 				missingAbsenceOrganizationIds: 0,
 			});
 
-		await expect(assertCanonicalCutoverReady("org-1")).rejects.toThrow(
-			"Canonical time-record backfill is incomplete for organization org-1",
-		);
+		await expect(assertCanonicalCutoverReady("org-1")).rejects.toMatchObject({
+			name: "CanonicalCutoverNotReadyError",
+			organizationId: "org-1",
+			message: "Canonical time-record backfill is incomplete for organization org-1",
+		});
 		expect(runCanonicalBackfill).toHaveBeenCalledWith({
 			organizationId: "org-1",
 			actorId: "user-1",

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
@@ -103,7 +103,8 @@ describe("assertCanonicalCutoverReady", () => {
 		await expect(assertCanonicalCutoverReady("org-1")).rejects.toMatchObject({
 			name: "CanonicalCutoverNotReadyError",
 			organizationId: "org-1",
-			message: "Canonical time-record backfill is incomplete for organization org-1",
+			message:
+				"Canonical time-record backfill is incomplete for organization org-1",
 		});
 		expect(runCanonicalBackfill).toHaveBeenCalledWith({
 			organizationId: "org-1",

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.ts
@@ -3,6 +3,16 @@ import { db, employee } from "@/db";
 import { runCanonicalBackfill } from "./backfill";
 import { reconcileLegacyToCanonical } from "./reconciliation";
 
+export class CanonicalCutoverNotReadyError extends Error {
+	readonly organizationId: string;
+
+	constructor(organizationId: string) {
+		super(`Canonical time-record backfill is incomplete for organization ${organizationId}`);
+		this.name = "CanonicalCutoverNotReadyError";
+		this.organizationId = organizationId;
+	}
+}
+
 export async function assertCanonicalCutoverReady(organizationId: string) {
 	let reconciliation = await reconcileLegacyToCanonical(organizationId);
 
@@ -25,9 +35,7 @@ export async function assertCanonicalCutoverReady(organizationId: string) {
 	}
 
 	if (hasReconciliationMismatch(reconciliation)) {
-		throw new Error(
-			`Canonical time-record backfill is incomplete for organization ${organizationId}`,
-		);
+		throw new CanonicalCutoverNotReadyError(organizationId);
 	}
 }
 

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.ts
@@ -7,7 +7,9 @@ export class CanonicalCutoverNotReadyError extends Error {
 	readonly organizationId: string;
 
 	constructor(organizationId: string) {
-		super(`Canonical time-record backfill is incomplete for organization ${organizationId}`);
+		super(
+			`Canonical time-record backfill is incomplete for organization ${organizationId}`,
+		);
 		this.name = "CanonicalCutoverNotReadyError";
 		this.organizationId = organizationId;
 	}

--- a/docs/superpowers/plans/2026-07-25-payroll-access-error-classification.md
+++ b/docs/superpowers/plans/2026-07-25-payroll-access-error-classification.md
@@ -1,0 +1,522 @@
+# Payroll Access Error Classification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop reporting assigned payroll officers as unauthorized when canonical payroll data is temporarily unavailable.
+
+**Architecture:** Give the canonical cutover failure a stable runtime type, translate it at the payroll server-action boundary into a safe `ConflictError`, and render payroll access denial only for authentication and authorization result codes. Keep the canonical integrity guard and all organization-scoped grant resolution unchanged.
+
+**Tech Stack:** TypeScript, Next.js server components and server actions, Effect tagged errors, Vitest, React Testing Library, pnpm.
+
+## Global Constraints
+
+- Authorization remains fail-closed and organization-scoped.
+- The change must not broaden payroll access or bypass employee scope.
+- Incomplete canonical payroll totals remain blocked.
+- Client-facing messages remain generic; detailed causes stay in server logs.
+- Use pnpm only.
+- Keep canonical payroll date/time behavior unchanged.
+
+---
+
+## File Structure
+
+- `apps/webapp/src/lib/time-record/migration/cutover-state.ts`: owns the stable error type emitted when reconciliation/backfill cannot make canonical data ready.
+- `apps/webapp/src/lib/time-record/migration/cutover-state.test.ts`: proves the cutover guard emits the stable error only after repair still fails.
+- `apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts`: maps payroll action failures to existing safe Effect application errors.
+- `apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts`: proves classification preserves auth/validation errors, identifies data-readiness conflicts, and retains unexpected causes in server-only database errors.
+- `apps/webapp/src/app/[locale]/(app)/payroll/actions.ts`: delegates action error classification to the mapper.
+- `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx`: renders either access denial or temporary unavailability from a server-action error code.
+- `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx`: verifies the user-visible distinction using the real component.
+- `apps/webapp/src/app/[locale]/(app)/payroll/page.tsx`: uses the failure-state component for unsuccessful initial summary loads.
+
+### Task 1: Give canonical cutover failures a stable type
+
+**Files:**
+- Modify: `apps/webapp/src/lib/time-record/migration/cutover-state.ts`
+- Modify: `apps/webapp/src/lib/time-record/migration/cutover-state.test.ts`
+
+**Interfaces:**
+- Produces: `CanonicalCutoverNotReadyError extends Error` with `organizationId: string`.
+- Consumed by: Task 2's `mapPayrollWorkspaceActionError`.
+
+- [ ] **Step 1: Write the failing typed-error assertion**
+
+Update the existing “throws when repair backfill still leaves canonical mismatches” test so it captures the rejection and checks its observable type and organization:
+
+```ts
+await expect(assertCanonicalCutoverReady("org-1")).rejects.toMatchObject({
+	name: "CanonicalCutoverNotReadyError",
+	organizationId: "org-1",
+	message: "Canonical time-record backfill is incomplete for organization org-1",
+});
+```
+
+This catches a regression where the cutover guard falls back to an unclassifiable plain `Error`.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run src/lib/time-record/migration/cutover-state.test.ts
+```
+
+Expected: FAIL because the rejection currently has `name: "Error"` and no `organizationId`.
+
+- [ ] **Step 3: Implement the stable cutover error**
+
+Add this export near the imports in `cutover-state.ts`:
+
+```ts
+export class CanonicalCutoverNotReadyError extends Error {
+	readonly organizationId: string;
+
+	constructor(organizationId: string) {
+		super(`Canonical time-record backfill is incomplete for organization ${organizationId}`);
+		this.name = "CanonicalCutoverNotReadyError";
+		this.organizationId = organizationId;
+	}
+}
+```
+
+Replace the final plain error:
+
+```ts
+if (hasReconciliationMismatch(reconciliation)) {
+	throw new CanonicalCutoverNotReadyError(organizationId);
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run src/lib/time-record/migration/cutover-state.test.ts
+```
+
+Expected: PASS with all cutover-state tests green.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add apps/webapp/src/lib/time-record/migration/cutover-state.ts apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
+git commit -m "fix(payroll): type canonical readiness failures"
+```
+
+### Task 2: Preserve payroll action error meaning
+
+**Files:**
+- Create: `apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts`
+- Create: `apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts`
+- Modify: `apps/webapp/src/app/[locale]/(app)/payroll/actions.ts`
+
+**Interfaces:**
+- Consumes: `CanonicalCutoverNotReadyError` from Task 1.
+- Produces:
+
+```ts
+export type PayrollErrorTranslator = (key: string, fallback: string) => string;
+
+export function mapPayrollWorkspaceActionError(
+	error: unknown,
+	t: PayrollErrorTranslator,
+): AnyAppError;
+```
+
+- [ ] **Step 1: Write the failing error-mapper tests**
+
+Create `action-errors.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	AuthenticationError,
+	AuthorizationError,
+	DatabaseError,
+	ValidationError,
+} from "@/lib/effect/errors";
+import { CanonicalCutoverNotReadyError } from "@/lib/time-record/migration/cutover-state";
+import { mapPayrollWorkspaceActionError } from "./action-errors";
+
+const t = (_key: string, fallback: string) => fallback;
+
+describe("mapPayrollWorkspaceActionError", () => {
+	it("classifies incomplete canonical payroll data as a conflict", () => {
+		const result = mapPayrollWorkspaceActionError(
+			new CanonicalCutoverNotReadyError("org-1"),
+			t,
+		);
+
+		expect(result).toMatchObject({
+			_tag: "ConflictError",
+			conflictType: "canonical_payroll_data_not_ready",
+			message: "Payroll data is temporarily unavailable",
+		});
+		expect(result._tag).not.toBe("ValidationError");
+	});
+
+	it("preserves authentication, authorization, and validation failures", () => {
+		const authentication = new AuthenticationError({ message: "Sign in" });
+		const authorization = new AuthorizationError({ message: "Denied" });
+		const validation = new ValidationError({ message: "Bad request" });
+
+		expect(mapPayrollWorkspaceActionError(authentication, t)).toBe(authentication);
+		expect(mapPayrollWorkspaceActionError(authorization, t)).toBe(authorization);
+		expect(mapPayrollWorkspaceActionError(validation, t)).toBe(validation);
+	});
+
+	it("keeps unexpected causes in a server-side database error", () => {
+		const cause = new Error("query failed");
+		const result = mapPayrollWorkspaceActionError(cause, t);
+
+		expect(result).toBeInstanceOf(DatabaseError);
+		expect(result).toMatchObject({
+			_tag: "DatabaseError",
+			message: "Payroll workspace action failed",
+			operation: "payroll_workspace_action",
+			cause,
+		});
+	});
+});
+```
+
+The production change that makes these pass is replacing the current catch-all `ValidationError` mapping with semantic classification.
+
+- [ ] **Step 2: Run the mapper tests and verify RED**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run 'src/app/[locale]/(app)/payroll/action-errors.test.ts'
+```
+
+Expected: FAIL because `action-errors.ts` and `mapPayrollWorkspaceActionError` do not exist.
+
+- [ ] **Step 3: Implement the error mapper**
+
+Create `action-errors.ts`:
+
+```ts
+import {
+	type AnyAppError,
+	AuthenticationError,
+	AuthorizationError,
+	ConflictError,
+	DatabaseError,
+	ValidationError,
+} from "@/lib/effect/errors";
+import { CanonicalCutoverNotReadyError } from "@/lib/time-record/migration/cutover-state";
+
+export type PayrollErrorTranslator = (key: string, fallback: string) => string;
+
+export function mapPayrollWorkspaceActionError(
+	error: unknown,
+	t: PayrollErrorTranslator,
+): AnyAppError {
+	if (isKnownPayrollActionError(error)) {
+		return error;
+	}
+
+	if (error instanceof CanonicalCutoverNotReadyError) {
+		return new ConflictError({
+			message: t(
+				"payroll.errors.dataTemporarilyUnavailable",
+				"Payroll data is temporarily unavailable",
+			),
+			conflictType: "canonical_payroll_data_not_ready",
+		});
+	}
+
+	return new DatabaseError({
+		message: t("payroll.errors.actionFailed", "Payroll workspace action failed"),
+		operation: "payroll_workspace_action",
+		cause: error,
+	});
+}
+
+function isKnownPayrollActionError(error: unknown): error is AnyAppError {
+	return (
+		error instanceof AuthenticationError ||
+		error instanceof AuthorizationError ||
+		error instanceof ConflictError ||
+		error instanceof DatabaseError ||
+		error instanceof ValidationError
+	);
+}
+```
+
+- [ ] **Step 4: Integrate the mapper into the action wrapper**
+
+In `actions.ts`, import `mapPayrollWorkspaceActionError`, remove the local `isAppError` function, remove now-unused error imports, and replace the catch body with:
+
+```ts
+catch: (error) => mapPayrollWorkspaceActionError(error, t),
+```
+
+This keeps input `ValidationError`s intact while ensuring cutover and unexpected operational failures are no longer logged or returned as validation failures.
+
+- [ ] **Step 5: Run focused action tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run \
+  'src/app/[locale]/(app)/payroll/action-errors.test.ts' \
+  'src/app/[locale]/(app)/payroll/actions.test.ts' \
+  'src/app/[locale]/(app)/payroll/actions.start-export.test.ts'
+```
+
+Expected: PASS. The data-readiness mapper result has `_tag: "ConflictError"` and unexpected errors retain their cause only on `DatabaseError`.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add 'apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/actions.ts'
+git commit -m "fix(payroll): preserve workspace error classification"
+```
+
+### Task 3: Distinguish denied access from temporary unavailability
+
+**Files:**
+- Create: `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx`
+- Create: `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx`
+- Modify: `apps/webapp/src/app/[locale]/(app)/payroll/page.tsx`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type PayrollFailureTranslator = (key: string, fallback: string) => string;
+
+export function PayrollFailureState(props: {
+	code?: string;
+	t: PayrollFailureTranslator;
+}): React.JSX.Element;
+```
+
+- Consumed by: `PayrollPage` when `summaryResult.success === false`.
+
+- [ ] **Step 1: Write the failing real-component tests**
+
+Create `payroll-failure-state.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PayrollFailureState } from "./payroll-failure-state";
+
+const t = (_key: string, fallback: string) => fallback;
+
+describe("PayrollFailureState", () => {
+	it.each(["AuthenticationError", "AuthorizationError"])(
+		"renders access denied for %s",
+		(code) => {
+			render(<PayrollFailureState code={code} t={t} />);
+
+			expect(screen.getByText("No payroll access")).toBeTruthy();
+			expect(screen.queryByText("Payroll temporarily unavailable")).toBeNull();
+		},
+	);
+
+	it.each(["ConflictError", "DatabaseError", "UNKNOWN_ERROR", undefined])(
+		"renders temporary unavailability for operational code %s",
+		(code) => {
+			render(<PayrollFailureState code={code} t={t} />);
+
+			expect(screen.getByText("Payroll temporarily unavailable")).toBeTruthy();
+			expect(screen.queryByText("No payroll access")).toBeNull();
+		},
+	);
+});
+```
+
+The tests exercise the real failure-state component, not a mocked UI or source-text assertion.
+
+- [ ] **Step 2: Run the component test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run 'src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx'
+```
+
+Expected: FAIL because `PayrollFailureState` does not exist.
+
+- [ ] **Step 3: Implement the failure-state component**
+
+Create `payroll-failure-state.tsx`:
+
+```tsx
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export type PayrollFailureTranslator = (key: string, fallback: string) => string;
+
+export function PayrollFailureState({
+	code,
+	t,
+}: {
+	code?: string;
+	t: PayrollFailureTranslator;
+}) {
+	const accessDenied = code === "AuthenticationError" || code === "AuthorizationError";
+	const title = accessDenied
+		? t("payroll.accessDenied.title", "No payroll access")
+		: t("payroll.unavailable.title", "Payroll temporarily unavailable");
+	const description = accessDenied
+		? t(
+				"payroll.accessDenied.description",
+				"You do not have access to payroll data for the active organization.",
+			)
+		: t(
+				"payroll.unavailable.description",
+				"Payroll data could not be prepared safely.",
+			);
+	const help = accessDenied
+		? t(
+				"payroll.accessDenied.help",
+				"Ask an organization administrator to assign payroll access if you need this workspace.",
+			)
+		: t(
+				"payroll.unavailable.help",
+				"Please try again later. If the problem continues, contact an organization administrator.",
+			);
+
+	return (
+		<div className="@container/main flex flex-1 items-center justify-center p-6">
+			<Card className="max-w-md text-center">
+				<CardHeader>
+					<CardTitle>{title}</CardTitle>
+					<CardDescription>{description}</CardDescription>
+				</CardHeader>
+				<CardContent className="text-muted-foreground text-sm">{help}</CardContent>
+			</Card>
+		</div>
+	);
+}
+```
+
+- [ ] **Step 4: Use the component from the payroll page**
+
+In `page.tsx`, remove the direct error `Card` markup and its now-unused UI imports. Add:
+
+```ts
+import { PayrollFailureState } from "./payroll-failure-state";
+```
+
+Replace the unsuccessful summary branch with:
+
+```tsx
+if (!summaryResult.success) {
+	return <PayrollFailureState code={summaryResult.code} t={t} />;
+}
+```
+
+- [ ] **Step 5: Run the focused UI test and verify GREEN**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run 'src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx'
+```
+
+Expected: PASS for auth, conflict, database, unknown, and missing error codes.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add 'apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/page.tsx'
+git commit -m "fix(payroll): distinguish unavailable data from denied access"
+```
+
+### Task 4: Regression and security verification
+
+**Files:**
+- Verify only; modify earlier task files only if a check exposes a defect.
+
+**Interfaces:**
+- Consumes all Task 1–3 behavior.
+- Produces a verified payroll access fix with no widened authorization scope.
+
+- [ ] **Step 1: Run the complete focused regression set**
+
+Run:
+
+```bash
+pnpm --filter webapp exec vitest run \
+  'src/lib/time-record/migration/cutover-state.test.ts' \
+  'src/lib/payroll-workspace/summary.cutover.test.ts' \
+  'src/lib/payroll-access/permissions.test.ts' \
+  'src/app/[locale]/(app)/payroll/action-errors.test.ts' \
+  'src/app/[locale]/(app)/payroll/actions.test.ts' \
+  'src/app/[locale]/(app)/payroll/actions.start-export.test.ts' \
+  'src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx' \
+  'src/components/app-sidebar.test.tsx'
+```
+
+Expected: PASS with no unexpected warnings.
+
+- [ ] **Step 2: Run webapp type checking**
+
+Run:
+
+```bash
+pnpm --filter webapp typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 3: Run formatting and static checks on touched files**
+
+Run:
+
+```bash
+pnpm exec ultracite check \
+  'apps/webapp/src/lib/time-record/migration/cutover-state.ts' \
+  'apps/webapp/src/lib/time-record/migration/cutover-state.test.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/actions.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/page.tsx'
+```
+
+Expected: PASS with no formatting, lint, accessibility, or import-order findings.
+
+- [ ] **Step 4: Review the authorization and data-integrity diff**
+
+Run:
+
+```bash
+git diff HEAD~3 -- \
+  'apps/webapp/src/lib/time-record/migration/cutover-state.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/actions.ts' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx' \
+  'apps/webapp/src/app/[locale]/(app)/payroll/page.tsx'
+```
+
+Confirm all four invariants:
+
+```txt
+1. Payroll grant lookup and employee scope resolution are unchanged.
+2. Organization IDs remain server-derived and organization-scoped.
+3. Canonical cutover mismatch still blocks totals and exports.
+4. Client responses contain safe copy while server-side DatabaseError retains unexpected causes.
+```
+
+- [ ] **Step 5: Check the final working tree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: the implementation commits are present and there are no unintended or uncommitted files.

--- a/docs/superpowers/specs/2026-07-25-payroll-access-error-classification-design.md
+++ b/docs/superpowers/specs/2026-07-25-payroll-access-error-classification-design.md
@@ -1,0 +1,71 @@
+# Payroll Access Error Classification
+
+## Problem
+
+The payroll workspace loads its initial summary through
+`getPayrollWorkspaceSummaryAction`. The canonical time-record cutover guard can
+reject that load when payroll data is not ready. The action wrapper currently
+converts that operational failure into a `ValidationError`, and the payroll page
+renders every failed action result as “No payroll access.”
+
+As a result, a user with an active, organization-scoped payroll access grant is
+shown an authorization denial even though authorization succeeded.
+
+## Design
+
+Keep the canonical cutover guard fail-closed so payroll never displays totals
+from an incomplete canonical dataset.
+
+Classify failures at the server-action boundary according to their actual
+meaning:
+
+- Authentication and authorization failures retain their existing tagged error
+  codes.
+- Canonical payroll data-readiness failures become a distinct, safe
+  operational result rather than a `ValidationError`.
+- Unexpected failures remain non-authorization failures and do not expose
+  sensitive internal details to the client.
+
+At the payroll page boundary:
+
+- Render the existing “No payroll access” state only for authentication and
+  authorization result codes.
+- Render a separate “Payroll temporarily unavailable” state for data-readiness
+  and other operational failures.
+- Do not render payroll totals or the workspace when the canonical dataset is
+  incomplete.
+
+The payroll access grant lookup and employee scope resolution remain unchanged.
+They already enforce the active organization and active grant.
+
+## Error Flow
+
+1. The assigned payroll officer requests the payroll workspace.
+2. Existing organization-scoped grant resolution authorizes the officer and
+   resolves allowed employee IDs.
+3. The summary service checks canonical cutover readiness.
+4. If ready, the payroll workspace renders normally.
+5. If not ready, the action returns an operational/data-readiness code and the
+   page renders the temporary-unavailability state.
+6. Only actual authentication or authorization failures render “No payroll
+   access.”
+
+## Security and Data Integrity
+
+- Authorization remains fail-closed and organization-scoped.
+- The change does not broaden payroll access or bypass employee scope.
+- Incomplete canonical payroll totals remain blocked.
+- Client-facing messages remain generic; detailed causes stay in server logs.
+
+## Testing
+
+Add focused regression coverage proving:
+
+- A canonical data-readiness failure is not returned as `ValidationError`.
+- Authentication and authorization failures retain access-denied
+  classification.
+- The payroll page renders access denied only for auth failures.
+- The payroll page renders temporary unavailability for operational failures.
+
+Run the focused payroll action/page tests, relevant payroll access tests, and
+the webapp type/lint checks appropriate to the touched files.


### PR DESCRIPTION
This pull request improves the classification and handling of payroll access errors, ensuring users see accurate error states on the payroll workspace page. Instead of showing all failures as "No payroll access," the app now distinguishes between authentication/authorization errors and operational/data-readiness failures (such as when payroll data is not ready). It introduces a new error type for canonical data readiness, updates error mapping and UI rendering, and adds focused tests and documentation for the new behavior.

**Error handling and classification:**
- Introduced a new `CanonicalCutoverNotReadyError` class to represent incomplete canonical payroll data and updated the cutover readiness check to throw this error instead of a generic error (`apps/webapp/src/lib/time-record/migration/cutover-state.ts`) (F07aaca1R1, [apps/webapp/src/lib/time-record/migration/cutover-state.tsL28-R40](diffhunk://#diff-b2a9dc60a6614ada10ef4e4724702777618d691f1d3d1ad2003b33c7a2bc355dL28-R40)).
- Added a new error mapping function, `mapPayrollWorkspaceActionError`, which translates errors into appropriate app error types, distinguishing between authentication/authorization, data readiness, and unexpected errors (`apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts`) ([apps/webapp/src/app/[locale]/(app)/payroll/action-errors.tsR1-R49](diffhunk://#diff-eaab4686f4040732aeaa172d4fed11c5e47564b6450e25712bb7bf1f20ddcc73R1-R49)).
- Updated the payroll workspace action handler to use the new error mapping, removing the old `isAppError` logic (`apps/webapp/src/app/[locale]/(app)/payroll/actions.ts`) ([apps/webapp/src/app/[locale]/(app)/payroll/actions.tsR26](diffhunk://#diff-103a412e68fee9d9ef90b076d4520cd1b19ca96409d4a79003c74d76d7186e6eR26), [apps/webapp/src/app/[locale]/(app)/payroll/actions.tsL358-L377](diffhunk://#diff-103a412e68fee9d9ef90b076d4520cd1b19ca96409d4a79003c74d76d7186e6eL358-L377)).

**UI and user experience:**
- Refactored the payroll page to use a new `PayrollFailureState` component, which renders distinct messages for access denied (auth errors) and temporary unavailability (operational/data-readiness errors) (`apps/webapp/src/app/[locale]/(app)/payroll/page.tsx`, `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsx`) ([apps/webapp/src/app/[locale]/(app)/payroll/page.tsxL4-R9](diffhunk://#diff-fc1aedbe347ccb5f4a8a511dc5d3557daaf97739b9128f37f529dd1c1e0daf11L4-R9), [apps/webapp/src/app/[locale]/(app)/payroll/page.tsxL30-R30](diffhunk://#diff-fc1aedbe347ccb5f4a8a511dc5d3557daaf97739b9128f37f529dd1c1e0daf11L30-R30), [apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.tsxR1-R58](diffhunk://#diff-a1254ccf6e24d5f51fd83c552362c80dcc3e0d5146ac8606086436986f569e56R1-R58)).

**Testing and documentation:**
- Added unit tests for the error mapping logic and the new failure state component to ensure correct rendering and error classification (`apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts`, `apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx`) ([apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.tsR1-R54](diffhunk://#diff-0a8491ce7976fd0bc3ace2a7b3f6f8d403048f69142f589a91b9d2baa2ecb8ddR1-R54), [apps/webapp/src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsxR1-R31](diffhunk://#diff-e66136cd330701a6f3e31d4d50aa54253ca4adccffb1dcf847c3c8c991271021R1-R31)).
- Documented the new error classification design and flow in a dedicated spec file (`docs/superpowers/specs/2026-07-25-payroll-access-error-classification-design.md`).