### PR TITLE
Log cutover reconciliation details for payroll

### DIFF
--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.ts
@@ -12,8 +12,21 @@ const t = (_key: string, fallback: string) => fallback;
 
 describe("mapPayrollWorkspaceActionError", () => {
 	it("classifies incomplete canonical payroll data as a conflict", () => {
+		const reconciliation = {
+			workCountMismatch: 0,
+			absenceCountMismatch: 0,
+			durationMismatchRecords: 0,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
 		const result = mapPayrollWorkspaceActionError(
-			new CanonicalCutoverNotReadyError("org-1"),
+			new CanonicalCutoverNotReadyError("org-1", reconciliation),
 			t,
 		);
 
@@ -21,7 +34,9 @@ describe("mapPayrollWorkspaceActionError", () => {
 			_tag: "ConflictError",
 			conflictType: "canonical_payroll_data_not_ready",
 			message: "Payroll data is temporarily unavailable",
+			details: { organizationId: "org-1", reconciliation },
 		});
+		expect(result.details).toEqual({ organizationId: "org-1", reconciliation });
 		expect(result._tag).not.toBe("ValidationError");
 	});
 

--- a/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
+++ b/apps/webapp/src/app/[locale]/(app)/payroll/action-errors.ts
@@ -25,6 +25,10 @@ export function mapPayrollWorkspaceActionError(
 				"Payroll data is temporarily unavailable",
 			),
 			conflictType: "canonical_payroll_data_not_ready",
+			details: {
+				organizationId: error.organizationId,
+				reconciliation: error.reconciliation,
+			},
 		});
 	}
 

--- a/apps/webapp/src/lib/effect/result.test.ts
+++ b/apps/webapp/src/lib/effect/result.test.ts
@@ -1,0 +1,38 @@
+import { Exit } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConflictError } from "./errors";
+import { toServerActionResult } from "./result";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("toServerActionResult", () => {
+	it("logs payroll conflict diagnostics without exposing them to the client", () => {
+		const error = new ConflictError({
+			message: "Payroll data is temporarily unavailable",
+			conflictType: "canonical_payroll_data_not_ready",
+			details: {
+				organizationId: "org-1",
+				reconciliation: {
+					workCountMismatch: 2,
+					absenceCountMismatch: 1,
+					durationMismatchRecords: 3,
+				},
+			},
+		});
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+
+		const result = toServerActionResult(Exit.fail(error));
+
+		expect(consoleError).toHaveBeenCalledWith("[ServerAction Error]", error);
+		expect(result).toEqual({
+			success: false,
+			error: "Payroll data is temporarily unavailable",
+			code: "ConflictError",
+		});
+		expect(result).not.toHaveProperty("details");
+	});
+});

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.test.ts
@@ -72,37 +72,40 @@ describe("assertCanonicalCutoverReady", () => {
 
 	it("throws when repair backfill still leaves canonical mismatches", async () => {
 		findFirstEmployee.mockResolvedValue({ userId: "user-1" });
+		const initialReconciliation = {
+			workCountMismatch: 1,
+			absenceCountMismatch: 0,
+			durationMismatchRecords: 0,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
+		const finalReconciliation = {
+			workCountMismatch: 0,
+			absenceCountMismatch: 1,
+			durationMismatchRecords: 2,
+			missingWorkCanonicalRecords: 0,
+			missingAbsenceCanonicalRecords: 0,
+			missingWorkDetailRows: 0,
+			missingAbsenceDetailRows: 0,
+			missingProjectAllocationRows: 0,
+			approvalStateMismatchRecords: 0,
+			missingAbsenceCanonicalLinks: 0,
+			missingAbsenceOrganizationIds: 0,
+		};
 		reconcileLegacyToCanonical
-			.mockResolvedValueOnce({
-				workCountMismatch: 1,
-				absenceCountMismatch: 0,
-				durationMismatchRecords: 0,
-				missingWorkCanonicalRecords: 0,
-				missingAbsenceCanonicalRecords: 0,
-				missingWorkDetailRows: 0,
-				missingAbsenceDetailRows: 0,
-				missingProjectAllocationRows: 0,
-				approvalStateMismatchRecords: 0,
-				missingAbsenceCanonicalLinks: 0,
-				missingAbsenceOrganizationIds: 0,
-			})
-			.mockResolvedValueOnce({
-				workCountMismatch: 1,
-				absenceCountMismatch: 0,
-				durationMismatchRecords: 0,
-				missingWorkCanonicalRecords: 0,
-				missingAbsenceCanonicalRecords: 0,
-				missingWorkDetailRows: 0,
-				missingAbsenceDetailRows: 0,
-				missingProjectAllocationRows: 0,
-				approvalStateMismatchRecords: 0,
-				missingAbsenceCanonicalLinks: 0,
-				missingAbsenceOrganizationIds: 0,
-			});
+			.mockResolvedValueOnce(initialReconciliation)
+			.mockResolvedValueOnce(finalReconciliation);
 
 		await expect(assertCanonicalCutoverReady("org-1")).rejects.toMatchObject({
 			name: "CanonicalCutoverNotReadyError",
 			organizationId: "org-1",
+			reconciliation: finalReconciliation,
 			message:
 				"Canonical time-record backfill is incomplete for organization org-1",
 		});

--- a/apps/webapp/src/lib/time-record/migration/cutover-state.ts
+++ b/apps/webapp/src/lib/time-record/migration/cutover-state.ts
@@ -1,17 +1,23 @@
 import { eq } from "drizzle-orm";
 import { db, employee } from "@/db";
 import { runCanonicalBackfill } from "./backfill";
+import type { LegacyCanonicalReconciliation } from "./reconciliation";
 import { reconcileLegacyToCanonical } from "./reconciliation";
 
 export class CanonicalCutoverNotReadyError extends Error {
 	readonly organizationId: string;
+	readonly reconciliation: LegacyCanonicalReconciliation;
 
-	constructor(organizationId: string) {
+	constructor(
+		organizationId: string,
+		reconciliation: LegacyCanonicalReconciliation,
+	) {
 		super(
 			`Canonical time-record backfill is incomplete for organization ${organizationId}`,
 		);
 		this.name = "CanonicalCutoverNotReadyError";
 		this.organizationId = organizationId;
+		this.reconciliation = reconciliation;
 	}
 }
 
@@ -37,7 +43,7 @@ export async function assertCanonicalCutoverReady(organizationId: string) {
 	}
 
 	if (hasReconciliationMismatch(reconciliation)) {
-		throw new CanonicalCutoverNotReadyError(organizationId);
+		throw new CanonicalCutoverNotReadyError(organizationId, reconciliation);
 	}
 }
 


### PR DESCRIPTION
This pull request enhances payroll error handling by including detailed reconciliation diagnostics when canonical payroll data is not ready, and ensures these details are logged server-side but not exposed to clients. It also refactors and improves related tests for clarity and accuracy.

**Payroll error handling improvements:**
- The `CanonicalCutoverNotReadyError` class now includes a `reconciliation` property with detailed diagnostics, and its constructor and usages are updated accordingly. [[1]](diffhunk://#diff-b2a9dc60a6614ada10ef4e4724702777618d691f1d3d1ad2003b33c7a2bc355dR4-R20) [[2]](diffhunk://#diff-b2a9dc60a6614ada10ef4e4724702777618d691f1d3d1ad2003b33c7a2bc355dL40-R46)
- The `mapPayrollWorkspaceActionError` function now attaches both `organizationId` and `reconciliation` details to the error result for improved diagnostics. ([apps/webapp/src/app/[locale]/(app)/payroll/action-errors.tsR28-R31](diffhunk://#diff-eaab4686f4040732aeaa172d4fed11c5e47564b6450e25712bb7bf1f20ddcc73R28-R31))
- The `toServerActionResult` function is tested to ensure payroll conflict diagnostics are logged (using `console.error`) but not sent to the client in error responses.

**Test refactoring and improvements:**
- Tests for payroll action errors and canonical cutover readiness are updated to use and validate the new `reconciliation` details, improving coverage and clarity. ([apps/webapp/src/app/[locale]/(app)/payroll/action-errors.test.tsR15-R39](diffhunk://#diff-0a8491ce7976fd0bc3ace2a7b3f6f8d403048f69142f589a91b9d2baa2ecb8ddR15-R39), [[1]](diffhunk://#diff-84246f1f2917d2aeb01baf0f1fd9e3dc6511e22966c112cbe96e47223c05ba19L75-R75) [[2]](diffhunk://#diff-84246f1f2917d2aeb01baf0f1fd9e3dc6511e22966c112cbe96e47223c05ba19L88-R91) [[3]](diffhunk://#diff-84246f1f2917d2aeb01baf0f1fd9e3dc6511e22966c112cbe96e47223c05ba19L101-R108)