### PR TITLE
fix(payroll): log cutover reconciliation details

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
@@ -12,8 +12,21 @@ const t = (_key: string, fallback: string) => fallback;
 
 describe("mapPayrollWorkspaceActionError", () => {
 	it("classifies incomplete canonical payroll data as a conflict", () => {
+		const reconciliation = {
+			workCountMismatch: 0,
+			absenceCountMismatch: 0,
+			durationMismatchRecords: 0,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
 		const result = mapPayrollWorkspaceActionError(
-			new CanonicalCutoverNotReadyError("org-1"),
+			new CanonicalCutoverNotReadyError("org-1", reconciliation),
 			t,
 		);
 
@@ -21,7 +34,9 @@ describe("mapPayrollWorkspaceActionError", () => {
 			_tag: "ConflictError",
 			conflictType: "canonical_payroll_data_not_ready",
 			message: "Payroll data is temporarily unavailable",
+			details: { organizationId: "org-1", reconciliation },
 		});
+		expect(result.details).toEqual({ organizationId: "org-1", reconciliation });
 		expect(result._tag).not.toBe("ValidationError");
 	});
 

--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
@@ -25,6 +25,10 @@ export function mapPayrollWorkspaceActionError(
 				"Payroll data is temporarily unavailable",
 			),
 			conflictType: "canonical_payroll_data_not_ready",
+			details: {
+				organizationId: error.organizationId,
+				reconciliation: error.reconciliation,
+			},
 		});
 	}
 

--- a/apps/webapp/src/lib/effect/result.test.ts
+++ b/apps/webapp/src/lib/effect/result.test.ts
@@ -1,0 +1,38 @@
+import { Exit } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConflictError } from "./errors";
+import { toServerActionResult } from "./result";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("toServerActionResult", () => {
+	it("logs payroll conflict diagnostics without exposing them to the client", () => {
+		const error = new ConflictError({
+			message: "Payroll data is temporarily unavailable",
+			conflictType: "canonical_payroll_data_not_ready",
+			details: {
+				organizationId: "org-1",
+				reconciliation: {
+					workCountMismatch: 2,
+					absenceCountMismatch: 1,
+					durationMismatchRecords: 3,
+				},
+			},
+		});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		const result = toServerActionResult(Exit.fail(error));
+
+		expect(consoleError).toHaveBeenCalledWith("[ServerAction Error]", error);
+		expect(result).toEqual({
+			success: false,
+			error: "Payroll data is temporarily unavailable",
+			code: "ConflictError",
+		});
+		expect(result).not.toHaveProperty("details");
+	});
+});

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
@@ -72,37 +72,40 @@ describe("assertCanonicalCutoverReady", () => {
 
 	it("throws when repair backfill still leaves canonical mismatches", async () => {
 		findFirstEmployee.mockResolvedValue({ userId: "user-1" });
+		const initialReconciliation = {
+			workCountMismatch: 1,
+			absenceCountMismatch: 0,
+			durationMismatchRecords: 0,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
+		const finalReconciliation = {
+			workCountMismatch: 0,
+			absenceCountMismatch: 1,
+			durationMismatchRecords: 2,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
 		reconcileLegacyToCanonical
-			.mockResolvedValueOnce({
-				workCountMismatch: 1,
-				absenceCountMismatch: 0,
-				durationMismatchRecords: 0,
-				missingWorkCanonicalRecords: 0,
-				missingAbsenceCanonicalRecords: 0,
-				missingWorkDetailRows: 0,
-				missingAbsenceDetailRows: 0,
-				missingProjectAllocationRows: 0,
-				approvalStateMismatchRecords: 0,
-				missingAbsenceCanonicalLinks: 0,
-				missingAbsenceOrganizationIds: 0,
-			})
-			.mockResolvedValueOnce({
-				workCountMismatch: 1,
-				absenceCountMismatch: 0,
-				durationMismatchRecords: 0,
-				missingWorkCanonicalRecords: 0,
-				missingAbsenceCanonicalRecords: 0,
-				missingWorkDetailRows: 0,
-				missingAbsenceDetailRows: 0,
-				missingProjectAllocationRows: 0,
-				approvalStateMismatchRecords: 0,
-				missingAbsenceCanonicalLinks: 0,
-				missingAbsenceOrganizationIds: 0,
-			});
+			.mockResolvedValueOnce(initialReconciliation)
+			.mockResolvedValueOnce(finalReconciliation);
 
 		await expect(assertCanonicalCutoverReady("org-1")).rejects.toMatchObject({
 			name: "CanonicalCutoverNotReadyError",
 			organizationId: "org-1",
+			reconciliation: finalReconciliation,
 			message:
 				"Canonical time-record backfill is incomplete for organization org-1",
 		});

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.ts
@@ -1,17 +1,23 @@
 import { eq } from "drizzle-orm";
 import { db, employee } from "@/db";
 import { runCanonicalBackfill } from "./backfill";
+import type { LegacyCanonicalReconciliation } from "./reconciliation";
 import { reconcileLegacyToCanonical } from "./reconciliation";
 
 export class CanonicalCutoverNotReadyError extends Error {
 	readonly organizationId: string;
+	readonly reconciliation: LegacyCanonicalReconciliation;
 
-	constructor(organizationId: string) {
+	constructor(
+		organizationId: string,
+		reconciliation: LegacyCanonicalReconciliation,
+	) {
 		super(
 			`Canonical time-record backfill is incomplete for organization ${organizationId}`,
 		);
 		this.name = "CanonicalCutoverNotReadyError";
 		this.organizationId = organizationId;
+		this.reconciliation = reconciliation;
 	}
 }
 
@@ -37,7 +43,7 @@ export async function assertCanonicalCutoverReady(organizationId: string) {
 	}
 
 	if (hasReconciliationMismatch(reconciliation)) {
-		throw new CanonicalCutoverNotReadyError(organizationId);
+		throw new CanonicalCutoverNotReadyError(organizationId, reconciliation);
 	}
 }
 


### PR DESCRIPTION
## Summary
- retain final post-repair canonical reconciliation counters on payroll readiness errors
- include organization-scoped aggregate diagnostics in server-logged conflict details
- verify conflict details are omitted from the browser response

## Test Plan
- [x] `pnpm --filter webapp exec vitest run src/lib/effect/result.test.ts src/lib/time-record/migration/__tests__/reconciliation.test.ts src/lib/time-record/migration/cutover-state.test.ts src/lib/payroll-workspace/summary.cutover.test.ts 'src/app/[locale]/(app)/payroll/action-errors.test.ts' 'src/app/[locale]/(app)/payroll/actions.test.ts' 'src/app/[locale]/(app)/payroll/payroll-failure-state.test.tsx'`\n- [x] `pnpm --filter webapp exec ultracite check ...`\n- [ ] `pnpm --filter webapp typecheck` (blocked by pre-existing missing generated `@/data/licenses.json`)\n