### PR TITLE
Repair canonical duration drift in payroll

### DIFF
--- a/apps/webapp/src/lib/time-record/migration/__tests__/backfill.test.ts
+++ b/apps/webapp/src/lib/time-record/migration/__tests__/backfill.test.ts
@@ -1,8 +1,16 @@
+import { sql } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => ({
-	insertValues: vi.fn(),
+	timeRecordTable: {
+		id: "time-record-id",
+		organizationId: "time-record-organization-id",
+	},
+	timeRecordInsertValues: vi.fn(),
+	detailInsertValues: vi.fn(),
+	timeRecordOnConflictDoNothing: vi.fn(),
 	onConflictDoNothing: vi.fn(),
+	onConflictDoUpdate: vi.fn(),
 	updateSet: vi.fn(),
 	updateWhere: vi.fn(),
 	deleteWhere: vi.fn(),
@@ -40,9 +48,7 @@ vi.mock("@/db", () => ({
 	approvalRequest: {
 		id: "approval-request-id",
 	},
-	timeRecord: {
-		id: "time-record-id",
-	},
+	timeRecord: mockState.timeRecordTable,
 	timeRecordAbsence: {
 		recordId: "time-record-absence-record-id",
 	},
@@ -74,11 +80,22 @@ describe("canonical backfill period normalization", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 
+		mockState.timeRecordOnConflictDoNothing.mockResolvedValue(undefined);
 		mockState.onConflictDoNothing.mockResolvedValue(undefined);
-		mockState.insertValues.mockReturnValue({
+		mockState.onConflictDoUpdate.mockResolvedValue(undefined);
+		mockState.timeRecordInsertValues.mockReturnValue({
+			onConflictDoNothing: mockState.timeRecordOnConflictDoNothing,
+			onConflictDoUpdate: mockState.onConflictDoUpdate,
+		});
+		mockState.detailInsertValues.mockReturnValue({
 			onConflictDoNothing: mockState.onConflictDoNothing,
 		});
-		mockState.dbInsert.mockReturnValue({ values: mockState.insertValues });
+		mockState.dbInsert.mockImplementation((table) => ({
+			values:
+				table === mockState.timeRecordTable
+					? mockState.timeRecordInsertValues
+					: mockState.detailInsertValues,
+		}));
 
 		mockState.updateWhere.mockResolvedValue(undefined);
 		mockState.updateSet.mockReturnValue({ where: mockState.updateWhere });
@@ -292,7 +309,61 @@ describe("canonical backfill period normalization", () => {
 			2,
 			expect.objectContaining({ canonicalRecordId: "absence-1", organizationId: "org-1" }),
 		);
-		expect(mockState.onConflictDoNothing).toHaveBeenCalledTimes(3);
+		expect(mockState.onConflictDoNothing).toHaveBeenCalledTimes(2);
+		expect(mockState.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+	});
+
+	it("upserts canonical time records by id and organization with reconciled fields only", async () => {
+		await runCanonicalBackfill({
+			organizationId: "org-1",
+			actorId: "actor-1",
+			legacy: {
+				workPeriods: [
+					{
+						id: "work-1",
+						organizationId: "org-1",
+						employeeId: "employee-1",
+						startTime: new Date("2026-01-15T08:00:00.000Z"),
+						endTime: new Date("2026-01-15T16:00:00.000Z"),
+						durationMinutes: 480,
+						approvalStatus: "approved",
+						projectId: null,
+						workCategoryId: null,
+						workLocationType: "office",
+						createdAt: new Date("2026-01-10T00:00:00.000Z"),
+						updatedAt: new Date("2026-01-10T00:00:00.000Z"),
+					},
+				],
+				absenceEntries: [],
+				approvalRequests: [],
+				absenceCategories: [],
+			},
+		});
+
+		expect(mockState.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+		expect(mockState.onConflictDoUpdate).toHaveBeenCalledWith({
+			target: ["time-record-id", "time-record-organization-id"],
+			set: {
+				durationMinutes: sql.raw("excluded.duration_minutes"),
+				approvalState: sql.raw("excluded.approval_state"),
+			},
+		});
+	});
+
+	it("skips canonical inserts and conflict updates for an empty payload", async () => {
+		await runCanonicalBackfill({
+			organizationId: "org-1",
+			actorId: "actor-1",
+			legacy: {
+				workPeriods: [],
+				absenceEntries: [],
+				approvalRequests: [],
+				absenceCategories: [],
+			},
+		});
+
+		expect(mockState.onConflictDoUpdate).not.toHaveBeenCalled();
+		expect(mockState.dbInsert).not.toHaveBeenCalled();
 	});
 
 	it("returns the generated payload after executing idempotent writes", async () => {

--- a/apps/webapp/src/lib/time-record/migration/backfill.ts
+++ b/apps/webapp/src/lib/time-record/migration/backfill.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, isNull } from "drizzle-orm";
+import { eq, inArray, isNull, sql } from "drizzle-orm";
 import { DateTime } from "luxon";
 
 import {
@@ -20,6 +20,7 @@ type LegacyApprovalStatus = "pending" | "approved" | "rejected";
 type CanonicalDayPeriod = "full_day" | "am" | "pm";
 type LegacyDayPeriod = CanonicalDayPeriod | "morning" | "afternoon";
 type LegacyEntityType = "time_entry" | "absence_entry";
+type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 export type LegacyWorkPeriod = {
 	id: string;
@@ -315,7 +316,7 @@ export async function runCanonicalBackfill(
 	const payload = buildCanonicalBackfillPayload(resolvedInput);
 
 	await db.transaction(async (tx) => {
-		await insertIfPresent(tx, timeRecord, payload.timeRecords);
+		await upsertCanonicalTimeRecords(tx, payload.timeRecords);
 		await insertIfPresent(tx, timeRecordWork, payload.timeRecordWork);
 		await insertIfPresent(tx, timeRecordAbsence, payload.timeRecordAbsence);
 
@@ -431,6 +432,26 @@ async function loadCanonicalBackfillInput(
 			absenceCategories,
 		},
 	};
+}
+
+async function upsertCanonicalTimeRecords(
+	tx: Transaction,
+	values: CanonicalBackfillPayload["timeRecords"],
+) {
+	if (values.length === 0) {
+		return;
+	}
+
+	await tx
+		.insert(timeRecord)
+		.values(values)
+		.onConflictDoUpdate({
+			target: [timeRecord.id, timeRecord.organizationId],
+			set: {
+				durationMinutes: sql.raw("excluded.duration_minutes"),
+				approvalState: sql.raw("excluded.approval_state"),
+			},
+		});
 }
 
 async function insertIfPresent<TTable, TValue>(


### PR DESCRIPTION
This pull request refactors the canonical backfill logic for time records to ensure idempotent upserts and improve test coverage. The main change is replacing simple inserts with an upsert operation for canonical time records, updating only specific fields on conflict. The test suite is also updated to reflect and verify this new upsert behavior.

**Backfill Logic Improvements:**

* Introduced an `upsertCanonicalTimeRecords` function in `backfill.ts` that performs an upsert on the `timeRecord` table, updating only `durationMinutes` and `approvalState` when a conflict on `id` and `organizationId` occurs. [[1]](diffhunk://#diff-f2c898599be55c0f84de832b13ba6745bd71c22062753d5c6f310997814c369cR437-R456) [[2]](diffhunk://#diff-f2c898599be55c0f84de832b13ba6745bd71c22062753d5c6f310997814c369cL318-R319)
* Updated `runCanonicalBackfill` to use the new upsert function instead of a plain insert for time records.

**Test Suite Updates:**

* Refactored test mocks to support upsert logic, including new mocks for `onConflictDoUpdate` and `timeRecordInsertValues`. [[1]](diffhunk://#diff-dc9071154b209cb3671e031f8ab72bb834bb424e16dccc586f17c6498ae52cd4R1-R13) [[2]](diffhunk://#diff-dc9071154b209cb3671e031f8ab72bb834bb424e16dccc586f17c6498ae52cd4L43-R51) [[3]](diffhunk://#diff-dc9071154b209cb3671e031f8ab72bb834bb424e16dccc586f17c6498ae52cd4R83-R98)
* Added tests to verify that upserts are performed with the correct fields and that no upserts or inserts occur for empty payloads.

**Other Minor Changes:**

* Added the `sql` import where needed for raw SQL expressions.
* Added a `Transaction` type alias for better type clarity in transaction functions.