### PR TITLE
feat: add absence dates to payroll PDF

### DIFF
--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -10,7 +10,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Z8 supports both file exports and selected API-based payroll integrations. The exact behavior depends on the target system.
 
-Users with Payroll access can also review the employees within their authorized scope and download a combined PDF that includes the exact dates of approved absences.
+Users with assigned, active Payroll access can also review the employees within their authorized scope and download a combined PDF that includes the exact dates of approved absences.
 
 Use **Settings** -> **Payroll Export** to configure export targets, store org-specific credentials, maintain wage type mappings, and start exports for a selected period.
 
@@ -147,7 +147,7 @@ Review mappings before every first export for a new target, especially when abse
 
 ## Combined Payroll PDF
 
-Payroll officers and org admins use `/payroll` to review a selected period for the employees within their authorized scope and download a combined payroll PDF.
+Payroll officers, including org admins, must have assigned, active Payroll access to use `/payroll`; the org admin role alone does not grant access. They can review a selected period for the employees within their authorized scope and download a combined payroll PDF.
 
 The PDF includes:
 
@@ -155,9 +155,9 @@ The PDF includes:
 - payroll readiness blockers
 - every approved absence date, its category, and whether it covers a **Full day**, **AM**, or **PM**
 
-For multi-day absence records, the report lists every recorded calendar date in the approved record, including weekends and holidays. It does not remove dates based on work schedules.
+For multi-day absence records, the report lists every recorded calendar date within the selected payroll period, including any weekends and holidays included in the approved record. Dates outside the report period are not shown, and dates are not removed based on work schedules.
 
-Use this report when you need to enter approved time and absence information manually into another legal or payroll system.
+Use this report when you need to enter approved time and absence information manually into a downstream payroll or HR system used for required recordkeeping.
 
 This report is PDF-only. It does not change DATEV, Lexware, or Sage export formats, or Personio, SAP SuccessFactors, or Workday API payloads.
 

--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -10,6 +10,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 Z8 supports both file exports and selected API-based payroll integrations. The exact behavior depends on the target system.
 
+Users with Payroll access can also review the employees within their authorized scope and download a combined PDF that includes the exact dates of approved absences.
+
 Use **Settings** -> **Payroll Export** to configure export targets, store org-specific credentials, maintain wage type mappings, and start exports for a selected period.
 
 Use **Settings** -> **Export Operations** to monitor export failures, upcoming scheduled runs, and recent payroll, audit, and scheduled export activity across the organization.
@@ -140,6 +142,24 @@ Use the **Wage Types** tab to map Z8 work categories, absence categories, and sp
 Each mapping can carry different codes per export target, which lets one organization maintain DATEV, Lexware, Sage, and SuccessFactors mappings without duplicating categories.
 
 Review mappings before every first export for a new target, especially when absences or overtime should be represented differently across systems.
+
+---
+
+## Combined Payroll PDF
+
+Payroll officers and org admins use `/payroll` to review a selected period for the employees within their authorized scope and download a combined payroll PDF.
+
+The PDF includes:
+
+- worked-hour and approved absence totals
+- payroll readiness blockers
+- every approved absence date, its category, and whether it covers a **Full day**, **AM**, or **PM**
+
+For multi-day absence records, the report lists every recorded calendar date in the approved record, including weekends and holidays. It does not remove dates based on work schedules.
+
+Use this report when you need to enter approved time and absence information manually into another legal or payroll system.
+
+This report is PDF-only. It does not change DATEV, Lexware, or Sage export formats, or Personio, SAP SuccessFactors, or Workday API payloads.
 
 ---
 

--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -155,7 +155,7 @@ The PDF includes:
 - payroll readiness blockers
 - every approved absence date, its category, and whether it covers a **Full day**, **AM**, **PM**, or **Partial day**; explicitly timed intervals that cross noon or continue overnight are shown as **Partial day**, with overnight intervals listed once on their recorded start date
 
-For multi-day absence records, the report lists every recorded calendar date within the selected payroll period, including any weekends and holidays included in the approved record. Dates outside the report period are not shown, and dates are not removed based on work schedules.
+For ordinary multi-day absence ranges, the report lists every recorded calendar date within the selected payroll period, including any weekends and holidays in the approved record. Timed overnight partials are the exception: they appear once on the recorded start date as **Partial day**. Dates outside the report period are not shown, and dates are not removed based on work schedules.
 
 Use this report when you need to review or enter approved time and absence information manually in a downstream payroll or HR system.
 

--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -153,11 +153,11 @@ The PDF includes:
 
 - worked-hour and approved absence totals
 - payroll readiness blockers
-- every approved absence date, its category, and whether it covers a **Full day**, **AM**, or **PM**
+- every approved absence date, its category, and whether it covers a **Full day**, **AM**, **PM**, or **Partial day**; explicitly timed intervals that cross from AM into PM are shown as **Partial day**
 
 For multi-day absence records, the report lists every recorded calendar date within the selected payroll period, including any weekends and holidays included in the approved record. Dates outside the report period are not shown, and dates are not removed based on work schedules.
 
-Use this report when you need to enter approved time and absence information manually into a downstream payroll or HR system used for required recordkeeping.
+Use this report when you need to review or enter approved time and absence information manually in a downstream payroll or HR system.
 
 This report is PDF-only. It does not change DATEV, Lexware, or Sage export formats, or Personio, SAP SuccessFactors, or Workday API payloads.
 

--- a/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+++ b/apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
@@ -153,7 +153,7 @@ The PDF includes:
 
 - worked-hour and approved absence totals
 - payroll readiness blockers
-- every approved absence date, its category, and whether it covers a **Full day**, **AM**, **PM**, or **Partial day**; explicitly timed intervals that cross from AM into PM are shown as **Partial day**
+- every approved absence date, its category, and whether it covers a **Full day**, **AM**, **PM**, or **Partial day**; explicitly timed intervals that cross noon or continue overnight are shown as **Partial day**, with overnight intervals listed once on their recorded start date
 
 For multi-day absence records, the report lists every recorded calendar date within the selected payroll period, including any weekends and holidays included in the approved record. Dates outside the report period are not shown, and dates are not removed based on work schedules.
 

--- a/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
@@ -60,6 +60,7 @@ const baseSummary: PayrollWorkspaceSummary = {
 			hasBlockers: false,
 		},
 	],
+	absenceDetails: [],
 	blockers: [
 		{
 			id: "blocker-1",
@@ -83,6 +84,7 @@ function buildSummary(overrides: Partial<PayrollWorkspaceSummary> = {}): Payroll
 		period: overrides.period ?? baseSummary.period,
 		totals: overrides.totals ?? baseSummary.totals,
 		employees: overrides.employees ?? baseSummary.employees,
+		absenceDetails: overrides.absenceDetails ?? baseSummary.absenceDetails,
 		blockers: overrides.blockers ?? baseSummary.blockers,
 	};
 }

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildPayrollAbsenceDetails,
+	payrollAbsenceDetailDays,
+} from "./absence-details";
+
+const june2026 = { start: "2026-06-01", end: "2026-06-30" };
+
+describe("buildPayrollAbsenceDetails", () => {
+	it.each([
+		"full_day",
+		"am",
+		"pm",
+	] as const)("preserves a same-day %s absence", (dayPeriod) => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "vacation",
+						categoryName: "Vacation",
+						startDate: "2026-06-10",
+						endDate: "2026-06-10",
+						startPeriod: dayPeriod,
+						endPeriod: dayPeriod,
+					},
+				],
+				june2026,
+			),
+		).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: dayPeriod,
+			},
+		]);
+	});
+
+	it("uses a full day when a same-day record has different endpoint periods", () => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-10",
+					startPeriod: "am",
+					endPeriod: "pm",
+				},
+			],
+			june2026,
+		);
+
+		expect(details[0]?.period).toBe("full_day");
+	});
+
+	it("clips a multi-day range while preserving only original endpoint periods", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "vacation",
+						categoryName: "Vacation",
+						startDate: "2026-05-31",
+						endDate: "2026-06-02",
+						startPeriod: "pm",
+						endPeriod: "am",
+					},
+				],
+				june2026,
+			),
+		).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-01",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-02",
+				period: "am",
+			},
+		]);
+	});
+
+	it("includes weekends and sorts by employee, date, category name, then category id", () => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-b",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-06",
+					endDate: "2026-06-08",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+				{
+					employeeId: "employee-a",
+					categoryId: "category-b",
+					categoryName: "Alpha",
+					startDate: "2026-06-07",
+					endDate: "2026-06-07",
+					startPeriod: "pm",
+					endPeriod: "pm",
+				},
+				{
+					employeeId: "employee-a",
+					categoryId: "category-z",
+					categoryName: "Zeta",
+					startDate: "2026-06-07",
+					endDate: "2026-06-07",
+					startPeriod: "am",
+					endPeriod: "am",
+				},
+				{
+					employeeId: "employee-a",
+					categoryId: "category-a",
+					categoryName: "Alpha",
+					startDate: "2026-06-07",
+					endDate: "2026-06-07",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+			],
+			june2026,
+		);
+
+		expect(
+			details.map(({ employeeId, date, categoryName, categoryId }) => [
+				employeeId,
+				date,
+				categoryName,
+				categoryId,
+			]),
+		).toEqual([
+			["employee-a", "2026-06-07", "Alpha", "category-a"],
+			["employee-a", "2026-06-07", "Alpha", "category-b"],
+			["employee-a", "2026-06-07", "Zeta", "category-z"],
+			["employee-b", "2026-06-06", "Vacation", "vacation"],
+			["employee-b", "2026-06-07", "Vacation", "vacation"],
+			["employee-b", "2026-06-08", "Vacation", "vacation"],
+		]);
+	});
+
+	it("excludes reversed record ranges", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "vacation",
+						categoryName: "Vacation",
+						startDate: "2026-06-11",
+						endDate: "2026-06-10",
+						startPeriod: "full_day",
+						endPeriod: "full_day",
+					},
+				],
+				june2026,
+			),
+		).toEqual([]);
+	});
+});
+
+describe("payrollAbsenceDetailDays", () => {
+	it.each([
+		["full_day", 1],
+		["am", 0.5],
+		["pm", 0.5],
+	] as const)("returns %s as %s day", (period, expectedDays) => {
+		expect(payrollAbsenceDetailDays(period)).toBe(expectedDays);
+	});
+});

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
@@ -91,6 +91,28 @@ describe("buildPayrollAbsenceDetails", () => {
 		]);
 	});
 
+	it("normalizes a multi-day AM start and PM end to full days", () => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-11",
+					startPeriod: "am",
+					endPeriod: "pm",
+				},
+			],
+			june2026,
+		);
+
+		expect(details.map(({ date, period }) => ({ date, period }))).toEqual([
+			{ date: "2026-06-10", period: "full_day" },
+			{ date: "2026-06-11", period: "full_day" },
+		]);
+	});
+
 	it("includes weekends and sorts by employee, date, category name, then category id", () => {
 		const details = buildPayrollAbsenceDetails(
 			[

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
@@ -57,6 +57,31 @@ describe("buildPayrollAbsenceDetails", () => {
 		expect(details[0]?.period).toBe("full_day");
 	});
 
+	it.each([
+		["14:00:00", "17:00:00", "pm"],
+		["09:00:00", "11:00:00", "am"],
+		["10:00:00", "14:00:00", "partial_day"],
+	] as const)("classifies an explicit %s-%s interval as %s", (startTime, endTime, expectedPeriod) => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-10",
+					startPeriod: "am",
+					endPeriod: "am",
+					startTime,
+					endTime,
+				},
+			],
+			june2026,
+		);
+
+		expect(details[0]?.period).toBe(expectedPeriod);
+	});
+
 	it("clips a multi-day range while preserving only original endpoint periods", () => {
 		expect(
 			buildPayrollAbsenceDetails(
@@ -220,6 +245,7 @@ describe("payrollAbsenceDetailDays", () => {
 		["full_day", 1],
 		["am", 0.5],
 		["pm", 0.5],
+		["partial_day", 0.5],
 	] as const)("returns %s as %s day", (period, expectedDays) => {
 		expect(payrollAbsenceDetailDays(period)).toBe(expectedDays);
 	});

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
@@ -60,6 +60,8 @@ describe("buildPayrollAbsenceDetails", () => {
 	it.each([
 		["14:00:00", "17:00:00", "pm"],
 		["09:00:00", "11:00:00", "am"],
+		["09:00:00", "12:00:00", "am"],
+		["12:00:00", "14:00:00", "pm"],
 		["10:00:00", "14:00:00", "partial_day"],
 	] as const)("classifies an explicit %s-%s interval as %s", (startTime, endTime, expectedPeriod) => {
 		const details = buildPayrollAbsenceDetails(
@@ -80,6 +82,78 @@ describe("buildPayrollAbsenceDetails", () => {
 		);
 
 		expect(details[0]?.period).toBe(expectedPeriod);
+	});
+
+	it("emits an explicit overnight partial only on its logical start date", () => {
+		const row = {
+			employeeId: "employee-1",
+			categoryId: "vacation",
+			categoryName: "Vacation",
+			startDate: "2026-06-10",
+			endDate: "2026-06-11",
+			startPeriod: "am" as const,
+			endPeriod: "am" as const,
+			startTime: "22:00:00",
+			endTime: "02:00:00",
+		};
+
+		expect(buildPayrollAbsenceDetails([row], june2026)).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: "partial_day",
+			},
+		]);
+		expect(
+			buildPayrollAbsenceDetails([row], {
+				start: "2026-06-10",
+				end: "2026-06-10",
+			}),
+		).toHaveLength(1);
+		expect(
+			buildPayrollAbsenceDetails([row], {
+				start: "2026-06-11",
+				end: "2026-06-11",
+			}),
+		).toEqual([]);
+	});
+
+	it("preserves period-only multi-day AM ranges with canonical boundary times", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "vacation",
+						categoryName: "Vacation",
+						startDate: "2026-06-10",
+						endDate: "2026-06-11",
+						startPeriod: "am",
+						endPeriod: "am",
+						startTime: "00:00:00",
+						endTime: "11:59:59",
+					},
+				],
+				june2026,
+			),
+		).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-11",
+				period: "am",
+			},
+		]);
 	});
 
 	it("clips a multi-day range while preserving only original endpoint periods", () => {

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
@@ -113,6 +113,28 @@ describe("buildPayrollAbsenceDetails", () => {
 		]);
 	});
 
+	it("preserves a multi-day PM start and AM end", () => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-11",
+					startPeriod: "pm",
+					endPeriod: "am",
+				},
+			],
+			june2026,
+		);
+
+		expect(details.map(({ date, period }) => ({ date, period }))).toEqual([
+			{ date: "2026-06-10", period: "pm" },
+			{ date: "2026-06-11", period: "am" },
+		]);
+	});
+
 	it("includes weekends and sorts by employee, date, category name, then category id", () => {
 		const details = buildPayrollAbsenceDetails(
 			[

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.ts
@@ -47,9 +47,9 @@ export function buildPayrollAbsenceDetails(
 			if (originalStart.equals(originalEnd)) {
 				if (row.startPeriod === row.endPeriod) dayPeriod = row.startPeriod;
 			} else if (date.equals(originalStart)) {
-				dayPeriod = row.startPeriod;
+				dayPeriod = row.startPeriod === "pm" ? "pm" : "full_day";
 			} else if (date.equals(originalEnd)) {
-				dayPeriod = row.endPeriod;
+				dayPeriod = row.endPeriod === "am" ? "am" : "full_day";
 			}
 
 			details.push({

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.ts
@@ -1,0 +1,76 @@
+import { Temporal } from "temporal-polyfill";
+import type {
+	PayrollAbsenceDetail,
+	PayrollDayPeriod,
+	PayrollPeriod,
+	PayrollSummaryAbsenceRow,
+} from "./types";
+
+function compareText(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+export function buildPayrollAbsenceDetails(
+	rows: PayrollSummaryAbsenceRow[],
+	period: Pick<PayrollPeriod, "start" | "end">,
+): PayrollAbsenceDetail[] {
+	const periodStart = Temporal.PlainDate.from(period.start);
+	const periodEnd = Temporal.PlainDate.from(period.end);
+	const details: PayrollAbsenceDetail[] = [];
+
+	for (const row of rows) {
+		const originalStart = Temporal.PlainDate.from(row.startDate);
+		const originalEnd = Temporal.PlainDate.from(row.endDate);
+
+		if (Temporal.PlainDate.compare(originalStart, originalEnd) > 0) continue;
+
+		const clippedStart =
+			Temporal.PlainDate.compare(originalStart, periodStart) < 0
+				? periodStart
+				: originalStart;
+		const clippedEnd =
+			Temporal.PlainDate.compare(originalEnd, periodEnd) > 0
+				? periodEnd
+				: originalEnd;
+
+		if (Temporal.PlainDate.compare(clippedStart, clippedEnd) > 0) continue;
+
+		for (
+			let date = clippedStart;
+			Temporal.PlainDate.compare(date, clippedEnd) <= 0;
+			date = date.add({ days: 1 })
+		) {
+			let dayPeriod: PayrollDayPeriod = "full_day";
+
+			if (originalStart.equals(originalEnd)) {
+				if (row.startPeriod === row.endPeriod) dayPeriod = row.startPeriod;
+			} else if (date.equals(originalStart)) {
+				dayPeriod = row.startPeriod;
+			} else if (date.equals(originalEnd)) {
+				dayPeriod = row.endPeriod;
+			}
+
+			details.push({
+				employeeId: row.employeeId,
+				categoryId: row.categoryId,
+				categoryName: row.categoryName,
+				date: date.toString(),
+				period: dayPeriod,
+			});
+		}
+	}
+
+	return details.sort(
+		(left, right) =>
+			compareText(left.employeeId, right.employeeId) ||
+			compareText(left.date, right.date) ||
+			compareText(left.categoryName, right.categoryName) ||
+			compareText(left.categoryId, right.categoryId),
+	);
+}
+
+export function payrollAbsenceDetailDays(period: PayrollDayPeriod): number {
+	return period === "full_day" ? 1 : 0.5;
+}

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.ts
@@ -1,7 +1,7 @@
 import { Temporal } from "temporal-polyfill";
 import type {
 	PayrollAbsenceDetail,
-	PayrollDayPeriod,
+	PayrollAbsenceDetailPeriod,
 	PayrollPeriod,
 	PayrollSummaryAbsenceRangeRow,
 } from "./types";
@@ -42,10 +42,10 @@ export function buildPayrollAbsenceDetails(
 			Temporal.PlainDate.compare(date, clippedEnd) <= 0;
 			date = date.add({ days: 1 })
 		) {
-			let dayPeriod: PayrollDayPeriod = "full_day";
+			let dayPeriod: PayrollAbsenceDetailPeriod = "full_day";
 
 			if (originalStart.equals(originalEnd)) {
-				if (row.startPeriod === row.endPeriod) dayPeriod = row.startPeriod;
+				dayPeriod = classifySameDayPeriod(row);
 			} else if (date.equals(originalStart)) {
 				dayPeriod = row.startPeriod === "pm" ? "pm" : "full_day";
 			} else if (date.equals(originalEnd)) {
@@ -71,6 +71,29 @@ export function buildPayrollAbsenceDetails(
 	);
 }
 
-export function payrollAbsenceDetailDays(period: PayrollDayPeriod): number {
+export function payrollAbsenceDetailDays(
+	period: PayrollAbsenceDetailPeriod,
+): number {
 	return period === "full_day" ? 1 : 0.5;
+}
+
+function classifySameDayPeriod(
+	row: PayrollSummaryAbsenceRangeRow,
+): PayrollAbsenceDetailPeriod {
+	if (
+		row.startPeriod === "am" &&
+		row.endPeriod === "am" &&
+		row.startTime &&
+		row.endTime
+	) {
+		const noon = Temporal.PlainTime.from("12:00:00");
+		const startTime = Temporal.PlainTime.from(row.startTime);
+		const endTime = Temporal.PlainTime.from(row.endTime);
+
+		if (Temporal.PlainTime.compare(startTime, noon) >= 0) return "pm";
+		if (Temporal.PlainTime.compare(endTime, noon) <= 0) return "am";
+		return "partial_day";
+	}
+
+	return row.startPeriod === row.endPeriod ? row.startPeriod : "full_day";
 }

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.ts
@@ -3,7 +3,7 @@ import type {
 	PayrollAbsenceDetail,
 	PayrollDayPeriod,
 	PayrollPeriod,
-	PayrollSummaryAbsenceRow,
+	PayrollSummaryAbsenceRangeRow,
 } from "./types";
 
 function compareText(left: string, right: string): number {
@@ -13,7 +13,7 @@ function compareText(left: string, right: string): number {
 }
 
 export function buildPayrollAbsenceDetails(
-	rows: PayrollSummaryAbsenceRow[],
+	rows: PayrollSummaryAbsenceRangeRow[],
 	period: Pick<PayrollPeriod, "start" | "end">,
 ): PayrollAbsenceDetail[] {
 	const periodStart = Temporal.PlainDate.from(period.start);

--- a/apps/webapp/src/lib/payroll-workspace/absence-details.ts
+++ b/apps/webapp/src/lib/payroll-workspace/absence-details.ts
@@ -25,6 +25,21 @@ export function buildPayrollAbsenceDetails(
 		const originalEnd = Temporal.PlainDate.from(row.endDate);
 
 		if (Temporal.PlainDate.compare(originalStart, originalEnd) > 0) continue;
+		if (isExplicitOvernightPartial(row, originalStart, originalEnd)) {
+			if (
+				Temporal.PlainDate.compare(originalStart, periodStart) >= 0 &&
+				Temporal.PlainDate.compare(originalStart, periodEnd) <= 0
+			) {
+				details.push({
+					employeeId: row.employeeId,
+					categoryId: row.categoryId,
+					categoryName: row.categoryName,
+					date: originalStart.toString(),
+					period: "partial_day",
+				});
+			}
+			continue;
+		}
 
 		const clippedStart =
 			Temporal.PlainDate.compare(originalStart, periodStart) < 0
@@ -96,4 +111,22 @@ function classifySameDayPeriod(
 	}
 
 	return row.startPeriod === row.endPeriod ? row.startPeriod : "full_day";
+}
+
+function isExplicitOvernightPartial(
+	row: PayrollSummaryAbsenceRangeRow,
+	startDate: Temporal.PlainDate,
+	endDate: Temporal.PlainDate,
+): boolean {
+	return (
+		!startDate.equals(endDate) &&
+		row.startPeriod === "am" &&
+		row.endPeriod === "am" &&
+		row.startTime !== undefined &&
+		row.endTime !== undefined &&
+		Temporal.PlainTime.compare(
+			Temporal.PlainTime.from(row.endTime),
+			Temporal.PlainTime.from(row.startTime),
+		) < 0
+	);
 }

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildPayrollAbsenceSections,
-	chunkPayrollAbsenceSections,
 	exportPayrollSummaryToPDF,
 	generatePayrollPDFFilename,
-	type PayrollAbsenceSection,
 } from "./pdf-exporter";
 import type { PayrollWorkspaceSummary } from "./types";
 
@@ -180,6 +178,33 @@ describe("payroll PDF exporter", () => {
 		).toEqual(["ada", "Zoe"]);
 	});
 
+	it("preserves summary employee order when names are identical", () => {
+		const identicalNamesSummary: PayrollWorkspaceSummary = {
+			...summary,
+			employees: [
+				{
+					...summary.employees[0],
+					id: "employee-2",
+					name: "Alex Smith",
+				},
+				{
+					...summary.employees[0],
+					name: "Alex Smith",
+				},
+			],
+			absenceDetails: [
+				{ ...summary.absenceDetails[0], employeeId: "employee-2" },
+				{ ...summary.absenceDetails[0], employeeId: "employee-1" },
+			],
+		};
+
+		expect(
+			buildPayrollAbsenceSections(identicalNamesSummary).map(
+				(section) => section.employeeId,
+			),
+		).toEqual(["employee-2", "employee-1"]);
+	});
+
 	it("preserves duplicate absence details", () => {
 		const duplicateDetail = summary.absenceDetails[0];
 		const duplicateSummary: PayrollWorkspaceSummary = {
@@ -191,41 +216,6 @@ describe("payroll PDF exporter", () => {
 			{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
 			{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
 		]);
-	});
-
-	it("chunks long employee sections without losing rows or employee context", () => {
-		const rows: PayrollAbsenceSection["rows"] = Array.from(
-			{ length: 60 },
-			(_, index) => ({
-				date: `2026-06-${String((index % 30) + 1).padStart(2, "0")}`,
-				categoryName: `Category ${index + 1}`,
-				periodLabel: "Full day",
-			}),
-		);
-		const section: PayrollAbsenceSection = {
-			employeeId: "employee-1",
-			employeeName: "Ada Lovelace",
-			employeeNumber: "E-1",
-			rows,
-		};
-
-		const chunks = chunkPayrollAbsenceSections([section]);
-
-		expect(chunks.map((chunk) => chunk.rows.length)).toEqual([18, 18, 18, 6]);
-		expect(
-			chunks.map((chunk) => ({
-				employeeId: chunk.employeeId,
-				employeeName: chunk.employeeName,
-				employeeNumber: chunk.employeeNumber,
-			})),
-		).toEqual(
-			Array.from({ length: 4 }, () => ({
-				employeeId: "employee-1",
-				employeeName: "Ada Lovelace",
-				employeeNumber: "E-1",
-			})),
-		);
-		expect(chunks.flatMap((chunk) => chunk.rows)).toEqual(rows);
 	});
 
 	it("omits absence sections when there are no approved details", () => {
@@ -251,5 +241,22 @@ describe("payroll PDF exporter", () => {
 			absenceDetails: [],
 		});
 		expect(pdf.byteLength).toBeGreaterThan(1000);
+	});
+
+	it("flows a long employee absence report across physical PDF pages", async () => {
+		const pdf = await exportPayrollSummaryToPDF({
+			...summary,
+			absenceDetails: Array.from({ length: 60 }, (_, index) => ({
+				employeeId: "employee-1",
+				categoryId: `category-${String(index).padStart(2, "0")}`,
+				categoryName: `Approved absence category ${index + 1}`,
+				date: "2026-06-03",
+				period: "full_day" as const,
+			})),
+		});
+		const pdfText = Buffer.from(pdf).toString("latin1");
+		const pageCount = pdfText.match(/\/Type \/Page\b/g)?.length ?? 0;
+
+		expect(pageCount).toBeGreaterThan(2);
 	});
 });

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildPayrollAbsenceSections,
+	chunkPayrollAbsenceSections,
 	exportPayrollSummaryToPDF,
 	generatePayrollPDFFilename,
+	type PayrollAbsenceSection,
 } from "./pdf-exporter";
 import type { PayrollWorkspaceSummary } from "./types";
 
@@ -124,6 +126,108 @@ describe("payroll PDF exporter", () => {
 		]);
 	});
 
+	it("uses the raw period as the final absence row sort key", () => {
+		const sameCategorySummary: PayrollWorkspaceSummary = {
+			...summary,
+			absenceDetails: [
+				{
+					employeeId: "employee-1",
+					categoryId: "sick",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "pm",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "am",
+				},
+			],
+		};
+
+		expect(buildPayrollAbsenceSections(sameCategorySummary)[0]?.rows).toEqual([
+			{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+			{ date: "2026-06-03", categoryName: "Sick", periodLabel: "PM" },
+		]);
+	});
+
+	it("uses payroll summary name sorting semantics for employee sections", () => {
+		const nameOrderingSummary: PayrollWorkspaceSummary = {
+			...summary,
+			employees: [
+				{
+					...summary.employees[0],
+					id: "employee-2",
+					name: "Zoe",
+				},
+				{
+					...summary.employees[0],
+					name: "ada",
+				},
+			],
+			absenceDetails: [
+				{ ...summary.absenceDetails[0], employeeId: "employee-2" },
+				{ ...summary.absenceDetails[0], employeeId: "employee-1" },
+			],
+		};
+
+		expect(
+			buildPayrollAbsenceSections(nameOrderingSummary).map(
+				(section) => section.employeeName,
+			),
+		).toEqual(["ada", "Zoe"]);
+	});
+
+	it("preserves duplicate absence details", () => {
+		const duplicateDetail = summary.absenceDetails[0];
+		const duplicateSummary: PayrollWorkspaceSummary = {
+			...summary,
+			absenceDetails: [duplicateDetail, duplicateDetail],
+		};
+
+		expect(buildPayrollAbsenceSections(duplicateSummary)[0]?.rows).toEqual([
+			{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
+			{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
+		]);
+	});
+
+	it("chunks long employee sections without losing rows or employee context", () => {
+		const rows: PayrollAbsenceSection["rows"] = Array.from(
+			{ length: 60 },
+			(_, index) => ({
+				date: `2026-06-${String((index % 30) + 1).padStart(2, "0")}`,
+				categoryName: `Category ${index + 1}`,
+				periodLabel: "Full day",
+			}),
+		);
+		const section: PayrollAbsenceSection = {
+			employeeId: "employee-1",
+			employeeName: "Ada Lovelace",
+			employeeNumber: "E-1",
+			rows,
+		};
+
+		const chunks = chunkPayrollAbsenceSections([section]);
+
+		expect(chunks.map((chunk) => chunk.rows.length)).toEqual([18, 18, 18, 6]);
+		expect(
+			chunks.map((chunk) => ({
+				employeeId: chunk.employeeId,
+				employeeName: chunk.employeeName,
+				employeeNumber: chunk.employeeNumber,
+			})),
+		).toEqual(
+			Array.from({ length: 4 }, () => ({
+				employeeId: "employee-1",
+				employeeName: "Ada Lovelace",
+				employeeNumber: "E-1",
+			})),
+		);
+		expect(chunks.flatMap((chunk) => chunk.rows)).toEqual(rows);
+	});
+
 	it("omits absence sections when there are no approved details", () => {
 		expect(
 			buildPayrollAbsenceSections({ ...summary, absenceDetails: [] }),
@@ -138,6 +242,14 @@ describe("payroll PDF exporter", () => {
 
 	it("generates a PDF byte array", async () => {
 		const pdf = await exportPayrollSummaryToPDF(summary);
+		expect(pdf.byteLength).toBeGreaterThan(1000);
+	});
+
+	it("generates a PDF byte array without absence details", async () => {
+		const pdf = await exportPayrollSummaryToPDF({
+			...summary,
+			absenceDetails: [],
+		});
 		expect(pdf.byteLength).toBeGreaterThan(1000);
 	});
 });

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -20,6 +20,7 @@ const summary: PayrollWorkspaceSummary = {
 			hasBlockers: true,
 		},
 	],
+	absenceDetails: [],
 	blockers: [
 		{
 			id: "blocker-1",

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { exportPayrollSummaryToPDF, generatePayrollPDFFilename } from "./pdf-exporter";
+import {
+	buildPayrollAbsenceSections,
+	exportPayrollSummaryToPDF,
+	generatePayrollPDFFilename,
+} from "./pdf-exporter";
 import type { PayrollWorkspaceSummary } from "./types";
 
 const summary: PayrollWorkspaceSummary = {
@@ -16,11 +20,29 @@ const summary: PayrollWorkspaceSummary = {
 			teamName: "Ops",
 			contractType: "hourly",
 			workedHours: 12.5,
-			absenceDaysByCategory: [{ categoryId: "vacation", categoryName: "Vacation", days: 2 }],
+			absenceDaysByCategory: [
+				{ categoryId: "sick", categoryName: "Sick", days: 1 },
+				{ categoryId: "vacation", categoryName: "Vacation", days: 0.5 },
+			],
 			hasBlockers: true,
 		},
 	],
-	absenceDetails: [],
+	absenceDetails: [
+		{
+			employeeId: "employee-1",
+			categoryId: "vacation",
+			categoryName: "Vacation",
+			date: "2026-06-08",
+			period: "am",
+		},
+		{
+			employeeId: "employee-1",
+			categoryId: "sick",
+			categoryName: "Sick",
+			date: "2026-06-03",
+			period: "full_day",
+		},
+	],
 	blockers: [
 		{
 			id: "blocker-1",
@@ -32,8 +54,30 @@ const summary: PayrollWorkspaceSummary = {
 };
 
 describe("payroll PDF exporter", () => {
+	it("groups approved absence details by employee in audit order", () => {
+		expect(buildPayrollAbsenceSections(summary)).toEqual([
+			{
+				employeeId: "employee-1",
+				employeeName: "Ada Lovelace",
+				employeeNumber: "E-1",
+				rows: [
+					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "Full day" },
+					{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
+				],
+			},
+		]);
+	});
+
+	it("omits absence sections when there are no approved details", () => {
+		expect(
+			buildPayrollAbsenceSections({ ...summary, absenceDetails: [] }),
+		).toEqual([]);
+	});
+
 	it("generates a stable filename", () => {
-		expect(generatePayrollPDFFilename(summary)).toBe("payroll-acme-gmbh-2026-06-01-2026-06-30.pdf");
+		expect(generatePayrollPDFFilename(summary)).toBe(
+			"payroll-acme-gmbh-2026-06-01-2026-06-30.pdf",
+		);
 	});
 
 	it("generates a PDF byte array", async () => {

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -113,8 +113,8 @@ describe("payroll PDF exporter", () => {
 				employeeName: "Ada Lovelace",
 				employeeNumber: "E-1",
 				rows: [
-					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "PM" },
 					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "PM" },
 					{
 						date: "2026-06-03",
 						categoryName: "Vacation",
@@ -133,7 +133,7 @@ describe("payroll PDF exporter", () => {
 		]);
 	});
 
-	it("uses the raw period as the final absence row sort key", () => {
+	it("uses the visible period before category id as an absence row sort key", () => {
 		const sameCategorySummary: PayrollWorkspaceSummary = {
 			...summary,
 			absenceDetails: [
@@ -157,6 +157,37 @@ describe("payroll PDF exporter", () => {
 		expect(buildPayrollAbsenceSections(sameCategorySummary)[0]?.rows).toEqual([
 			{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
 			{ date: "2026-06-03", categoryName: "Sick", periodLabel: "PM" },
+		]);
+	});
+
+	it("formats crossing timed intervals and sorts by the visible period before category id", () => {
+		const sameCategorySummary: PayrollWorkspaceSummary = {
+			...summary,
+			absenceDetails: [
+				{
+					employeeId: "employee-1",
+					categoryId: "sick-a",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "partial_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick-z",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "am",
+				},
+			],
+		};
+
+		expect(buildPayrollAbsenceSections(sameCategorySummary)[0]?.rows).toEqual([
+			{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+			{
+				date: "2026-06-03",
+				categoryName: "Sick",
+				periodLabel: "Partial day",
+			},
 		]);
 	});
 
@@ -187,7 +218,7 @@ describe("payroll PDF exporter", () => {
 		).toEqual(["ada", "Zoe"]);
 	});
 
-	it("preserves summary employee order when names are identical", () => {
+	it("sorts employees with identical names by id", () => {
 		const identicalNamesSummary: PayrollWorkspaceSummary = {
 			...summary,
 			employees: [
@@ -211,7 +242,7 @@ describe("payroll PDF exporter", () => {
 			buildPayrollAbsenceSections(identicalNamesSummary).map(
 				(section) => section.employeeId,
 			),
-		).toEqual(["employee-2", "employee-1"]);
+		).toEqual(["employee-1", "employee-2"]);
 	});
 
 	it("preserves duplicate absence details", () => {

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -2,9 +2,18 @@ import { describe, expect, it } from "vitest";
 import {
 	buildPayrollAbsenceSections,
 	exportPayrollSummaryToPDF,
+	flattenPayrollAbsenceSections,
 	generatePayrollPDFFilename,
 } from "./pdf-exporter";
 import type { PayrollWorkspaceSummary } from "./types";
+
+function countPDFPages(pdf: Uint8Array): number {
+	return (
+		Buffer.from(pdf)
+			.toString("latin1")
+			.match(/\/Type \/Page\b/g)?.length ?? 0
+	);
+}
 
 const summary: PayrollWorkspaceSummary = {
 	organizationName: "Acme GmbH",
@@ -218,6 +227,52 @@ describe("payroll PDF exporter", () => {
 		]);
 	});
 
+	it("flattens grouped rows without losing employee context or duplicates", () => {
+		expect(
+			flattenPayrollAbsenceSections([
+				{
+					employeeId: "employee-1",
+					employeeName: "Ada Lovelace",
+					employeeNumber: "E-1",
+					rows: [
+						{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+						{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+					],
+				},
+				{
+					employeeId: "employee-2",
+					employeeName: "Grace Hopper",
+					employeeNumber: null,
+					rows: [
+						{ date: "2026-06-04", categoryName: "Vacation", periodLabel: "PM" },
+					],
+				},
+			]),
+		).toEqual([
+			{
+				employeeName: "Ada Lovelace",
+				employeeNumber: "E-1",
+				date: "2026-06-03",
+				categoryName: "Sick",
+				periodLabel: "AM",
+			},
+			{
+				employeeName: "Ada Lovelace",
+				employeeNumber: "E-1",
+				date: "2026-06-03",
+				categoryName: "Sick",
+				periodLabel: "AM",
+			},
+			{
+				employeeName: "Grace Hopper",
+				employeeNumber: "No employee no.",
+				date: "2026-06-04",
+				categoryName: "Vacation",
+				periodLabel: "PM",
+			},
+		]);
+	});
+
 	it("omits absence sections when there are no approved details", () => {
 		expect(
 			buildPayrollAbsenceSections({ ...summary, absenceDetails: [] }),
@@ -254,9 +309,37 @@ describe("payroll PDF exporter", () => {
 				period: "full_day" as const,
 			})),
 		});
-		const pdfText = Buffer.from(pdf).toString("latin1");
-		const pageCount = pdfText.match(/\/Type \/Page\b/g)?.length ?? 0;
+		const pageCount = countPDFPages(pdf);
 
 		expect(pageCount).toBeGreaterThan(2);
 	});
+
+	it("keeps one-row employee absence reports compact", async () => {
+		const employees = Array.from({ length: 100 }, (_, index) => {
+			const employeeNumber = String(index + 1).padStart(3, "0");
+			return {
+				...summary.employees[0],
+				id: `employee-${employeeNumber}`,
+				name: `Employee ${employeeNumber}`,
+				employeeNumber: `E-${employeeNumber}`,
+			};
+		});
+		const pdf = await exportPayrollSummaryToPDF({
+			...summary,
+			totals: { ...summary.totals, employeeCount: employees.length },
+			employees,
+			absenceDetails: employees.map((employee) => ({
+				employeeId: employee.id,
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-03",
+				period: "full_day" as const,
+			})),
+			blockers: [],
+		});
+
+		const pageCount = countPDFPages(pdf);
+
+		expect(pageCount).toBeLessThan(20);
+	}, 15_000);
 });

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -54,15 +54,71 @@ const summary: PayrollWorkspaceSummary = {
 };
 
 describe("payroll PDF exporter", () => {
-	it("groups approved absence details by employee in audit order", () => {
-		expect(buildPayrollAbsenceSections(summary)).toEqual([
+	it("sorts employee sections and same-date absence rows in audit order", () => {
+		const orderingSummary: PayrollWorkspaceSummary = {
+			...summary,
+			employees: [
+				{
+					...summary.employees[0],
+					id: "employee-2",
+					name: "Grace Hopper",
+					employeeNumber: "E-2",
+				},
+				summary.employees[0],
+			],
+			absenceDetails: [
+				{
+					employeeId: "employee-2",
+					categoryId: "sick",
+					categoryName: "Sick",
+					date: "2026-06-04",
+					period: "full_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					date: "2026-06-03",
+					period: "full_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick-b",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "am",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick-a",
+					categoryName: "Sick",
+					date: "2026-06-03",
+					period: "pm",
+				},
+			],
+		};
+
+		expect(buildPayrollAbsenceSections(orderingSummary)).toEqual([
 			{
 				employeeId: "employee-1",
 				employeeName: "Ada Lovelace",
 				employeeNumber: "E-1",
 				rows: [
-					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "Full day" },
-					{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
+					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "PM" },
+					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "AM" },
+					{
+						date: "2026-06-03",
+						categoryName: "Vacation",
+						periodLabel: "Full day",
+					},
+				],
+			},
+			{
+				employeeId: "employee-2",
+				employeeName: "Grace Hopper",
+				employeeNumber: "E-2",
+				rows: [
+					{ date: "2026-06-04", categoryName: "Sick", periodLabel: "Full day" },
 				],
 			},
 		]);

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
@@ -1,5 +1,20 @@
 import { DateTime } from "luxon";
-import type { PayrollEmployeeSummary, PayrollWorkspaceSummary } from "./types";
+import type {
+	PayrollDayPeriod,
+	PayrollEmployeeSummary,
+	PayrollWorkspaceSummary,
+} from "./types";
+
+export interface PayrollAbsenceSection {
+	employeeId: string;
+	employeeName: string;
+	employeeNumber: string | null;
+	rows: Array<{
+		date: string;
+		categoryName: string;
+		periodLabel: string;
+	}>;
+}
 
 const styleDefinitions = {
 	page: {
@@ -160,6 +175,61 @@ const styleDefinitions = {
 	muted: {
 		color: "#64748B",
 	},
+	absenceDetailsSection: {
+		marginTop: 14,
+	},
+	employeeCard: {
+		marginBottom: 8,
+		borderWidth: 1,
+		borderColor: "#CBD5E1",
+	},
+	employeeCardHeader: {
+		paddingTop: 5,
+		paddingRight: 7,
+		paddingBottom: 5,
+		paddingLeft: 7,
+		fontSize: 9,
+		fontWeight: "bold" as const,
+		color: "#0F172A",
+		backgroundColor: "#F1F5F9",
+	},
+	absenceDetailHeader: {
+		flexDirection: "row" as const,
+		paddingTop: 4,
+		paddingRight: 7,
+		paddingBottom: 4,
+		paddingLeft: 7,
+		fontSize: 7,
+		fontWeight: "bold" as const,
+		textTransform: "uppercase" as const,
+		color: "#64748B",
+	},
+	absenceDetailRow: {
+		flexDirection: "row" as const,
+		paddingTop: 4,
+		paddingRight: 7,
+		paddingBottom: 4,
+		paddingLeft: 7,
+		borderTopWidth: 1,
+		borderTopColor: "#E2E8F0",
+	},
+	absenceDateColumn: {
+		width: "24%",
+	},
+	absenceCategoryColumn: {
+		width: "58%",
+	},
+	absencePeriodColumn: {
+		width: "18%",
+		textAlign: "right" as const,
+	},
+	emptyState: {
+		padding: 8,
+		borderWidth: 1,
+		borderColor: "#CBD5E1",
+		backgroundColor: "#F8FAFC",
+		color: "#64748B",
+	},
 	footer: {
 		position: "absolute" as const,
 		left: 36,
@@ -179,10 +249,14 @@ function formatHours(hours: number): string {
 }
 
 function formatGeneratedAt(summary: PayrollWorkspaceSummary): string {
-	return DateTime.fromISO(summary.generatedAt, { zone: "utc" }).toFormat("yyyy-LL-dd HH:mm 'UTC'");
+	return DateTime.fromISO(summary.generatedAt, { zone: "utc" }).toFormat(
+		"yyyy-LL-dd HH:mm 'UTC'",
+	);
 }
 
-function formatContractType(contractType: PayrollEmployeeSummary["contractType"]): string {
+function formatContractType(
+	contractType: PayrollEmployeeSummary["contractType"],
+): string {
 	return contractType === "hourly" ? "Hourly" : "Fixed";
 }
 
@@ -196,10 +270,62 @@ function formatAbsences(employee: PayrollEmployeeSummary): string {
 		.join("; ");
 }
 
+function compareText(left: string, right: string): number {
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function formatAbsencePeriod(period: PayrollDayPeriod): string {
+	return period === "full_day" ? "Full day" : period.toUpperCase();
+}
+
+export function buildPayrollAbsenceSections(
+	summary: PayrollWorkspaceSummary,
+): PayrollAbsenceSection[] {
+	const detailsByEmployee = new Map<
+		string,
+		PayrollWorkspaceSummary["absenceDetails"]
+	>();
+
+	for (const detail of summary.absenceDetails) {
+		const details = detailsByEmployee.get(detail.employeeId) ?? [];
+		details.push(detail);
+		detailsByEmployee.set(detail.employeeId, details);
+	}
+
+	return summary.employees
+		.filter((employee) => detailsByEmployee.has(employee.id))
+		.sort(
+			(left, right) =>
+				compareText(left.name, right.name) || compareText(left.id, right.id),
+		)
+		.map((employee) => ({
+			employeeId: employee.id,
+			employeeName: employee.name,
+			employeeNumber: employee.employeeNumber,
+			rows: [...(detailsByEmployee.get(employee.id) ?? [])]
+				.sort(
+					(left, right) =>
+						compareText(left.date, right.date) ||
+						compareText(left.categoryName, right.categoryName) ||
+						compareText(left.categoryId, right.categoryId),
+				)
+				.map((detail) => ({
+					date: detail.date,
+					categoryName: detail.categoryName,
+					periodLabel: formatAbsencePeriod(detail.period),
+				})),
+		}));
+}
+
 export async function exportPayrollSummaryToPDF(
 	summary: PayrollWorkspaceSummary,
 ): Promise<Uint8Array> {
-	const { Document, Page, pdf, StyleSheet, Text, View } = await import("@react-pdf/renderer");
+	const absenceSections = buildPayrollAbsenceSections(summary);
+	const { Document, Page, pdf, StyleSheet, Text, View } = await import(
+		"@react-pdf/renderer"
+	);
 	const styles = StyleSheet.create(styleDefinitions);
 
 	const PayrollSummaryPDF = () => (
@@ -212,7 +338,8 @@ export async function exportPayrollSummaryToPDF(
 						<View style={styles.headerItem}>
 							<Text style={styles.label}>Period</Text>
 							<Text style={styles.value}>
-								{summary.period.label} ({summary.period.start} - {summary.period.end})
+								{summary.period.label} ({summary.period.start} -{" "}
+								{summary.period.end})
 							</Text>
 						</View>
 						<View style={styles.headerItem}>
@@ -233,15 +360,21 @@ export async function exportPayrollSummaryToPDF(
 				<View style={styles.metrics}>
 					<View style={styles.metricCard}>
 						<Text style={styles.label}>Employees</Text>
-						<Text style={styles.metricValue}>{summary.totals.employeeCount}</Text>
+						<Text style={styles.metricValue}>
+							{summary.totals.employeeCount}
+						</Text>
 					</View>
 					<View style={styles.metricCard}>
 						<Text style={styles.label}>Worked hours</Text>
-						<Text style={styles.metricValue}>{formatHours(summary.totals.totalWorkedHours)}</Text>
+						<Text style={styles.metricValue}>
+							{formatHours(summary.totals.totalWorkedHours)}
+						</Text>
 					</View>
 					<View style={[styles.metricCard, styles.metricCardLast]}>
 						<Text style={styles.label}>Blockers</Text>
-						<Text style={styles.metricValue}>{summary.totals.blockerCount}</Text>
+						<Text style={styles.metricValue}>
+							{summary.totals.blockerCount}
+						</Text>
 					</View>
 				</View>
 
@@ -263,29 +396,39 @@ export async function exportPayrollSummaryToPDF(
 						<Text style={[styles.cell, styles.teamCell]}>Team</Text>
 						<Text style={[styles.cell, styles.contractCell]}>Contract</Text>
 						<Text style={[styles.cell, styles.hoursCell]}>Hours</Text>
-						<Text style={[styles.cell, styles.absenceCell]}>Absence totals</Text>
+						<Text style={[styles.cell, styles.absenceCell]}>
+							Absence totals
+						</Text>
 						<Text style={[styles.cell, styles.statusCell]}>Status</Text>
 					</View>
 					{summary.employees.map((employee) => (
 						<View
 							key={employee.id}
 							style={
-								employee.hasBlockers ? [styles.tableRow, styles.tableRowBlocked] : styles.tableRow
+								employee.hasBlockers
+									? [styles.tableRow, styles.tableRowBlocked]
+									: styles.tableRow
 							}
 							wrap={false}
 						>
 							<View style={[styles.cell, styles.employeeCell]}>
 								<Text style={styles.employeeName}>{employee.name}</Text>
-								<Text style={styles.muted}>{employee.employeeNumber ?? "No employee no."}</Text>
+								<Text style={styles.muted}>
+									{employee.employeeNumber ?? "No employee no."}
+								</Text>
 							</View>
-							<Text style={[styles.cell, styles.teamCell]}>{employee.teamName ?? "No team"}</Text>
+							<Text style={[styles.cell, styles.teamCell]}>
+								{employee.teamName ?? "No team"}
+							</Text>
 							<Text style={[styles.cell, styles.contractCell]}>
 								{formatContractType(employee.contractType)}
 							</Text>
 							<Text style={[styles.cell, styles.hoursCell]}>
 								{formatHours(employee.workedHours)}
 							</Text>
-							<Text style={[styles.cell, styles.absenceCell]}>{formatAbsences(employee)}</Text>
+							<Text style={[styles.cell, styles.absenceCell]}>
+								{formatAbsences(employee)}
+							</Text>
 							<Text style={[styles.cell, styles.statusCell]}>
 								{employee.hasBlockers ? "Review" : "Clear"}
 							</Text>
@@ -293,9 +436,47 @@ export async function exportPayrollSummaryToPDF(
 					))}
 				</View>
 
+				<View style={styles.absenceDetailsSection}>
+					<Text style={styles.sectionTitle}>Absence details</Text>
+					{absenceSections.length === 0 ? (
+						<Text style={styles.emptyState}>
+							No approved absences for the selected period.
+						</Text>
+					) : (
+						absenceSections.map((section) => (
+							<View key={section.employeeId} style={styles.employeeCard}>
+								<Text style={styles.employeeCardHeader}>
+									{section.employeeName} (
+									{section.employeeNumber ?? "No employee no."})
+								</Text>
+								<View style={styles.absenceDetailHeader}>
+									<Text style={styles.absenceDateColumn}>Date</Text>
+									<Text style={styles.absenceCategoryColumn}>Category</Text>
+									<Text style={styles.absencePeriodColumn}>Period</Text>
+								</View>
+								{section.rows.map((row) => (
+									<View
+										key={`${row.date}-${row.categoryName}-${row.periodLabel}`}
+										style={styles.absenceDetailRow}
+									>
+										<Text style={styles.absenceDateColumn}>{row.date}</Text>
+										<Text style={styles.absenceCategoryColumn}>
+											{row.categoryName}
+										</Text>
+										<Text style={styles.absencePeriodColumn}>
+											{row.periodLabel}
+										</Text>
+									</View>
+								))}
+							</View>
+						))
+					)}
+				</View>
+
 				<Text style={styles.footer}>
-					Audit note: Blockers are informational review markers and did not prevent this export.
-					Confirm unresolved items before payroll submission.
+					Audit note: Blockers are informational review markers and did not
+					prevent this export. Confirm unresolved items before payroll
+					submission.
 				</Text>
 			</Page>
 		</Document>
@@ -305,7 +486,9 @@ export async function exportPayrollSummaryToPDF(
 	return new Uint8Array(await blob.arrayBuffer());
 }
 
-export function generatePayrollPDFFilename(summary: PayrollWorkspaceSummary): string {
+export function generatePayrollPDFFilename(
+	summary: PayrollWorkspaceSummary,
+): string {
 	const organizationSlug =
 		summary.organizationName
 			.toLowerCase()

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
@@ -16,8 +16,6 @@ export interface PayrollAbsenceSection {
 	}>;
 }
 
-const PAYROLL_ABSENCE_ROWS_PER_CHUNK = 18;
-
 const styleDefinitions = {
 	page: {
 		paddingTop: 34,
@@ -180,20 +178,31 @@ const styleDefinitions = {
 	absenceDetailsSection: {
 		marginTop: 14,
 	},
-	employeeCard: {
-		marginBottom: 8,
-		borderWidth: 1,
-		borderColor: "#CBD5E1",
+	absencePage: {
+		paddingTop: 104,
+		paddingBottom: 60,
 	},
-	employeeCardHeader: {
-		paddingTop: 5,
-		paddingRight: 7,
-		paddingBottom: 5,
-		paddingLeft: 7,
+	absenceReportHeader: {
+		position: "absolute" as const,
+		top: 28,
+		left: 36,
+		right: 36,
+		paddingBottom: 7,
+		backgroundColor: "#FFFFFF",
+		borderBottomWidth: 1,
+		borderBottomColor: "#CBD5E1",
+	},
+	absenceReportTitle: {
+		fontSize: 11,
+		fontWeight: "bold" as const,
+		color: "#0F172A",
+		marginBottom: 3,
+	},
+	absenceEmployeeName: {
 		fontSize: 9,
 		fontWeight: "bold" as const,
 		color: "#0F172A",
-		backgroundColor: "#F1F5F9",
+		marginBottom: 5,
 	},
 	absenceDetailHeader: {
 		flexDirection: "row" as const,
@@ -298,10 +307,7 @@ export function buildPayrollAbsenceSections(
 
 	return summary.employees
 		.filter((employee) => detailsByEmployee.has(employee.id))
-		.sort(
-			(left, right) =>
-				left.name.localeCompare(right.name) || left.id.localeCompare(right.id),
-		)
+		.sort((left, right) => left.name.localeCompare(right.name))
 		.map((employee) => ({
 			employeeId: employee.id,
 			employeeName: employee.name,
@@ -322,30 +328,10 @@ export function buildPayrollAbsenceSections(
 		}));
 }
 
-export function chunkPayrollAbsenceSections(
-	sections: PayrollAbsenceSection[],
-): PayrollAbsenceSection[] {
-	return sections.flatMap((section) =>
-		Array.from(
-			{
-				length: Math.ceil(section.rows.length / PAYROLL_ABSENCE_ROWS_PER_CHUNK),
-			},
-			(_, chunkIndex) => ({
-				...section,
-				rows: section.rows.slice(
-					chunkIndex * PAYROLL_ABSENCE_ROWS_PER_CHUNK,
-					(chunkIndex + 1) * PAYROLL_ABSENCE_ROWS_PER_CHUNK,
-				),
-			}),
-		),
-	);
-}
-
 export async function exportPayrollSummaryToPDF(
 	summary: PayrollWorkspaceSummary,
 ): Promise<Uint8Array> {
 	const absenceSections = buildPayrollAbsenceSections(summary);
-	const absenceSectionChunks = chunkPayrollAbsenceSections(absenceSections);
 	const { Document, Page, pdf, StyleSheet, Text, View } = await import(
 		"@react-pdf/renderer"
 	);
@@ -459,48 +445,14 @@ export async function exportPayrollSummaryToPDF(
 					))}
 				</View>
 
-				<View style={styles.absenceDetailsSection}>
-					<Text style={styles.sectionTitle}>Absence details</Text>
-					{absenceSections.length === 0 ? (
+				{absenceSections.length === 0 && (
+					<View style={styles.absenceDetailsSection}>
+						<Text style={styles.sectionTitle}>Absence details</Text>
 						<Text style={styles.emptyState}>
 							No approved absences for the selected period.
 						</Text>
-					) : (
-						absenceSectionChunks.map((section, sectionIndex) => (
-							<View
-								// biome-ignore lint/suspicious/noArrayIndexKey: Chunk order is immutable for this one-shot PDF render.
-								key={`${section.employeeId}-${sectionIndex}`}
-								style={styles.employeeCard}
-								wrap={false}
-							>
-								<Text style={styles.employeeCardHeader}>
-									{section.employeeName} (
-									{section.employeeNumber ?? "No employee no."})
-								</Text>
-								<View style={styles.absenceDetailHeader}>
-									<Text style={styles.absenceDateColumn}>Date</Text>
-									<Text style={styles.absenceCategoryColumn}>Category</Text>
-									<Text style={styles.absencePeriodColumn}>Period</Text>
-								</View>
-								{section.rows.map((row, rowIndex) => (
-									<View
-										// biome-ignore lint/suspicious/noArrayIndexKey: Sorted PDF rows are immutable and duplicate details must remain distinct.
-										key={`${row.date}-${row.categoryName}-${row.periodLabel}-${rowIndex}`}
-										style={styles.absenceDetailRow}
-									>
-										<Text style={styles.absenceDateColumn}>{row.date}</Text>
-										<Text style={styles.absenceCategoryColumn}>
-											{row.categoryName}
-										</Text>
-										<Text style={styles.absencePeriodColumn}>
-											{row.periodLabel}
-										</Text>
-									</View>
-								))}
-							</View>
-						))
-					)}
-				</View>
+					</View>
+				)}
 
 				<Text style={styles.footer}>
 					Audit note: Blockers are informational review markers and did not
@@ -508,6 +460,44 @@ export async function exportPayrollSummaryToPDF(
 					submission.
 				</Text>
 			</Page>
+			{absenceSections.map((section) => (
+				<Page
+					key={section.employeeId}
+					size="A4"
+					style={[styles.page, styles.absencePage]}
+				>
+					<View fixed style={styles.absenceReportHeader}>
+						<Text style={styles.absenceReportTitle}>Absence details</Text>
+						<Text style={styles.absenceEmployeeName}>
+							{section.employeeName} (
+							{section.employeeNumber ?? "No employee no."})
+						</Text>
+						<View style={styles.absenceDetailHeader}>
+							<Text style={styles.absenceDateColumn}>Date</Text>
+							<Text style={styles.absenceCategoryColumn}>Category</Text>
+							<Text style={styles.absencePeriodColumn}>Period</Text>
+						</View>
+					</View>
+					{section.rows.map((row, rowIndex) => (
+						<View
+							// biome-ignore lint/suspicious/noArrayIndexKey: Sorted PDF rows are immutable and duplicate details must remain distinct.
+							key={`${row.date}-${row.categoryName}-${row.periodLabel}-${rowIndex}`}
+							style={styles.absenceDetailRow}
+						>
+							<Text style={styles.absenceDateColumn}>{row.date}</Text>
+							<Text style={styles.absenceCategoryColumn}>
+								{row.categoryName}
+							</Text>
+							<Text style={styles.absencePeriodColumn}>{row.periodLabel}</Text>
+						</View>
+					))}
+					<Text fixed style={styles.footer}>
+						Audit note: Blockers are informational review markers and did not
+						prevent this export. Confirm unresolved items before payroll
+						submission.
+					</Text>
+				</Page>
+			))}
 		</Document>
 	);
 

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
@@ -16,6 +16,14 @@ export interface PayrollAbsenceSection {
 	}>;
 }
 
+export interface PayrollAbsenceReportRow {
+	employeeName: string;
+	employeeNumber: string;
+	date: string;
+	categoryName: string;
+	periodLabel: string;
+}
+
 const styleDefinitions = {
 	page: {
 		paddingTop: 34,
@@ -179,7 +187,7 @@ const styleDefinitions = {
 		marginTop: 14,
 	},
 	absencePage: {
-		paddingTop: 104,
+		paddingTop: 82,
 		paddingBottom: 60,
 	},
 	absenceReportHeader: {
@@ -194,12 +202,6 @@ const styleDefinitions = {
 	},
 	absenceReportTitle: {
 		fontSize: 11,
-		fontWeight: "bold" as const,
-		color: "#0F172A",
-		marginBottom: 3,
-	},
-	absenceEmployeeName: {
-		fontSize: 9,
 		fontWeight: "bold" as const,
 		color: "#0F172A",
 		marginBottom: 5,
@@ -225,13 +227,16 @@ const styleDefinitions = {
 		borderTopColor: "#E2E8F0",
 	},
 	absenceDateColumn: {
-		width: "24%",
+		width: "18%",
+	},
+	absenceEmployeeColumn: {
+		width: "28%",
 	},
 	absenceCategoryColumn: {
-		width: "58%",
+		width: "39%",
 	},
 	absencePeriodColumn: {
-		width: "18%",
+		width: "15%",
 		textAlign: "right" as const,
 	},
 	emptyState: {
@@ -328,10 +333,23 @@ export function buildPayrollAbsenceSections(
 		}));
 }
 
+export function flattenPayrollAbsenceSections(
+	sections: PayrollAbsenceSection[],
+): PayrollAbsenceReportRow[] {
+	return sections.flatMap((section) =>
+		section.rows.map((row) => ({
+			employeeName: section.employeeName,
+			employeeNumber: section.employeeNumber ?? "No employee no.",
+			...row,
+		})),
+	);
+}
+
 export async function exportPayrollSummaryToPDF(
 	summary: PayrollWorkspaceSummary,
 ): Promise<Uint8Array> {
 	const absenceSections = buildPayrollAbsenceSections(summary);
+	const absenceReportRows = flattenPayrollAbsenceSections(absenceSections);
 	const { Document, Page, pdf, StyleSheet, Text, View } = await import(
 		"@react-pdf/renderer"
 	);
@@ -460,30 +478,27 @@ export async function exportPayrollSummaryToPDF(
 					submission.
 				</Text>
 			</Page>
-			{absenceSections.map((section) => (
-				<Page
-					key={section.employeeId}
-					size="A4"
-					style={[styles.page, styles.absencePage]}
-				>
+			{absenceReportRows.length > 0 && (
+				<Page size="A4" style={[styles.page, styles.absencePage]}>
 					<View fixed style={styles.absenceReportHeader}>
 						<Text style={styles.absenceReportTitle}>Absence details</Text>
-						<Text style={styles.absenceEmployeeName}>
-							{section.employeeName} (
-							{section.employeeNumber ?? "No employee no."})
-						</Text>
 						<View style={styles.absenceDetailHeader}>
+							<Text style={styles.absenceEmployeeColumn}>Employee</Text>
 							<Text style={styles.absenceDateColumn}>Date</Text>
 							<Text style={styles.absenceCategoryColumn}>Category</Text>
 							<Text style={styles.absencePeriodColumn}>Period</Text>
 						</View>
 					</View>
-					{section.rows.map((row, rowIndex) => (
+					{absenceReportRows.map((row, rowIndex) => (
 						<View
 							// biome-ignore lint/suspicious/noArrayIndexKey: Sorted PDF rows are immutable and duplicate details must remain distinct.
-							key={`${row.date}-${row.categoryName}-${row.periodLabel}-${rowIndex}`}
+							key={`${row.employeeName}-${row.date}-${row.categoryName}-${row.periodLabel}-${rowIndex}`}
 							style={styles.absenceDetailRow}
 						>
+							<View style={styles.absenceEmployeeColumn}>
+								<Text style={styles.employeeName}>{row.employeeName}</Text>
+								<Text style={styles.muted}>{row.employeeNumber}</Text>
+							</View>
 							<Text style={styles.absenceDateColumn}>{row.date}</Text>
 							<Text style={styles.absenceCategoryColumn}>
 								{row.categoryName}
@@ -497,7 +512,7 @@ export async function exportPayrollSummaryToPDF(
 						submission.
 					</Text>
 				</Page>
-			))}
+			)}
 		</Document>
 	);
 

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import type {
-	PayrollDayPeriod,
+	PayrollAbsenceDetailPeriod,
 	PayrollEmployeeSummary,
 	PayrollWorkspaceSummary,
 } from "./types";
@@ -292,8 +292,17 @@ function compareText(left: string, right: string): number {
 	return 0;
 }
 
-function formatAbsencePeriod(period: PayrollDayPeriod): string {
-	return period === "full_day" ? "Full day" : period.toUpperCase();
+function formatAbsencePeriod(period: PayrollAbsenceDetailPeriod): string {
+	if (period === "full_day") return "Full day";
+	if (period === "partial_day") return "Partial day";
+	return period.toUpperCase();
+}
+
+function compareEmployees(
+	left: PayrollEmployeeSummary,
+	right: PayrollEmployeeSummary,
+): number {
+	return left.name.localeCompare(right.name) || compareText(left.id, right.id);
 }
 
 export function buildPayrollAbsenceSections(
@@ -312,7 +321,7 @@ export function buildPayrollAbsenceSections(
 
 	return summary.employees
 		.filter((employee) => detailsByEmployee.has(employee.id))
-		.sort((left, right) => left.name.localeCompare(right.name))
+		.sort(compareEmployees)
 		.map((employee) => ({
 			employeeId: employee.id,
 			employeeName: employee.name,
@@ -322,8 +331,11 @@ export function buildPayrollAbsenceSections(
 					(left, right) =>
 						compareText(left.date, right.date) ||
 						compareText(left.categoryName, right.categoryName) ||
-						compareText(left.categoryId, right.categoryId) ||
-						compareText(left.period, right.period),
+						compareText(
+							formatAbsencePeriod(left.period),
+							formatAbsencePeriod(right.period),
+						) ||
+						compareText(left.categoryId, right.categoryId),
 				)
 				.map((detail) => ({
 					date: detail.date,
@@ -350,6 +362,7 @@ export async function exportPayrollSummaryToPDF(
 ): Promise<Uint8Array> {
 	const absenceSections = buildPayrollAbsenceSections(summary);
 	const absenceReportRows = flattenPayrollAbsenceSections(absenceSections);
+	const sortedEmployees = [...summary.employees].sort(compareEmployees);
 	const { Document, Page, pdf, StyleSheet, Text, View } = await import(
 		"@react-pdf/renderer"
 	);
@@ -428,7 +441,7 @@ export async function exportPayrollSummaryToPDF(
 						</Text>
 						<Text style={[styles.cell, styles.statusCell]}>Status</Text>
 					</View>
-					{summary.employees.map((employee) => (
+					{sortedEmployees.map((employee) => (
 						<View
 							key={employee.id}
 							style={

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx
@@ -16,6 +16,8 @@ export interface PayrollAbsenceSection {
 	}>;
 }
 
+const PAYROLL_ABSENCE_ROWS_PER_CHUNK = 18;
+
 const styleDefinitions = {
 	page: {
 		paddingTop: 34,
@@ -298,7 +300,7 @@ export function buildPayrollAbsenceSections(
 		.filter((employee) => detailsByEmployee.has(employee.id))
 		.sort(
 			(left, right) =>
-				compareText(left.name, right.name) || compareText(left.id, right.id),
+				left.name.localeCompare(right.name) || left.id.localeCompare(right.id),
 		)
 		.map((employee) => ({
 			employeeId: employee.id,
@@ -309,7 +311,8 @@ export function buildPayrollAbsenceSections(
 					(left, right) =>
 						compareText(left.date, right.date) ||
 						compareText(left.categoryName, right.categoryName) ||
-						compareText(left.categoryId, right.categoryId),
+						compareText(left.categoryId, right.categoryId) ||
+						compareText(left.period, right.period),
 				)
 				.map((detail) => ({
 					date: detail.date,
@@ -319,10 +322,30 @@ export function buildPayrollAbsenceSections(
 		}));
 }
 
+export function chunkPayrollAbsenceSections(
+	sections: PayrollAbsenceSection[],
+): PayrollAbsenceSection[] {
+	return sections.flatMap((section) =>
+		Array.from(
+			{
+				length: Math.ceil(section.rows.length / PAYROLL_ABSENCE_ROWS_PER_CHUNK),
+			},
+			(_, chunkIndex) => ({
+				...section,
+				rows: section.rows.slice(
+					chunkIndex * PAYROLL_ABSENCE_ROWS_PER_CHUNK,
+					(chunkIndex + 1) * PAYROLL_ABSENCE_ROWS_PER_CHUNK,
+				),
+			}),
+		),
+	);
+}
+
 export async function exportPayrollSummaryToPDF(
 	summary: PayrollWorkspaceSummary,
 ): Promise<Uint8Array> {
 	const absenceSections = buildPayrollAbsenceSections(summary);
+	const absenceSectionChunks = chunkPayrollAbsenceSections(absenceSections);
 	const { Document, Page, pdf, StyleSheet, Text, View } = await import(
 		"@react-pdf/renderer"
 	);
@@ -443,8 +466,13 @@ export async function exportPayrollSummaryToPDF(
 							No approved absences for the selected period.
 						</Text>
 					) : (
-						absenceSections.map((section) => (
-							<View key={section.employeeId} style={styles.employeeCard}>
+						absenceSectionChunks.map((section, sectionIndex) => (
+							<View
+								// biome-ignore lint/suspicious/noArrayIndexKey: Chunk order is immutable for this one-shot PDF render.
+								key={`${section.employeeId}-${sectionIndex}`}
+								style={styles.employeeCard}
+								wrap={false}
+							>
 								<Text style={styles.employeeCardHeader}>
 									{section.employeeName} (
 									{section.employeeNumber ?? "No employee no."})
@@ -454,9 +482,10 @@ export async function exportPayrollSummaryToPDF(
 									<Text style={styles.absenceCategoryColumn}>Category</Text>
 									<Text style={styles.absencePeriodColumn}>Period</Text>
 								</View>
-								{section.rows.map((row) => (
+								{section.rows.map((row, rowIndex) => (
 									<View
-										key={`${row.date}-${row.categoryName}-${row.periodLabel}`}
+										// biome-ignore lint/suspicious/noArrayIndexKey: Sorted PDF rows are immutable and duplicate details must remain distinct.
+										key={`${row.date}-${row.categoryName}-${row.periodLabel}-${rowIndex}`}
 										style={styles.absenceDetailRow}
 									>
 										<Text style={styles.absenceDateColumn}>{row.date}</Text>

--- a/apps/webapp/src/lib/payroll-workspace/summary.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.test.ts
@@ -199,6 +199,17 @@ describe("buildPayrollSummaryFromRows", () => {
 					startTime: "10:00:00",
 					endTime: "14:00:00",
 				},
+				{
+					employeeId: "employee-1",
+					categoryId: "overnight",
+					categoryName: "Overnight",
+					startDate: "2026-06-13",
+					endDate: "2026-06-14",
+					startPeriod: "am",
+					endPeriod: "am",
+					startTime: "22:00:00",
+					endTime: "02:00:00",
+				},
 			],
 			blockers: [],
 		});
@@ -207,6 +218,7 @@ describe("buildPayrollSummaryFromRows", () => {
 			{ categoryId: "afternoon", categoryName: "Afternoon", days: 0.5 },
 			{ categoryId: "cross-noon", categoryName: "Cross noon", days: 0.5 },
 			{ categoryId: "morning", categoryName: "Morning", days: 0.5 },
+			{ categoryId: "overnight", categoryName: "Overnight", days: 0.5 },
 		]);
 		expect(
 			summary.absenceDetails.map(({ date, period }) => ({ date, period })),
@@ -214,6 +226,7 @@ describe("buildPayrollSummaryFromRows", () => {
 			{ date: "2026-06-10", period: "pm" },
 			{ date: "2026-06-11", period: "am" },
 			{ date: "2026-06-12", period: "partial_day" },
+			{ date: "2026-06-13", period: "partial_day" },
 		]);
 	});
 

--- a/apps/webapp/src/lib/payroll-workspace/summary.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.test.ts
@@ -149,6 +149,107 @@ describe("buildPayrollSummaryFromRows", () => {
 		]);
 	});
 
+	it("classifies timed partial absences and counts each as half a day", () => {
+		const summary = buildPayrollSummaryFromRows({
+			organizationName: "Acme GmbH",
+			period: { start: "2026-06-01", end: "2026-06-30", label: "June 2026" },
+			generatedAt: DateTime.fromISO("2026-06-30T12:00:00Z"),
+			generatedBy: { id: "payroll-1", name: "Payroll User" },
+			employees: [
+				{
+					id: "employee-1",
+					name: "Ada Lovelace",
+					employeeNumber: "E-1",
+					teamName: "Ops",
+					contractType: "fixed",
+				},
+			],
+			workRows: [],
+			absenceRows: [
+				{
+					employeeId: "employee-1",
+					categoryId: "afternoon",
+					categoryName: "Afternoon",
+					startDate: "2026-06-10",
+					endDate: "2026-06-10",
+					startPeriod: "am",
+					endPeriod: "am",
+					startTime: "14:00:00",
+					endTime: "17:00:00",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "morning",
+					categoryName: "Morning",
+					startDate: "2026-06-11",
+					endDate: "2026-06-11",
+					startPeriod: "am",
+					endPeriod: "am",
+					startTime: "09:00:00",
+					endTime: "11:00:00",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "cross-noon",
+					categoryName: "Cross noon",
+					startDate: "2026-06-12",
+					endDate: "2026-06-12",
+					startPeriod: "am",
+					endPeriod: "am",
+					startTime: "10:00:00",
+					endTime: "14:00:00",
+				},
+			],
+			blockers: [],
+		});
+
+		expect(summary.employees[0]?.absenceDaysByCategory).toEqual([
+			{ categoryId: "afternoon", categoryName: "Afternoon", days: 0.5 },
+			{ categoryId: "cross-noon", categoryName: "Cross noon", days: 0.5 },
+			{ categoryId: "morning", categoryName: "Morning", days: 0.5 },
+		]);
+		expect(
+			summary.absenceDetails.map(({ date, period }) => ({ date, period })),
+		).toEqual([
+			{ date: "2026-06-10", period: "pm" },
+			{ date: "2026-06-11", period: "am" },
+			{ date: "2026-06-12", period: "partial_day" },
+		]);
+	});
+
+	it("sorts employees with identical names by id", () => {
+		const summary = buildPayrollSummaryFromRows({
+			organizationName: "Acme GmbH",
+			period: { start: "2026-06-01", end: "2026-06-30", label: "June 2026" },
+			generatedAt: DateTime.fromISO("2026-06-30T12:00:00Z"),
+			generatedBy: { id: "payroll-1", name: "Payroll User" },
+			employees: [
+				{
+					id: "employee-2",
+					name: "Alex Smith",
+					employeeNumber: null,
+					teamName: null,
+					contractType: "fixed",
+				},
+				{
+					id: "employee-1",
+					name: "Alex Smith",
+					employeeNumber: null,
+					teamName: null,
+					contractType: "fixed",
+				},
+			],
+			workRows: [],
+			absenceRows: [],
+			blockers: [],
+		});
+
+		expect(summary.employees.map((employee) => employee.id)).toEqual([
+			"employee-1",
+			"employee-2",
+		]);
+	});
+
 	it("keeps blockers as warnings and marks affected employees", () => {
 		const summary = buildPayrollSummaryFromRows({
 			organizationName: "Acme GmbH",

--- a/apps/webapp/src/lib/payroll-workspace/summary.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.test.ts
@@ -105,6 +105,50 @@ describe("buildPayrollSummaryFromRows", () => {
 		]);
 	});
 
+	it("includes a same-day half-day absence in details and category totals", () => {
+		const summary = buildPayrollSummaryFromRows({
+			organizationName: "Acme GmbH",
+			period: { start: "2026-06-01", end: "2026-06-30", label: "June 2026" },
+			generatedAt: DateTime.fromISO("2026-06-30T12:00:00Z"),
+			generatedBy: { id: "payroll-1", name: "Payroll User" },
+			employees: [
+				{
+					id: "employee-1",
+					name: "Ada Lovelace",
+					employeeNumber: "E-1",
+					teamName: "Ops",
+					contractType: "fixed",
+				},
+			],
+			workRows: [],
+			absenceRows: [
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-10",
+					startPeriod: "am",
+					endPeriod: "am",
+				},
+			],
+			blockers: [],
+		});
+
+		expect(summary.employees[0]?.absenceDaysByCategory).toEqual([
+			{ categoryId: "vacation", categoryName: "Vacation", days: 0.5 },
+		]);
+		expect(summary.absenceDetails).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: "am",
+			},
+		]);
+	});
+
 	it("keeps blockers as warnings and marks affected employees", () => {
 		const summary = buildPayrollSummaryFromRows({
 			organizationName: "Acme GmbH",

--- a/apps/webapp/src/lib/payroll-workspace/summary.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.test.ts
@@ -2,7 +2,6 @@ import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
 import {
 	buildPayrollSummaryFromRows,
-	calculatePayrollAbsenceDays,
 	calculatePayrollWorkedMinutes,
 	filterMissingClockOutBlockers,
 	filterPendingTimeApprovalBlockers,
@@ -35,6 +34,7 @@ describe("buildPayrollSummaryFromRows", () => {
 		expect(summary.totals.totalWorkedHours).toBe(2.75);
 		expect(summary.employees[0]?.workedHours).toBe(2.75);
 		expect(summary.generatedAt).toBe("2026-06-30T12:00:00.000Z");
+		expect(summary.absenceDetails).toEqual([]);
 	});
 
 	it("groups absence days by employee and category", () => {
@@ -54,8 +54,24 @@ describe("buildPayrollSummaryFromRows", () => {
 			],
 			workRows: [],
 			absenceRows: [
-				{ employeeId: "employee-1", categoryId: "vacation", categoryName: "Vacation", days: 2 },
-				{ employeeId: "employee-1", categoryId: "sick", categoryName: "Sick", days: 1 },
+				{
+					employeeId: "employee-1",
+					categoryId: "sick",
+					categoryName: "Sick",
+					startDate: "2026-06-12",
+					endDate: "2026-06-12",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-11",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
 			],
 			blockers: [],
 		});
@@ -63,6 +79,29 @@ describe("buildPayrollSummaryFromRows", () => {
 		expect(summary.employees[0]?.absenceDaysByCategory).toEqual([
 			{ categoryId: "sick", categoryName: "Sick", days: 1 },
 			{ categoryId: "vacation", categoryName: "Vacation", days: 2 },
+		]);
+		expect(summary.absenceDetails).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-11",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "sick",
+				categoryName: "Sick",
+				date: "2026-06-12",
+				period: "full_day",
+			},
 		]);
 	});
 
@@ -95,6 +134,7 @@ describe("buildPayrollSummaryFromRows", () => {
 
 		expect(summary.totals.blockerCount).toBe(1);
 		expect(summary.employees[0]?.hasBlockers).toBe(true);
+		expect(summary.absenceDetails).toEqual([]);
 	});
 });
 
@@ -145,53 +185,6 @@ describe("calculatePayrollWorkedMinutes", () => {
 				period,
 			).get("employee-1"),
 		).toBeUndefined();
-	});
-});
-
-describe("calculatePayrollAbsenceDays", () => {
-	it("counts full-day same-day absences as one day", () => {
-		expect(
-			calculatePayrollAbsenceDays({
-				startAt: DateTime.fromISO("2026-06-10T00:00:00Z"),
-				endAt: DateTime.fromISO("2026-06-10T23:59:59Z"),
-				startPeriod: "full_day",
-				endPeriod: "full_day",
-				period: {
-					start: DateTime.fromISO("2026-06-01T00:00:00Z"),
-					end: DateTime.fromISO("2026-06-30T23:59:59Z"),
-				},
-			}),
-		).toBe(1);
-	});
-
-	it("counts same-day half-day absences as half a day", () => {
-		expect(
-			calculatePayrollAbsenceDays({
-				startAt: DateTime.fromISO("2026-06-10T00:00:00Z"),
-				endAt: DateTime.fromISO("2026-06-10T11:59:59Z"),
-				startPeriod: "am",
-				endPeriod: "am",
-				period: {
-					start: DateTime.fromISO("2026-06-01T00:00:00Z"),
-					end: DateTime.fromISO("2026-06-30T23:59:59Z"),
-				},
-			}),
-		).toBe(0.5);
-	});
-
-	it("clips multi-day absences to the selected payroll period", () => {
-		expect(
-			calculatePayrollAbsenceDays({
-				startAt: DateTime.fromISO("2026-05-30T00:00:00Z"),
-				endAt: DateTime.fromISO("2026-06-02T23:59:59Z"),
-				startPeriod: "full_day",
-				endPeriod: "full_day",
-				period: {
-					start: DateTime.fromISO("2026-06-01T00:00:00Z"),
-					end: DateTime.fromISO("2026-06-30T23:59:59Z"),
-				},
-			}),
-		).toBe(2);
 	});
 });
 

--- a/apps/webapp/src/lib/payroll-workspace/summary.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.ts
@@ -85,7 +85,7 @@ export function buildPayrollSummaryFromRows(input: {
 				hasBlockers: employeesWithBlockers.has(employeeRow.id),
 			};
 		})
-		.sort((a, b) => a.name.localeCompare(b.name));
+		.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
 
 	return {
 		organizationName: input.organizationName,
@@ -343,6 +343,8 @@ async function getAbsenceRows(
 		endDate: (row.endAt ?? row.startAt).toISOString().slice(0, 10),
 		startPeriod: row.startPeriod,
 		endPeriod: row.endPeriod,
+		startTime: row.startAt.toISOString().slice(11, 19),
+		endTime: (row.endAt ?? row.startAt).toISOString().slice(11, 19),
 	}));
 }
 

--- a/apps/webapp/src/lib/payroll-workspace/summary.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.ts
@@ -9,9 +9,9 @@ import {
 	timeRecord,
 	timeRecordAbsence,
 } from "@/db/schema";
+import { buildPayrollAbsenceDetails, payrollAbsenceDetailDays } from "./absence-details";
 import type {
 	PayrollBlocker,
-	PayrollDayPeriod,
 	PayrollPeriod,
 	PayrollSummaryAbsenceRow,
 	PayrollSummaryEmployeeSource,
@@ -53,31 +53,21 @@ export function buildPayrollSummaryFromRows(input: {
 }): PayrollWorkspaceSummary {
 	const summaryPeriod = parsePayrollPeriod(input.period);
 	const workedMinutesByEmployee = calculatePayrollWorkedMinutes(input.workRows, summaryPeriod);
+	const absenceDetails = buildPayrollAbsenceDetails(input.absenceRows, input.period);
 
 	const absenceDaysByEmployee = new Map<
 		string,
 		Map<string, { categoryId: string; categoryName: string; days: number }>
 	>();
-	for (const row of input.absenceRows) {
-		const employeeAbsences = absenceDaysByEmployee.get(row.employeeId) ?? new Map();
-		const existing = employeeAbsences.get(row.categoryId);
-		const days =
-			row.days ??
-			(row.startAt && row.startPeriod && row.endPeriod
-				? calculatePayrollAbsenceDays({
-						startAt: row.startAt,
-						endAt: row.endAt ?? null,
-						startPeriod: row.startPeriod,
-						endPeriod: row.endPeriod,
-						period: summaryPeriod,
-					})
-				: 0);
-		employeeAbsences.set(row.categoryId, {
-			categoryId: row.categoryId,
-			categoryName: row.categoryName,
-			days: (existing?.days ?? 0) + days,
+	for (const detail of absenceDetails) {
+		const employeeAbsences = absenceDaysByEmployee.get(detail.employeeId) ?? new Map();
+		const existing = employeeAbsences.get(detail.categoryId);
+		employeeAbsences.set(detail.categoryId, {
+			categoryId: detail.categoryId,
+			categoryName: detail.categoryName,
+			days: (existing?.days ?? 0) + payrollAbsenceDetailDays(detail.period),
 		});
-		absenceDaysByEmployee.set(row.employeeId, employeeAbsences);
+		absenceDaysByEmployee.set(detail.employeeId, employeeAbsences);
 	}
 
 	const employeesWithBlockers = new Set(input.blockers.map((blocker) => blocker.employeeId));
@@ -110,6 +100,7 @@ export function buildPayrollSummaryFromRows(input: {
 			blockerCount: input.blockers.length,
 		},
 		employees,
+		absenceDetails,
 		blockers: input.blockers,
 	};
 }
@@ -135,39 +126,6 @@ export function calculatePayrollWorkedMinutes(
 	}
 
 	return workedMinutesByEmployee;
-}
-
-export function calculatePayrollAbsenceDays(input: {
-	startAt: DateTime;
-	endAt: DateTime | null;
-	startPeriod: PayrollDayPeriod;
-	endPeriod: PayrollDayPeriod;
-	period: PayrollDateTimePeriod;
-}): number {
-	const recordStartDate = input.startAt.toUTC().startOf("day");
-	const recordEndDate = (input.endAt ?? input.startAt).toUTC().startOf("day");
-	if (recordEndDate < recordStartDate) return 0;
-
-	let days = 0;
-	let day = recordStartDate;
-	while (day <= recordEndDate) {
-		for (const slot of getAbsenceSlotsForDay(
-			day,
-			recordStartDate,
-			recordEndDate,
-			input.startPeriod,
-			input.endPeriod,
-		)) {
-			if (
-				intervalsOverlap(slot.start, slot.end, input.period.start.toUTC(), input.period.end.toUTC())
-			) {
-				days += 0.5;
-			}
-		}
-		day = day.plus({ days: 1 });
-	}
-
-	return roundDays(days);
 }
 
 export function filterPendingTimeApprovalBlockers(input: {
@@ -381,8 +339,8 @@ async function getAbsenceRows(
 		employeeId: row.employeeId,
 		categoryId: row.categoryId,
 		categoryName: row.categoryName,
-		startAt: DateTime.fromJSDate(row.startAt, { zone: "utc" }),
-		endAt: row.endAt ? DateTime.fromJSDate(row.endAt, { zone: "utc" }) : null,
+		startDate: row.startAt.toISOString().slice(0, 10),
+		endDate: (row.endAt ?? row.startAt).toISOString().slice(0, 10),
 		startPeriod: row.startPeriod,
 		endPeriod: row.endPeriod,
 	}));
@@ -544,35 +502,6 @@ function intervalsOverlap(
 	periodEnd: DateTime,
 ): boolean {
 	return startAt.toUTC() <= periodEnd.toUTC() && endAt.toUTC() >= periodStart.toUTC();
-}
-
-function getAbsenceSlotsForDay(
-	day: DateTime,
-	recordStartDate: DateTime,
-	recordEndDate: DateTime,
-	startPeriod: PayrollDayPeriod,
-	endPeriod: PayrollDayPeriod,
-): Array<{ start: DateTime; end: DateTime }> {
-	const slots = [
-		{
-			period: "am" as const,
-			start: day.startOf("day"),
-			end: day.startOf("day").plus({ hours: 12 }),
-		},
-		{ period: "pm" as const, start: day.startOf("day").plus({ hours: 12 }), end: day.endOf("day") },
-	];
-	const startSlot = day.hasSame(recordStartDate, "day") ? firstAbsenceSlot(startPeriod) : "am";
-	const endSlot = day.hasSame(recordEndDate, "day") ? lastAbsenceSlot(endPeriod) : "pm";
-
-	return slots.filter((slot) => slot.period >= startSlot && slot.period <= endSlot);
-}
-
-function firstAbsenceSlot(period: PayrollDayPeriod): "am" | "pm" {
-	return period === "pm" ? "pm" : "am";
-}
-
-function lastAbsenceSlot(period: PayrollDayPeriod): "am" | "pm" {
-	return period === "am" ? "am" : "pm";
 }
 
 function roundHours(hours: number): number {

--- a/apps/webapp/src/lib/payroll-workspace/types.ts
+++ b/apps/webapp/src/lib/payroll-workspace/types.ts
@@ -29,6 +29,17 @@ export interface PayrollSummaryAbsenceRow {
 	employeeId: string;
 	categoryId: string;
 	categoryName: string;
+	days?: number;
+	startAt?: DateTime;
+	endAt?: DateTime | null;
+	startPeriod?: PayrollDayPeriod;
+	endPeriod?: PayrollDayPeriod;
+}
+
+export interface PayrollSummaryAbsenceRangeRow {
+	employeeId: string;
+	categoryId: string;
+	categoryName: string;
 	startDate: string;
 	endDate: string;
 	startPeriod: PayrollDayPeriod;
@@ -78,6 +89,5 @@ export interface PayrollWorkspaceSummary {
 		blockerCount: number;
 	};
 	employees: PayrollEmployeeSummary[];
-	absenceDetails: PayrollAbsenceDetail[];
 	blockers: PayrollBlocker[];
 }

--- a/apps/webapp/src/lib/payroll-workspace/types.ts
+++ b/apps/webapp/src/lib/payroll-workspace/types.ts
@@ -2,6 +2,8 @@ import type { DateTime } from "luxon";
 
 export type PayrollDayPeriod = "full_day" | "am" | "pm";
 
+export type PayrollAbsenceDetailPeriod = PayrollDayPeriod | "partial_day";
+
 export type PayrollDateRangeMode = "month" | "week" | "custom";
 
 export interface PayrollPeriod {
@@ -33,6 +35,8 @@ export interface PayrollSummaryAbsenceRangeRow {
 	endDate: string;
 	startPeriod: PayrollDayPeriod;
 	endPeriod: PayrollDayPeriod;
+	startTime?: string;
+	endTime?: string;
 }
 
 export type PayrollSummaryAbsenceRow = PayrollSummaryAbsenceRangeRow;
@@ -42,7 +46,7 @@ export interface PayrollAbsenceDetail {
 	categoryId: string;
 	categoryName: string;
 	date: string;
-	period: PayrollDayPeriod;
+	period: PayrollAbsenceDetailPeriod;
 }
 
 export type PayrollBlockerType =

--- a/apps/webapp/src/lib/payroll-workspace/types.ts
+++ b/apps/webapp/src/lib/payroll-workspace/types.ts
@@ -25,17 +25,6 @@ export interface PayrollSummaryWorkRow {
 	endAt?: DateTime | null;
 }
 
-export interface PayrollSummaryAbsenceRow {
-	employeeId: string;
-	categoryId: string;
-	categoryName: string;
-	days?: number;
-	startAt?: DateTime;
-	endAt?: DateTime | null;
-	startPeriod?: PayrollDayPeriod;
-	endPeriod?: PayrollDayPeriod;
-}
-
 export interface PayrollSummaryAbsenceRangeRow {
 	employeeId: string;
 	categoryId: string;
@@ -45,6 +34,8 @@ export interface PayrollSummaryAbsenceRangeRow {
 	startPeriod: PayrollDayPeriod;
 	endPeriod: PayrollDayPeriod;
 }
+
+export type PayrollSummaryAbsenceRow = PayrollSummaryAbsenceRangeRow;
 
 export interface PayrollAbsenceDetail {
 	employeeId: string;
@@ -89,5 +80,6 @@ export interface PayrollWorkspaceSummary {
 		blockerCount: number;
 	};
 	employees: PayrollEmployeeSummary[];
+	absenceDetails: PayrollAbsenceDetail[];
 	blockers: PayrollBlocker[];
 }

--- a/apps/webapp/src/lib/payroll-workspace/types.ts
+++ b/apps/webapp/src/lib/payroll-workspace/types.ts
@@ -29,11 +29,18 @@ export interface PayrollSummaryAbsenceRow {
 	employeeId: string;
 	categoryId: string;
 	categoryName: string;
-	days?: number;
-	startAt?: DateTime;
-	endAt?: DateTime | null;
-	startPeriod?: PayrollDayPeriod;
-	endPeriod?: PayrollDayPeriod;
+	startDate: string;
+	endDate: string;
+	startPeriod: PayrollDayPeriod;
+	endPeriod: PayrollDayPeriod;
+}
+
+export interface PayrollAbsenceDetail {
+	employeeId: string;
+	categoryId: string;
+	categoryName: string;
+	date: string;
+	period: PayrollDayPeriod;
 }
 
 export type PayrollBlockerType =
@@ -71,5 +78,6 @@ export interface PayrollWorkspaceSummary {
 		blockerCount: number;
 	};
 	employees: PayrollEmployeeSummary[];
+	absenceDetails: PayrollAbsenceDetail[];
 	blockers: PayrollBlocker[];
 }

--- a/docs/superpowers/plans/2026-07-28-payroll-absence-day-details.md
+++ b/docs/superpowers/plans/2026-07-28-payroll-absence-day-details.md
@@ -1,0 +1,817 @@
+# Payroll Absence Day Details Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add exact approved absence dates and full-day/AM/PM detail to the combined PDF downloaded from `/payroll`.
+
+**Architecture:** Add a small Temporal-based calendar expansion unit that converts approved payroll absence ranges into primitive day-detail rows. Integrate those rows into the existing organization- and employee-scoped payroll summary, derive category totals from the same details, and render grouped employee sections in the existing React PDF without changing payroll connector data or contracts.
+
+**Tech Stack:** TypeScript, Temporal via `temporal-polyfill`, Drizzle ORM, React, `@react-pdf/renderer`, Vitest, MDX
+
+---
+
+## File Structure
+
+- Create `apps/webapp/src/lib/payroll-workspace/absence-details.ts`: expand logical absence ranges into clipped, sorted day details and aggregate their day values.
+- Create `apps/webapp/src/lib/payroll-workspace/absence-details.test.ts`: focused Temporal calendar tests for full-day, partial-day, multi-day, clipping, weekend, ordering, and invalid-range behavior.
+- Modify `apps/webapp/src/lib/payroll-workspace/types.ts`: define the wire-safe day-detail shape and use logical date strings for summary absence rows.
+- Modify `apps/webapp/src/lib/payroll-workspace/summary.ts`: map canonical absence database boundaries to logical date keys, build details, and derive category totals from those details.
+- Modify `apps/webapp/src/lib/payroll-workspace/summary.test.ts`: verify summary integration, totals/detail consistency, and deterministic output.
+- Modify `apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx`: add grouped, paginated absence-detail sections and an explicit empty state.
+- Modify `apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx`: verify grouping data and PDF generation for populated and empty details.
+- Modify `apps/webapp/src/components/payroll/payroll-workspace.test.tsx`: update the typed summary fixture for the new required summary field; no UI behavior changes.
+- Modify `apps/docs/content/docs/guide/admin-guide/payroll-export.mdx`: document the `/payroll` combined PDF and distinguish it from connector exports.
+
+### Task 1: Expand Logical Absence Ranges
+
+**Files:**
+- Create: `apps/webapp/src/lib/payroll-workspace/absence-details.ts`
+- Create: `apps/webapp/src/lib/payroll-workspace/absence-details.test.ts`
+- Modify: `apps/webapp/src/lib/payroll-workspace/types.ts:28-37,51-75`
+
+- [ ] **Step 1: Add the day-detail and logical-row types**
+
+In `apps/webapp/src/lib/payroll-workspace/types.ts`, replace the timestamp fields on `PayrollSummaryAbsenceRow` and add a day-detail type:
+
+```ts
+export interface PayrollSummaryAbsenceRow {
+	employeeId: string;
+	categoryId: string;
+	categoryName: string;
+	startDate: string;
+	endDate: string;
+	startPeriod: PayrollDayPeriod;
+	endPeriod: PayrollDayPeriod;
+}
+
+export interface PayrollAbsenceDetail {
+	employeeId: string;
+	categoryId: string;
+	categoryName: string;
+	date: string;
+	period: PayrollDayPeriod;
+}
+```
+
+Add the required primitive array to `PayrollWorkspaceSummary` after `employees`:
+
+```ts
+	employees: PayrollEmployeeSummary[];
+	absenceDetails: PayrollAbsenceDetail[];
+	blockers: PayrollBlocker[];
+```
+
+- [ ] **Step 2: Write failing expansion tests**
+
+Create `apps/webapp/src/lib/payroll-workspace/absence-details.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildPayrollAbsenceDetails, payrollAbsenceDetailDays } from "./absence-details";
+
+const june = { start: "2026-06-01", end: "2026-06-30" };
+
+describe("buildPayrollAbsenceDetails", () => {
+	it("expands same-day full, AM, and PM absences", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "sick",
+						categoryName: "Sick",
+						startDate: "2026-06-03",
+						endDate: "2026-06-03",
+						startPeriod: "full_day",
+						endPeriod: "full_day",
+					},
+					{
+						employeeId: "employee-1",
+						categoryId: "vacation",
+						categoryName: "Vacation",
+						startDate: "2026-06-04",
+						endDate: "2026-06-04",
+						startPeriod: "am",
+						endPeriod: "am",
+					},
+					{
+						employeeId: "employee-1",
+						categoryId: "personal",
+						categoryName: "Personal",
+						startDate: "2026-06-05",
+						endDate: "2026-06-05",
+						startPeriod: "pm",
+						endPeriod: "pm",
+					},
+				],
+				june,
+			),
+		).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "sick",
+				categoryName: "Sick",
+				date: "2026-06-03",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-04",
+				period: "am",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "personal",
+				categoryName: "Personal",
+				date: "2026-06-05",
+				period: "pm",
+			},
+		]);
+	});
+
+	it("clips a multi-day range and preserves boundary periods", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "sick",
+						categoryName: "Sick",
+						startDate: "2026-05-31",
+						endDate: "2026-06-02",
+						startPeriod: "pm",
+						endPeriod: "am",
+					},
+				],
+				june,
+			),
+		).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "sick",
+				categoryName: "Sick",
+				date: "2026-06-01",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "sick",
+				categoryName: "Sick",
+				date: "2026-06-02",
+				period: "am",
+			},
+		]);
+	});
+
+	it("includes recorded weekend dates and sorts deterministically", () => {
+		const details = buildPayrollAbsenceDetails(
+			[
+				{
+					employeeId: "employee-2",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-07",
+					endDate: "2026-06-07",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick",
+					categoryName: "Sick",
+					startDate: "2026-06-06",
+					endDate: "2026-06-07",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+			],
+			june,
+		);
+
+		expect(details.map((detail) => `${detail.employeeId}:${detail.date}:${detail.categoryName}`)).toEqual([
+			"employee-1:2026-06-06:Sick",
+			"employee-1:2026-06-07:Sick",
+			"employee-2:2026-06-07:Vacation",
+		]);
+	});
+
+	it("drops reversed ranges", () => {
+		expect(
+			buildPayrollAbsenceDetails(
+				[
+					{
+						employeeId: "employee-1",
+						categoryId: "sick",
+						categoryName: "Sick",
+						startDate: "2026-06-05",
+						endDate: "2026-06-04",
+						startPeriod: "full_day",
+						endPeriod: "full_day",
+					},
+				],
+				june,
+			),
+		).toEqual([]);
+	});
+});
+
+describe("payrollAbsenceDetailDays", () => {
+	it("values full days as one and AM/PM as half a day", () => {
+		expect(payrollAbsenceDetailDays("full_day")).toBe(1);
+		expect(payrollAbsenceDetailDays("am")).toBe(0.5);
+		expect(payrollAbsenceDetailDays("pm")).toBe(0.5);
+	});
+});
+```
+
+- [ ] **Step 3: Run the new test to verify it fails**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/absence-details.test.ts`
+
+Expected: FAIL because `./absence-details` does not exist.
+
+- [ ] **Step 4: Implement Temporal-based date expansion**
+
+Create `apps/webapp/src/lib/payroll-workspace/absence-details.ts`:
+
+```ts
+import { Temporal } from "temporal-polyfill";
+import type {
+	PayrollAbsenceDetail,
+	PayrollDayPeriod,
+	PayrollPeriod,
+	PayrollSummaryAbsenceRow,
+} from "./types";
+
+export function buildPayrollAbsenceDetails(
+	rows: PayrollSummaryAbsenceRow[],
+	period: Pick<PayrollPeriod, "start" | "end">,
+): PayrollAbsenceDetail[] {
+	const periodStart = Temporal.PlainDate.from(period.start);
+	const periodEnd = Temporal.PlainDate.from(period.end);
+	const details: PayrollAbsenceDetail[] = [];
+
+	for (const row of rows) {
+		const recordStart = Temporal.PlainDate.from(row.startDate);
+		const recordEnd = Temporal.PlainDate.from(row.endDate);
+		if (Temporal.PlainDate.compare(recordEnd, recordStart) < 0) continue;
+
+		const firstDate = Temporal.PlainDate.compare(recordStart, periodStart) < 0 ? periodStart : recordStart;
+		const lastDate = Temporal.PlainDate.compare(recordEnd, periodEnd) > 0 ? periodEnd : recordEnd;
+		if (Temporal.PlainDate.compare(lastDate, firstDate) < 0) continue;
+
+		for (
+			let date = firstDate;
+			Temporal.PlainDate.compare(date, lastDate) <= 0;
+			date = date.add({ days: 1 })
+		) {
+			details.push({
+				employeeId: row.employeeId,
+				categoryId: row.categoryId,
+				categoryName: row.categoryName,
+				date: date.toString(),
+				period: absencePeriodForDate(date, recordStart, recordEnd, row.startPeriod, row.endPeriod),
+			});
+		}
+	}
+
+	return details.sort(
+		(a, b) =>
+			a.employeeId.localeCompare(b.employeeId) ||
+			a.date.localeCompare(b.date) ||
+			a.categoryName.localeCompare(b.categoryName) ||
+			a.categoryId.localeCompare(b.categoryId),
+	);
+}
+
+export function payrollAbsenceDetailDays(period: PayrollDayPeriod): number {
+	return period === "full_day" ? 1 : 0.5;
+}
+
+function absencePeriodForDate(
+	date: Temporal.PlainDate,
+	recordStart: Temporal.PlainDate,
+	recordEnd: Temporal.PlainDate,
+	startPeriod: PayrollDayPeriod,
+	endPeriod: PayrollDayPeriod,
+): PayrollDayPeriod {
+	if (recordStart.equals(recordEnd)) {
+		return startPeriod === endPeriod ? startPeriod : "full_day";
+	}
+	if (date.equals(recordStart)) return startPeriod;
+	if (date.equals(recordEnd)) return endPeriod;
+	return "full_day";
+}
+```
+
+- [ ] **Step 5: Run the focused tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/absence-details.test.ts`
+
+Expected: PASS with 5 tests.
+
+- [ ] **Step 6: Commit the expansion unit**
+
+```bash
+git add apps/webapp/src/lib/payroll-workspace/types.ts apps/webapp/src/lib/payroll-workspace/absence-details.ts apps/webapp/src/lib/payroll-workspace/absence-details.test.ts
+git commit -m "feat(payroll): expand absence ranges by day"
+```
+
+### Task 2: Integrate Details Into The Scoped Payroll Summary
+
+**Files:**
+- Modify: `apps/webapp/src/lib/payroll-workspace/summary.ts:44-115,338-389,513-584`
+- Modify: `apps/webapp/src/lib/payroll-workspace/summary.test.ts:11-196`
+- Modify: `apps/webapp/src/components/payroll/payroll-workspace.test.tsx:35-77`
+
+- [ ] **Step 1: Replace aggregate-only absence fixtures with logical ranges**
+
+In `apps/webapp/src/lib/payroll-workspace/summary.test.ts`, change the two absence rows in `groups absence days by employee and category` to:
+
+```ts
+			absenceRows: [
+				{
+					employeeId: "employee-1",
+					categoryId: "vacation",
+					categoryName: "Vacation",
+					startDate: "2026-06-10",
+					endDate: "2026-06-11",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+				{
+					employeeId: "employee-1",
+					categoryId: "sick",
+					categoryName: "Sick",
+					startDate: "2026-06-12",
+					endDate: "2026-06-12",
+					startPeriod: "full_day",
+					endPeriod: "full_day",
+				},
+			],
+```
+
+After the existing category-total assertion, add:
+
+```ts
+		expect(summary.absenceDetails).toEqual([
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-10",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "vacation",
+				categoryName: "Vacation",
+				date: "2026-06-11",
+				period: "full_day",
+			},
+			{
+				employeeId: "employee-1",
+				categoryId: "sick",
+				categoryName: "Sick",
+				date: "2026-06-12",
+				period: "full_day",
+			},
+		]);
+```
+
+Remove the old `calculatePayrollAbsenceDays` test block and remove that function from the test imports. Task 1 now owns calendar expansion coverage.
+
+- [ ] **Step 2: Run the summary test to verify integration fails**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/summary.test.ts`
+
+Expected: FAIL because `buildPayrollSummaryFromRows` does not return `absenceDetails` and still expects aggregate/timestamp rows.
+
+- [ ] **Step 3: Derive details and category totals from one source**
+
+In `apps/webapp/src/lib/payroll-workspace/summary.ts`, import the new helpers:
+
+```ts
+import { buildPayrollAbsenceDetails, payrollAbsenceDetailDays } from "./absence-details";
+```
+
+Replace the existing `absenceDaysByEmployee` row loop inside `buildPayrollSummaryFromRows` with:
+
+```ts
+	const absenceDetails = buildPayrollAbsenceDetails(input.absenceRows, input.period);
+	const absenceDaysByEmployee = new Map<
+		string,
+		Map<string, { categoryId: string; categoryName: string; days: number }>
+	>();
+	for (const detail of absenceDetails) {
+		const employeeAbsences = absenceDaysByEmployee.get(detail.employeeId) ?? new Map();
+		const existing = employeeAbsences.get(detail.categoryId);
+		employeeAbsences.set(detail.categoryId, {
+			categoryId: detail.categoryId,
+			categoryName: detail.categoryName,
+			days: (existing?.days ?? 0) + payrollAbsenceDetailDays(detail.period),
+		});
+		absenceDaysByEmployee.set(detail.employeeId, employeeAbsences);
+	}
+```
+
+Add `absenceDetails` to the returned summary immediately after `employees`:
+
+```ts
+		employees,
+		absenceDetails,
+		blockers: input.blockers,
+```
+
+Delete `calculatePayrollAbsenceDays`, `getAbsenceSlotsForDay`, `firstAbsenceSlot`, `lastAbsenceSlot`, and their now-unused `PayrollDayPeriod` import. Keep work-period overlap helpers unchanged.
+
+- [ ] **Step 4: Map database timestamp boundaries to logical date keys at the boundary**
+
+In `getAbsenceRows`, keep all existing organization, approval-state, period, and `allowedEmployeeIds` constraints. Change only the returned row mapping:
+
+```ts
+	return rows.map((row) => ({
+		employeeId: row.employeeId,
+		categoryId: row.categoryId,
+		categoryName: row.categoryName,
+		startDate: row.startAt.toISOString().slice(0, 10),
+		endDate: (row.endAt ?? row.startAt).toISOString().slice(0, 10),
+		startPeriod: row.startPeriod,
+		endPeriod: row.endPeriod,
+	}));
+```
+
+This conversion occurs at the Drizzle `Date` boundary. All calendar iteration remains in Temporal and all summary output remains primitive strings.
+
+- [ ] **Step 5: Update the client-component typed fixture**
+
+In `apps/webapp/src/components/payroll/payroll-workspace.test.tsx`, add the required field between `employees` and `blockers`:
+
+```ts
+	absenceDetails: [],
+```
+
+In `buildSummary`, preserve overrides for it:
+
+```ts
+		absenceDetails: overrides.absenceDetails ?? baseSummary.absenceDetails,
+```
+
+- [ ] **Step 6: Run summary and payroll workspace tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/absence-details.test.ts src/lib/payroll-workspace/summary.test.ts src/components/payroll/payroll-workspace.test.tsx`
+
+Expected: PASS. The summary test proves detail/totals consistency; existing component tests prove the new wire field does not alter the `/payroll` UI.
+
+- [ ] **Step 7: Run existing authorization action tests**
+
+Run: `pnpm --dir apps/webapp test 'src/app/[locale]/(app)/payroll/actions.test.ts' 'src/app/[locale]/(app)/payroll/actions.start-export.test.ts'`
+
+Expected: PASS. These tests preserve server-side intersection with the payroll officer's allowed employee IDs. Confirm the changed absence query still contains all four constraints: `timeRecord.organizationId`, approved state, selected-period overlap, and `allowedEmployeeIds`.
+
+- [ ] **Step 8: Commit the summary integration**
+
+```bash
+git add apps/webapp/src/lib/payroll-workspace/summary.ts apps/webapp/src/lib/payroll-workspace/summary.test.ts apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+git commit -m "feat(payroll): include absence day details in summaries"
+```
+
+### Task 3: Render Employee Absence Details In The PDF
+
+**Files:**
+- Modify: `apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx:4-175,189-306`
+- Modify: `apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx:1-42`
+
+- [ ] **Step 1: Add populated and empty grouping tests**
+
+In `apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx`, import the pure grouping helper:
+
+```ts
+import {
+	buildPayrollAbsenceSections,
+	exportPayrollSummaryToPDF,
+	generatePayrollPDFFilename,
+} from "./pdf-exporter";
+```
+
+Replace the existing `summary` fixture so its totals and details represent the same approved absence dates:
+
+```ts
+const summary: PayrollWorkspaceSummary = {
+	organizationName: "Acme GmbH",
+	period: { start: "2026-06-01", end: "2026-06-30", label: "June 2026" },
+	generatedAt: "2026-06-30T12:00:00.000Z",
+	generatedBy: { id: "payroll-1", name: "Payroll User" },
+	totals: { employeeCount: 1, totalWorkedHours: 12.5, blockerCount: 1 },
+	employees: [
+		{
+			id: "employee-1",
+			name: "Ada Lovelace",
+			employeeNumber: "E-1",
+			teamName: "Ops",
+			contractType: "hourly",
+			workedHours: 12.5,
+			absenceDaysByCategory: [
+				{ categoryId: "sick", categoryName: "Sick", days: 1 },
+				{ categoryId: "vacation", categoryName: "Vacation", days: 0.5 },
+			],
+			hasBlockers: true,
+		},
+	],
+	absenceDetails: [
+		{
+			employeeId: "employee-1",
+			categoryId: "sick",
+			categoryName: "Sick",
+			date: "2026-06-03",
+			period: "full_day",
+		},
+		{
+			employeeId: "employee-1",
+			categoryId: "vacation",
+			categoryName: "Vacation",
+			date: "2026-06-08",
+			period: "am",
+		},
+	],
+	blockers: [
+		{
+			id: "blocker-1",
+			employeeId: "employee-1",
+			type: "missing_clock_out",
+			label: "Missing clock-out",
+		},
+	],
+};
+```
+
+Add these tests before the byte-array smoke test:
+
+```ts
+	it("groups absence details by employee in report order", () => {
+		expect(buildPayrollAbsenceSections(summary)).toEqual([
+			{
+				employeeId: "employee-1",
+				employeeName: "Ada Lovelace",
+				employeeNumber: "E-1",
+				rows: [
+					{ date: "2026-06-03", categoryName: "Sick", periodLabel: "Full day" },
+					{ date: "2026-06-08", categoryName: "Vacation", periodLabel: "AM" },
+				],
+			},
+		]);
+	});
+
+	it("returns no employee sections when the report has no approved absences", () => {
+		expect(buildPayrollAbsenceSections({ ...summary, absenceDetails: [] })).toEqual([]);
+	});
+```
+
+- [ ] **Step 2: Run the PDF tests to verify they fail**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/pdf-exporter.test.tsx`
+
+Expected: FAIL because `buildPayrollAbsenceSections` is not exported.
+
+- [ ] **Step 3: Implement deterministic report grouping**
+
+In `apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx`, add:
+
+```ts
+export interface PayrollAbsenceSection {
+	employeeId: string;
+	employeeName: string;
+	employeeNumber: string | null;
+	rows: Array<{ date: string; categoryName: string; periodLabel: string }>;
+}
+
+export function buildPayrollAbsenceSections(
+	summary: PayrollWorkspaceSummary,
+): PayrollAbsenceSection[] {
+	const detailsByEmployee = new Map<string, typeof summary.absenceDetails>();
+	for (const detail of summary.absenceDetails) {
+		detailsByEmployee.set(detail.employeeId, [
+			...(detailsByEmployee.get(detail.employeeId) ?? []),
+			detail,
+		]);
+	}
+
+	return summary.employees.flatMap((employee) => {
+		const details = detailsByEmployee.get(employee.id);
+		if (!details?.length) return [];
+
+		return [
+			{
+				employeeId: employee.id,
+				employeeName: employee.name,
+				employeeNumber: employee.employeeNumber,
+				rows: details
+					.toSorted(
+						(a, b) =>
+							a.date.localeCompare(b.date) ||
+							a.categoryName.localeCompare(b.categoryName) ||
+							a.categoryId.localeCompare(b.categoryId),
+					)
+					.map((detail) => ({
+						date: detail.date,
+						categoryName: detail.categoryName,
+						periodLabel:
+							detail.period === "full_day" ? "Full day" : detail.period.toUpperCase(),
+					})),
+			},
+		];
+	});
+}
+```
+
+The summary already sorts employees by name, so iterating `summary.employees` provides the required employee-name order and omits employees without details.
+
+- [ ] **Step 4: Add compact PDF detail styles**
+
+Add these entries to `styleDefinitions` before `footer`:
+
+```ts
+	absenceSection: {
+		marginTop: 14,
+	},
+	absenceEmployee: {
+		marginBottom: 9,
+		borderWidth: 1,
+		borderColor: "#CBD5E1",
+	},
+	absenceEmployeeHeader: {
+		padding: 6,
+		backgroundColor: "#EFF6FF",
+		fontWeight: "bold" as const,
+		color: "#1E3A8A",
+	},
+	absenceRow: {
+		flexDirection: "row" as const,
+		borderTopWidth: 1,
+		borderTopColor: "#E2E8F0",
+	},
+	absenceDateCell: {
+		width: "24%",
+		padding: 5,
+	},
+	absenceCategoryCell: {
+		width: "56%",
+		padding: 5,
+	},
+	absencePeriodCell: {
+		width: "20%",
+		padding: 5,
+	},
+	emptyAbsences: {
+		padding: 9,
+		borderWidth: 1,
+		borderColor: "#CBD5E1",
+		backgroundColor: "#F8FAFC",
+		color: "#64748B",
+	},
+```
+
+- [ ] **Step 5: Render the grouped details after employee totals**
+
+Inside `exportPayrollSummaryToPDF`, calculate sections after styles are created:
+
+```ts
+	const absenceSections = buildPayrollAbsenceSections(summary);
+```
+
+Insert this JSX after the employee totals table and before the footer:
+
+```tsx
+				<View style={styles.absenceSection}>
+					<Text style={styles.sectionTitle}>Absence details</Text>
+					{absenceSections.length === 0 ? (
+						<Text style={styles.emptyAbsences}>
+							No approved absences for the selected period.
+						</Text>
+					) : (
+						absenceSections.map((section) => (
+							<View key={section.employeeId} style={styles.absenceEmployee}>
+								<Text style={styles.absenceEmployeeHeader}>
+									{section.employeeName} ({section.employeeNumber ?? "No employee no."})
+								</Text>
+								{section.rows.map((row, index) => (
+									<View
+										key={`${row.date}-${row.categoryName}-${index}`}
+										style={styles.absenceRow}
+									>
+										<Text style={styles.absenceDateCell}>{row.date}</Text>
+										<Text style={styles.absenceCategoryCell}>{row.categoryName}</Text>
+										<Text style={styles.absencePeriodCell}>{row.periodLabel}</Text>
+									</View>
+								))}
+							</View>
+						))
+					)}
+				</View>
+```
+
+The employee container deliberately remains wrappable so long absence lists flow onto later pages instead of being truncated or pushed outside the page.
+
+- [ ] **Step 6: Run the PDF tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/pdf-exporter.test.tsx`
+
+Expected: PASS with filename, grouping, empty-state, and PDF byte-array tests.
+
+- [ ] **Step 7: Commit the PDF report change**
+
+```bash
+git add apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+git commit -m "feat(payroll): list absence dates in PDF reports"
+```
+
+### Task 4: Document The Payroll Officer Workflow
+
+**Files:**
+- Modify: `apps/docs/content/docs/guide/admin-guide/payroll-export.mdx:9-16,146-155`
+
+- [ ] **Step 1: Add the combined PDF workflow to the guide**
+
+In `apps/docs/content/docs/guide/admin-guide/payroll-export.mdx`, add this section before `## Running Exports`:
+
+```mdx
+## Combined Payroll PDF
+
+Payroll officers and org admins with access to **Payroll** can download one combined PDF for the selected period and employee scope.
+
+The PDF includes:
+
+- worked-hour and approved-absence totals per employee
+- payroll blockers that still require review
+- every approved absence date, grouped by employee
+- the absence category and whether each date is a full day, morning (**AM**), or afternoon (**PM**)
+
+Use these day-level details when approved sickness, vacation, or other absence dates must be entered manually into another legal or payroll system. Multi-day absences list every recorded calendar date, including weekends and holidays contained in the approved record.
+
+The combined PDF is an audit and manual-entry report. It does not alter the configured DATEV, Lexware, Sage, Personio, SAP SuccessFactors, or Workday export formats and payloads described below.
+```
+
+Update the overview after the Settings instructions with:
+
+```mdx
+Use **Payroll** to review the employee scope and download the combined PDF with exact approved absence dates.
+```
+
+- [ ] **Step 2: Check the MDX content for syntax and scope accuracy**
+
+Run: `pnpm --dir apps/docs build`
+
+Expected: PASS, including Fumadocs MDX compilation and the payroll export guide route.
+
+Confirm the text says approved absences, every recorded calendar date, full-day/AM/PM, `/payroll` scope, and PDF-only connector behavior.
+
+- [ ] **Step 3: Commit the guide update**
+
+```bash
+git add apps/docs/content/docs/guide/admin-guide/payroll-export.mdx
+git commit -m "docs: explain payroll absence day report"
+```
+
+### Task 5: Verify The Complete Change
+
+**Files:**
+- Verify: `apps/webapp/src/lib/payroll-workspace/absence-details.ts`
+- Verify: `apps/webapp/src/lib/payroll-workspace/summary.ts`
+- Verify: `apps/webapp/src/lib/payroll-workspace/pdf-exporter.tsx`
+- Verify: `apps/docs/content/docs/guide/admin-guide/payroll-export.mdx`
+
+- [ ] **Step 1: Run all focused payroll workspace tests**
+
+Run: `pnpm --dir apps/webapp test src/lib/payroll-workspace/absence-details.test.ts src/lib/payroll-workspace/summary.test.ts src/lib/payroll-workspace/pdf-exporter.test.tsx src/components/payroll/payroll-workspace.test.tsx 'src/app/[locale]/(app)/payroll/actions.test.ts' 'src/app/[locale]/(app)/payroll/actions.start-export.test.ts'`
+
+Expected: PASS with no failed tests.
+
+- [ ] **Step 2: Run the webapp typecheck**
+
+Run: `pnpm --dir apps/webapp typecheck`
+
+Expected: PASS with no TypeScript errors. This catches every `PayrollWorkspaceSummary` fixture that needs the required `absenceDetails` field.
+
+- [ ] **Step 3: Verify connector files are unchanged**
+
+Run: `git diff 25500f57 -- apps/webapp/src/lib/payroll-export`
+
+Expected: no output. The feature must not modify file-based formatters or API connector payloads.
+
+- [ ] **Step 4: Inspect formatting and whitespace**
+
+Run: `git diff --check`
+
+Expected: no output.
+
+- [ ] **Step 5: Review the final diff against the design**
+
+Run: `git diff 25500f57 --stat && git status --short`
+
+Expected: the feature diff contains only the implementation plan, payroll workspace source/tests, and the payroll export guide. Unrelated concurrent work may remain in the worktree but must not be staged, reverted, or modified.
+
+- [ ] **Step 6: Record verification without an empty commit**
+
+If every command passes, retain the three focused implementation commits from Tasks 2-4 plus the expansion-unit commit from Task 1. Do not create an empty verification commit.

--- a/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
+++ b/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
@@ -31,11 +31,12 @@ Existing absence totals remain available for the employee totals table. Totals a
 
 ## Date Expansion
 
-An approved absence record is expanded into one detail for each recorded calendar date that overlaps the selected payroll period.
+An approved absence record is expanded into one detail for each recorded calendar date that overlaps the selected payroll period, except for explicitly timed overnight partials as described below.
 
 - A same-day full-day absence produces one `full_day` detail.
 - A same-day partial absence produces one `am` or `pm` detail.
 - A same-day absence with explicit clock times uses those times when its stored endpoint periods are generic AM placeholders: an interval beginning at or after 12:00 is `pm`, one ending at or before 12:00 is `am`, and one crossing 12:00 is `partial_day`.
+- An explicitly timed overnight partial produces one `partial_day` detail on its recorded start date and counts as 0.5 day. It is included only when that start date is within the selected payroll period.
 - For a multi-day absence, the first date is `pm` only when the record starts in the PM; an AM or full-day start produces `full_day` coverage for that date.
 - The last date is `am` only when the record ends in the AM; a PM or full-day end produces `full_day` coverage for that date.
 - All interior dates are `full_day`. Dates that become range boundaries only because the record is clipped to the selected payroll period are also `full_day` unless they are an original record endpoint.
@@ -84,6 +85,7 @@ Implementation follows red-green-refactor and covers:
 - same-day full-day expansion
 - same-day AM and PM expansion
 - explicitly timed same-day AM, PM, and cross-noon classification
+- explicitly timed overnight classification, start-date assignment, and period clipping
 - multi-day expansion with first and last partial-day boundaries
 - clipping details to the selected payroll period
 - inclusion of all recorded calendar dates, including weekends

--- a/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
+++ b/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
@@ -2,11 +2,11 @@
 
 ## Goal
 
-Make the combined PDF downloaded from `/payroll` suitable for manual documentation in another legal system by showing the exact approved absence dates for each employee.
+Make the combined PDF downloaded from `/payroll` suitable for manual review or entry in another system by showing the exact approved absence dates for each employee.
 
 ## Scope
 
-The combined payroll PDF will list every approved absence category by exact recorded calendar date. Full-day and partial-day absences will be distinguished as `Full day`, `AM`, or `PM`.
+The combined payroll PDF will list every approved absence category by exact recorded calendar date. Absences will be distinguished as `Full day`, `AM`, `PM`, or `Partial day`. `Partial day` identifies an explicitly timed same-day interval that crosses from AM into PM.
 
 This change applies only to the combined PDF downloaded from `/payroll`. It does not change DATEV, Lexware, or Sage files, and it does not change Personio, SuccessFactors, Workday, or other connector payloads.
 
@@ -23,7 +23,7 @@ Extend the payroll workspace summary with day-level absence details. Each detail
 - employee ID
 - absence category ID and name
 - logical ISO calendar date (`YYYY-MM-DD`)
-- day period: `full_day`, `am`, or `pm`
+- day period: `full_day`, `am`, `pm`, or `partial_day`
 
 These dates are logical absence dates. They must not be derived from the payroll officer's or another viewer's timezone.
 
@@ -35,6 +35,7 @@ An approved absence record is expanded into one detail for each recorded calenda
 
 - A same-day full-day absence produces one `full_day` detail.
 - A same-day partial absence produces one `am` or `pm` detail.
+- A same-day absence with explicit clock times uses those times when its stored endpoint periods are generic AM placeholders: an interval beginning at or after 12:00 is `pm`, one ending at or before 12:00 is `am`, and one crossing 12:00 is `partial_day`.
 - For a multi-day absence, the first date is `pm` only when the record starts in the PM; an AM or full-day start produces `full_day` coverage for that date.
 - The last date is `am` only when the record ends in the AM; a PM or full-day end produces `full_day` coverage for that date.
 - All interior dates are `full_day`. Dates that become range boundaries only because the record is clipped to the selected payroll period are also `full_day` unless they are an original record endpoint.
@@ -51,7 +52,7 @@ The section uses a compact table with columns for:
 - employee identity
 - date
 - absence category name
-- `Full day`, `AM`, or `PM`
+- `Full day`, `AM`, `PM`, or `Partial day`
 
 Rows remain contiguous and grouped by employee, with the employee's identity repeated on every row so that each row retains its context across page breaks. Employee groups are sorted by employee name, and rows within each group are sorted by date, category name, and period for deterministic output. Employees without approved absences are omitted from the detail section. If the selected scope has no approved absences, the PDF displays the unchanged message: `No approved absences for the selected period.`
 
@@ -72,7 +73,7 @@ All absence queries remain filtered by `organizationId`, approved status, select
 
 ## Documentation
 
-Update the payroll export guide to explain that payroll officers can use `/payroll` to download a combined PDF containing approved absence dates and full-day or AM/PM detail for manual documentation in downstream legal systems.
+Update the payroll export guide to explain that payroll officers can use `/payroll` to download a combined PDF containing approved absence dates and `Full day`, `AM`, `PM`, or `Partial day` detail for manual review or entry in downstream systems.
 
 The guide must distinguish this combined PDF from configured payroll connector exports, whose formats and payloads are unchanged.
 
@@ -82,6 +83,7 @@ Implementation follows red-green-refactor and covers:
 
 - same-day full-day expansion
 - same-day AM and PM expansion
+- explicitly timed same-day AM, PM, and cross-noon classification
 - multi-day expansion with first and last partial-day boundaries
 - clipping details to the selected payroll period
 - inclusion of all recorded calendar dates, including weekends

--- a/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
+++ b/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
@@ -35,7 +35,9 @@ An approved absence record is expanded into one detail for each recorded calenda
 
 - A same-day full-day absence produces one `full_day` detail.
 - A same-day partial absence produces one `am` or `pm` detail.
-- For a multi-day absence, the first date retains the record's starting period, the last date retains its ending period, and intermediate dates are `full_day`.
+- For a multi-day absence, the first date is `pm` only when the record starts in the PM; an AM or full-day start produces `full_day` coverage for that date.
+- The last date is `am` only when the record ends in the AM; a PM or full-day end produces `full_day` coverage for that date.
+- All interior dates are `full_day`. Dates that become range boundaries only because the record is clipped to the selected payroll period are also `full_day` unless they are an original record endpoint.
 - Expansion includes every recorded calendar date, including weekends, holidays, and employee non-working days. It does not recalculate the record against work schedules.
 - Details outside the selected payroll period are excluded.
 - An invalid range whose end precedes its start produces no details.
@@ -44,15 +46,16 @@ An approved absence record is expanded into one detail for each recorded calenda
 
 Keep the existing PDF header, metrics, blocker summary, and employee totals table. Add an `Absence details` section after the totals table.
 
-The section is grouped by employee. Each employee group contains rows with:
+The section uses a compact table with columns for:
 
+- employee identity
 - date
 - absence category name
 - `Full day`, `AM`, or `PM`
 
-Employee groups are sorted by employee name. Rows within each group are sorted by date and then category name for deterministic output. Employees without approved absences are omitted from the detail section. If the selected scope has no approved absences, the PDF states that there are no approved absences for the selected period.
+Rows remain contiguous and grouped by employee, with the employee's identity repeated on every row so that each row retains its context across page breaks. Employee groups are sorted by employee name, and rows within each group are sorted by date, category name, and period for deterministic output. Employees without approved absences are omitted from the detail section. If the selected scope has no approved absences, the PDF displays the unchanged message: `No approved absences for the selected period.`
 
-The section may flow across multiple pages. Employee headings and absence rows should remain compact and audit-readable, while avoiding a wide date matrix that would not fit monthly or custom periods.
+The compact table may flow across multiple pages. Its fixed table headers repeat on continuation pages, while the contiguous rows and repeated employee identity keep the report audit-readable without the pagination overhead of separate employee cards or headings.
 
 ## Authorization And Tenant Isolation
 

--- a/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
+++ b/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
@@ -6,7 +6,7 @@ Make the combined PDF downloaded from `/payroll` suitable for manual review or e
 
 ## Scope
 
-The combined payroll PDF will list every approved absence category by exact recorded calendar date. Absences will be distinguished as `Full day`, `AM`, `PM`, or `Partial day`. `Partial day` identifies an explicitly timed same-day interval that crosses from AM into PM.
+The combined payroll PDF will list every approved absence category by exact recorded calendar date. Absences will be distinguished as `Full day`, `AM`, `PM`, or `Partial day`. `Partial day` identifies an explicitly timed interval that crosses noon or midnight.
 
 This change applies only to the combined PDF downloaded from `/payroll`. It does not change DATEV, Lexware, or Sage files, and it does not change Personio, SuccessFactors, Workday, or other connector payloads.
 

--- a/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
+++ b/docs/superpowers/specs/2026-07-28-payroll-absence-day-details-design.md
@@ -1,0 +1,100 @@
+# Payroll Absence Day Details Design
+
+## Goal
+
+Make the combined PDF downloaded from `/payroll` suitable for manual documentation in another legal system by showing the exact approved absence dates for each employee.
+
+## Scope
+
+The combined payroll PDF will list every approved absence category by exact recorded calendar date. Full-day and partial-day absences will be distinguished as `Full day`, `AM`, or `PM`.
+
+This change applies only to the combined PDF downloaded from `/payroll`. It does not change DATEV, Lexware, or Sage files, and it does not change Personio, SuccessFactors, Workday, or other connector payloads.
+
+## Existing Behavior
+
+The payroll workspace summary currently reduces approved absences to total days per employee and category. The PDF displays those totals in the employee table but does not retain or display the dates represented by each absence record.
+
+The underlying payroll summary query already reads approved canonical absence records, including their date range and first/last day periods. No database schema change is required.
+
+## Data Model
+
+Extend the payroll workspace summary with day-level absence details. Each detail contains:
+
+- employee ID
+- absence category ID and name
+- logical ISO calendar date (`YYYY-MM-DD`)
+- day period: `full_day`, `am`, or `pm`
+
+These dates are logical absence dates. They must not be derived from the payroll officer's or another viewer's timezone.
+
+Existing absence totals remain available for the employee totals table. Totals and details must be derived from the same approved absence rows so that the two representations cannot disagree.
+
+## Date Expansion
+
+An approved absence record is expanded into one detail for each recorded calendar date that overlaps the selected payroll period.
+
+- A same-day full-day absence produces one `full_day` detail.
+- A same-day partial absence produces one `am` or `pm` detail.
+- For a multi-day absence, the first date retains the record's starting period, the last date retains its ending period, and intermediate dates are `full_day`.
+- Expansion includes every recorded calendar date, including weekends, holidays, and employee non-working days. It does not recalculate the record against work schedules.
+- Details outside the selected payroll period are excluded.
+- An invalid range whose end precedes its start produces no details.
+
+## PDF Structure
+
+Keep the existing PDF header, metrics, blocker summary, and employee totals table. Add an `Absence details` section after the totals table.
+
+The section is grouped by employee. Each employee group contains rows with:
+
+- date
+- absence category name
+- `Full day`, `AM`, or `PM`
+
+Employee groups are sorted by employee name. Rows within each group are sorted by date and then category name for deterministic output. Employees without approved absences are omitted from the detail section. If the selected scope has no approved absences, the PDF states that there are no approved absences for the selected period.
+
+The section may flow across multiple pages. Employee headings and absence rows should remain compact and audit-readable, while avoiding a wide date matrix that would not fit monthly or custom periods.
+
+## Authorization And Tenant Isolation
+
+The existing `/payroll` server action remains the authorization boundary. It resolves the payroll officer's permitted employee IDs server-side and intersects them with requested filters before building the summary.
+
+All absence queries remain filtered by `organizationId`, approved status, selected period, and the resolved employee IDs. Day-level details must not expose employees or absence records outside that scope.
+
+## Error Handling
+
+- Invalid or reversed absence ranges produce no day-level rows rather than misleading dates.
+- An empty approved-absence result is valid and renders the explicit empty message in the PDF.
+- PDF generation failures continue through the existing payroll download error path and do not clear the selected period or employee filters.
+- No connector behavior changes, so connector-specific validation and errors remain unchanged.
+
+## Documentation
+
+Update the payroll export guide to explain that payroll officers can use `/payroll` to download a combined PDF containing approved absence dates and full-day or AM/PM detail for manual documentation in downstream legal systems.
+
+The guide must distinguish this combined PDF from configured payroll connector exports, whose formats and payloads are unchanged.
+
+## Testing
+
+Implementation follows red-green-refactor and covers:
+
+- same-day full-day expansion
+- same-day AM and PM expansion
+- multi-day expansion with first and last partial-day boundaries
+- clipping details to the selected payroll period
+- inclusion of all recorded calendar dates, including weekends
+- rejection of reversed ranges
+- deterministic employee, date, and category ordering
+- approved absences only
+- organization and payroll-access scope enforcement
+- preservation of category totals from the same source details
+- PDF generation with populated and empty absence-detail sections
+- unchanged payroll connector output behavior through focused regression tests where needed
+
+## Non-Goals
+
+- Showing day-level absence details in the `/payroll` web table.
+- Changing absence approval or editing workflows.
+- Excluding weekends, holidays, or non-working days from recorded absence ranges.
+- Exporting sick-detail metadata, notes, medical information, or approval history.
+- Modifying file-based or API-based payroll connector contracts.
+- Adding a database migration.


### PR DESCRIPTION
## Summary
- list every approved absence date in the combined `/payroll` PDF with employee, category, and Full day/AM/PM/Partial day context
- preserve scoped access, exact half-day totals, timed and overnight partial semantics, and compact multi-page rendering
- document the payroll officer workflow while leaving connector exports unchanged

## Test Plan
- [x] `pnpm --dir apps/webapp test src/lib/payroll-workspace/absence-details.test.ts src/lib/payroll-workspace/summary.test.ts src/lib/payroll-workspace/pdf-exporter.test.tsx src/components/payroll/payroll-workspace.test.tsx 'src/app/[locale]/(app)/payroll/actions.test.ts' 'src/app/[locale]/(app)/payroll/actions.start-export.test.ts'`\n- [x] `pnpm --dir apps/webapp typecheck`\n- [x] `pnpm --dir apps/docs build`\n- [x] `git diff --check`\n- [x] React Doctor checked; reported findings are pre-existing and outside changed files