### PR TITLE
Make payroll blockers actionable

### DIFF
--- a/apps/webapp/messages/payroll/de.json
+++ b/apps/webapp/messages/payroll/de.json
@@ -11,7 +11,14 @@
       "triggerExport": "Export auslösen"
     },
     "blockers": {
-      "needReview": "{count} Lohnabrechnungsblocker müssen überprüft werden"
+      "dateUnavailable": "Datum nicht verfügbar",
+      "missingClockOut": "Fehlende Ausstempelung",
+      "needReview": "{count} Lohnabrechnungsblocker müssen überprüft werden",
+      "openApprovals": "Genehmigungen öffnen",
+      "openCalendar": "Kalender öffnen",
+      "pendingAbsence": "Ausstehender Abwesenheitsantrag",
+      "pendingTimeCorrection": "Ausstehende Zeitkorrektur",
+      "unknownEmployee": "Unbekannter Mitarbeiter"
     },
     "description": "Überprüfen Sie die Lohnabrechnungssummen, die Bereitschaft und die Exporte für den ausgewählten Zeitraum.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/el.json
+++ b/apps/webapp/messages/payroll/el.json
@@ -11,7 +11,14 @@
       "triggerExport": "Ενεργοποίηση εξαγωγής"
     },
     "blockers": {
-      "needReview": "{count} εμπόδια μισθοδοσίας χρειάζονται έλεγχο"
+      "dateUnavailable": "Η ημερομηνία δεν είναι διαθέσιμη",
+      "missingClockOut": "Λείπει η καταγραφή εξόδου",
+      "needReview": "{count} εμπόδια μισθοδοσίας χρειάζονται έλεγχο",
+      "openApprovals": "Άνοιγμα εγκρίσεων",
+      "openCalendar": "Άνοιγμα ημερολογίου",
+      "pendingAbsence": "Εκκρεμής απουσία",
+      "pendingTimeCorrection": "Εκκρεμής διόρθωση χρόνου",
+      "unknownEmployee": "Άγνωστος εργαζόμενος"
     },
     "description": "Ελέγξτε τα σύνολα μισθοδοσίας, την ετοιμότητα και τις εξαγωγές για την επιλεγμένη περίοδο.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/en.json
+++ b/apps/webapp/messages/payroll/en.json
@@ -11,7 +11,14 @@
       "triggerExport": "Trigger export"
     },
     "blockers": {
-      "needReview": "{count} payroll blockers need review"
+      "dateUnavailable": "Date unavailable",
+      "missingClockOut": "Missing clock-out",
+      "needReview": "{count} payroll blockers need review",
+      "openApprovals": "Open approvals",
+      "openCalendar": "Open calendar",
+      "pendingAbsence": "Pending absence",
+      "pendingTimeCorrection": "Pending time correction",
+      "unknownEmployee": "Unknown employee"
     },
     "description": "Review payroll totals, readiness, and exports for the selected period.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/es.json
+++ b/apps/webapp/messages/payroll/es.json
@@ -11,7 +11,14 @@
       "triggerExport": "Iniciar exportación"
     },
     "blockers": {
-      "needReview": "{count} bloqueos de nómina requieren revisión"
+      "dateUnavailable": "Fecha no disponible",
+      "missingClockOut": "Falta el fichaje de salida",
+      "needReview": "{count} bloqueos de nómina requieren revisión",
+      "openApprovals": "Abrir aprobaciones",
+      "openCalendar": "Abrir calendario",
+      "pendingAbsence": "Ausencia pendiente",
+      "pendingTimeCorrection": "Corrección de tiempo pendiente",
+      "unknownEmployee": "Empleado desconocido"
     },
     "description": "Revisa los totales de nómina, la preparación y las exportaciones para el periodo seleccionado.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/fr.json
+++ b/apps/webapp/messages/payroll/fr.json
@@ -11,7 +11,14 @@
       "triggerExport": "Déclencher l'exportation"
     },
     "blockers": {
-      "needReview": "{count} blocages de paie nécessitent une vérification"
+      "dateUnavailable": "Date indisponible",
+      "missingClockOut": "Pointage de sortie manquant",
+      "needReview": "{count} blocages de paie nécessitent une vérification",
+      "openApprovals": "Ouvrir les approbations",
+      "openCalendar": "Ouvrir le calendrier",
+      "pendingAbsence": "Absence en attente",
+      "pendingTimeCorrection": "Correction du temps en attente",
+      "unknownEmployee": "Employé inconnu"
     },
     "description": "Vérifiez les totaux de paie, l'état de préparation et les exportations pour la période sélectionnée.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/gsw.json
+++ b/apps/webapp/messages/payroll/gsw.json
@@ -11,7 +11,14 @@
       "triggerExport": "Export starte"
     },
     "blockers": {
-      "needReview": "{count} Lohnabrächnigshindernis bruched e Prüefig"
+      "dateUnavailable": "Datum nöd verfüegbar",
+      "missingClockOut": "Fählendi Uusstämplig",
+      "needReview": "{count} Lohnabrächnigshindernis bruched e Prüefig",
+      "openApprovals": "Genehmigunge öffne",
+      "openCalendar": "Kaländer öffne",
+      "pendingAbsence": "Uusstahendi Abweseheit",
+      "pendingTimeCorrection": "Uusstahendi Ziitkorrektur",
+      "unknownEmployee": "Unbekannte Aagstellte"
     },
     "description": "Prüef d Lohnsumme, d Bereitschaft und d Export für die gwählti Periode.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/it.json
+++ b/apps/webapp/messages/payroll/it.json
@@ -11,7 +11,14 @@
       "triggerExport": "Avvia esportazione"
     },
     "blockers": {
-      "needReview": "{count} blocchi delle buste paga richiedono una revisione"
+      "dateUnavailable": "Data non disponibile",
+      "missingClockOut": "Timbratura di uscita mancante",
+      "needReview": "{count} blocchi delle buste paga richiedono una revisione",
+      "openApprovals": "Apri approvazioni",
+      "openCalendar": "Apri calendario",
+      "pendingAbsence": "Assenza in attesa",
+      "pendingTimeCorrection": "Correzione oraria in attesa",
+      "unknownEmployee": "Dipendente sconosciuto"
     },
     "description": "Revisiona i totali delle buste paga, la preparazione e le esportazioni per il periodo selezionato.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/pl.json
+++ b/apps/webapp/messages/payroll/pl.json
@@ -11,7 +11,14 @@
       "triggerExport": "Uruchom eksport"
     },
     "blockers": {
-      "needReview": "{count, plural, one {# blokada płacowa wymaga sprawdzenia} few {# blokady płacowe wymagają sprawdzenia} other {# blokad płacowych wymaga sprawdzenia}}"
+      "dateUnavailable": "Data niedostępna",
+      "missingClockOut": "Brak odbicia wyjścia",
+      "needReview": "{count, plural, one {# blokada płacowa wymaga sprawdzenia} few {# blokady płacowe wymagają sprawdzenia} other {# blokad płacowych wymaga sprawdzenia}}",
+      "openApprovals": "Otwórz zatwierdzenia",
+      "openCalendar": "Otwórz kalendarz",
+      "pendingAbsence": "Oczekująca nieobecność",
+      "pendingTimeCorrection": "Oczekująca korekta czasu",
+      "unknownEmployee": "Nieznany pracownik"
     },
     "description": "Sprawdź sumy płac, gotowość i eksporty dla wybranego okresu.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/pt.json
+++ b/apps/webapp/messages/payroll/pt.json
@@ -11,7 +11,14 @@
       "triggerExport": "Acionar exportação"
     },
     "blockers": {
-      "needReview": "{count} bloqueios de folha de pagamento precisam de revisão"
+      "dateUnavailable": "Data indisponível",
+      "missingClockOut": "Registro de saída em falta",
+      "needReview": "{count} bloqueios de folha de pagamento precisam de revisão",
+      "openApprovals": "Abrir aprovações",
+      "openCalendar": "Abrir calendário",
+      "pendingAbsence": "Ausência pendente",
+      "pendingTimeCorrection": "Correção de horário pendente",
+      "unknownEmployee": "Funcionário desconhecido"
     },
     "description": "Revise os totais da folha de pagamento, prontidão e exportações para o período selecionado.",
     "employeeTotals": {

--- a/apps/webapp/messages/payroll/tr.json
+++ b/apps/webapp/messages/payroll/tr.json
@@ -11,7 +11,14 @@
       "triggerExport": "Dışa aktarmayı tetikle"
     },
     "blockers": {
-      "needReview": "{count} bordro engelinin gözden geçirilmesi gerekiyor"
+      "dateUnavailable": "Tarih kullanılamıyor",
+      "missingClockOut": "Eksik çıkış kaydı",
+      "needReview": "{count} bordro engelinin gözden geçirilmesi gerekiyor",
+      "openApprovals": "Onayları aç",
+      "openCalendar": "Takvimi aç",
+      "pendingAbsence": "Bekleyen izin",
+      "pendingTimeCorrection": "Bekleyen zaman düzeltmesi",
+      "unknownEmployee": "Bilinmeyen çalışan"
     },
     "description": "Seçilen dönem için bordro toplamlarını, hazırlık durumunu ve dışa aktarımları gözden geçirin.",
     "employeeTotals": {

--- a/apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../page", () => ({ CalendarPageContent: "CalendarPageContent" }));
+
+const { default: CalendarEmployeePage } = await import("./page");
+
+describe("CalendarEmployeePage", () => {
+	it("passes the raw requested date to the authorized employee calendar content", async () => {
+		const page = await CalendarEmployeePage({
+			params: Promise.resolve({ employeeId: "employee-1" }),
+			searchParams: Promise.resolve({ date: "06/12/2026" }),
+		});
+
+		expect(page.props.children.props).toMatchObject({
+			selectedEmployeeId: "employee-1",
+			requestedDate: "06/12/2026",
+		});
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.tsx
@@ -16,14 +16,19 @@ function CalendarPageLoading() {
 
 export default async function CalendarEmployeePage({
 	params,
+	searchParams,
 }: {
 	params: Promise<{ employeeId: string }>;
+	searchParams: Promise<{ date?: string }>;
 }) {
-	const { employeeId } = await params;
+	const [{ employeeId }, { date }] = await Promise.all([params, searchParams]);
 
 	return (
 		<Suspense fallback={<CalendarPageLoading />}>
-			<CalendarPageContent selectedEmployeeId={employeeId} />
+			<CalendarPageContent
+				requestedDate={date}
+				selectedEmployeeId={employeeId}
+			/>
 		</Suspense>
 	);
 }

--- a/apps/webapp/src/app/[locale]/(app)/calendar/page.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/calendar/page.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => ({
+	connection: vi.fn(),
+	getAuthContext: vi.fn(),
+	resolveAuthorizedCalendarEmployeeContext: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({ connection: mockState.connection }));
+vi.mock("@/lib/auth-helpers", () => ({
+	getAuthContext: mockState.getAuthContext,
+}));
+vi.mock("@/lib/calendar/calendar-employee-context", () => ({
+	resolveAuthorizedCalendarEmployeeContext:
+		mockState.resolveAuthorizedCalendarEmployeeContext,
+}));
+vi.mock("@/components/calendar/calendar-view", () => ({
+	CalendarView: "CalendarView",
+}));
+vi.mock("@/components/errors/no-employee-error", () => ({
+	NoEmployeeError: "NoEmployeeError",
+}));
+
+const { CalendarPageContent } = await import("./page");
+
+describe("CalendarPageContent initial date", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.getAuthContext.mockResolvedValue({
+			user: { id: "user-1", role: "user" },
+			employee: { id: "employee-current", organizationId: "org-1" },
+		});
+		mockState.resolveAuthorizedCalendarEmployeeContext.mockResolvedValue({
+			employeeId: "employee-selected",
+			timezone: "America/New_York",
+			initialDateKey: "2026-06-01",
+		});
+	});
+
+	it("uses a valid requested date after employee authorization", async () => {
+		const page = await CalendarPageContent({
+			selectedEmployeeId: "employee-selected",
+			requestedDate: "2026-06-12",
+		});
+
+		expect(
+			mockState.resolveAuthorizedCalendarEmployeeContext,
+		).toHaveBeenCalledTimes(1);
+		expect(page.props.initialDateKey).toBe("2026-06-12");
+	});
+
+	it("renders with the employee-local fallback for an invalid requested date", async () => {
+		const page = await CalendarPageContent({
+			selectedEmployeeId: "employee-selected",
+			requestedDate: "2026-02-30",
+		});
+
+		expect(page.props.initialDateKey).toBe("2026-06-01");
+	});
+
+	it("does not apply a requested date when employee authorization fails", async () => {
+		mockState.resolveAuthorizedCalendarEmployeeContext.mockResolvedValue(null);
+
+		const page = await CalendarPageContent({
+			selectedEmployeeId: "employee-unauthorized",
+			requestedDate: "2026-06-12",
+		});
+
+		expect(page.type).toBe("div");
+		expect(page.props.children.type).toBe("NoEmployeeError");
+	});
+});

--- a/apps/webapp/src/app/[locale]/(app)/calendar/page.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/calendar/page.tsx
@@ -5,11 +5,14 @@ import { NoEmployeeError } from "@/components/errors/no-employee-error";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getAuthContext } from "@/lib/auth-helpers";
 import { resolveAuthorizedCalendarEmployeeContext } from "@/lib/calendar/calendar-employee-context";
+import { resolveCalendarInitialDate } from "@/lib/calendar/initial-date";
 
 export async function CalendarPageContent({
 	selectedEmployeeId,
+	requestedDate,
 }: {
 	selectedEmployeeId?: string;
+	requestedDate?: string;
 } = {}) {
 	await connection(); // Mark as fully dynamic for cacheComponents mode
 
@@ -22,13 +25,14 @@ export async function CalendarPageContent({
 			</div>
 		);
 	}
-	const calendarEmployeeContext = await resolveAuthorizedCalendarEmployeeContext({
-		userId: authContext.user.id,
-		isPlatformAdmin: authContext.user.role === "admin",
-		organizationId: authContext.employee.organizationId,
-		currentEmployeeId: authContext.employee.id,
-		requestedEmployeeId: selectedEmployeeId,
-	});
+	const calendarEmployeeContext =
+		await resolveAuthorizedCalendarEmployeeContext({
+			userId: authContext.user.id,
+			isPlatformAdmin: authContext.user.role === "admin",
+			organizationId: authContext.employee.organizationId,
+			currentEmployeeId: authContext.employee.id,
+			requestedEmployeeId: selectedEmployeeId,
+		});
 
 	if (!calendarEmployeeContext) {
 		return (
@@ -43,7 +47,10 @@ export async function CalendarPageContent({
 			organizationId={authContext.employee.organizationId}
 			currentEmployeeId={authContext.employee.id}
 			initialSelectedEmployeeId={calendarEmployeeContext.employeeId}
-			initialDateKey={calendarEmployeeContext.initialDateKey}
+			initialDateKey={resolveCalendarInitialDate(
+				requestedDate,
+				calendarEmployeeContext.initialDateKey,
+			)}
 			initialTimezone={calendarEmployeeContext.timezone}
 		/>
 	);

--- a/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
@@ -12,6 +12,7 @@ const actionMocks = vi.hoisted(() => ({
 }));
 
 let translateOverrides: Record<string, string> = {};
+let activeLocale = "en";
 
 vi.mock("@tolgee/react", () => ({
 	useTranslate: () => ({
@@ -24,6 +25,9 @@ vi.mock("@tolgee/react", () => ({
 			);
 		},
 	}),
+}));
+vi.mock("next-intl", () => ({
+	useLocale: () => activeLocale,
 }));
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock("@/app/[locale]/(app)/payroll/actions", () => ({
@@ -67,12 +71,16 @@ const baseSummary: PayrollWorkspaceSummary = {
 			employeeId: "employee-1",
 			type: "missing_clock_out",
 			label: "Missing clock-out",
+			date: "2026-06-03",
+			time: "09:00",
 		},
 		{
 			id: "blocker-2",
 			employeeId: "employee-1",
 			type: "pending_absence",
 			label: "Pending absence approval",
+			date: "2026-06-04",
+			time: null,
 		},
 	],
 };
@@ -95,6 +103,7 @@ describe("PayrollWorkspace", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 		translateOverrides = {};
+		activeLocale = "en";
 		actionMocks.getPayrollWorkspaceSummaryAction.mockResolvedValue({
 			success: true,
 			data: summary,
@@ -166,6 +175,273 @@ describe("PayrollWorkspace", () => {
 		expect(screen.getByText("Missing clock-out")).toBeTruthy();
 		expect(screen.getByText("Download PDF")).toBeTruthy();
 		expect(screen.getByText("Trigger export")).toBeTruthy();
+	});
+
+	it("renders blocker exceptions with employee context and authorized workflow links", () => {
+		activeLocale = "de-DE";
+		translateOverrides = {
+			"payroll.blockers.missingClockOut": "Fehlende Ausstempelung",
+			"payroll.blockers.needReview": "{count} Lohnblocker prüfen",
+			"payroll.blockers.openApprovals": "Genehmigungen öffnen",
+			"payroll.blockers.openCalendar": "Kalender öffnen",
+			"payroll.blockers.pendingAbsence": "Ausstehende Abwesenheit",
+			"payroll.blockers.pendingTimeCorrection": "Ausstehende Zeitkorrektur",
+		};
+		const blockersSummary = buildSummary({
+			totals: { employeeCount: 2, totalWorkedHours: 8, blockerCount: 4 },
+			blockers: [
+				{
+					id: "missing-ada",
+					employeeId: "employee-1",
+					type: "missing_clock_out",
+					label: "Backend label must not be displayed",
+					date: "2026-06-03",
+					time: "09:00",
+				},
+				{
+					id: "missing-grace",
+					employeeId: "employee-2",
+					type: "missing_clock_out",
+					label: "Another backend label",
+					date: "2026-06-05",
+					time: "17:30",
+				},
+				{
+					id: "correction-ada",
+					employeeId: "employee-1",
+					type: "pending_time_correction",
+					label: "Correction backend label",
+					date: "2026-06-07",
+					time: "14:15",
+				},
+				{
+					id: "absence-grace",
+					employeeId: "employee-2",
+					type: "pending_absence",
+					label: "Absence backend label",
+					date: "2026-06-08",
+					time: null,
+				},
+			],
+		});
+
+		render(
+			<PayrollWorkspace
+				initialSummary={blockersSummary}
+				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
+			/>,
+		);
+
+		const blockersRegion = screen.getByRole("region", {
+			name: "4 Lohnblocker prüfen",
+		});
+		expect(screen.queryByRole("alert")).toBeNull();
+
+		const adaMissingRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="missing-ada"]',
+		);
+		expect(adaMissingRow).toBeTruthy();
+		expect(adaMissingRow?.className).toContain(
+			"lg:grid-cols-[minmax(0,1fr)_auto]",
+		);
+		expect(adaMissingRow?.className).not.toContain("sm:grid-cols");
+		expect(
+			within(adaMissingRow as HTMLElement).getByText("Ada Lovelace"),
+		).toBeTruthy();
+		expect(
+			within(adaMissingRow as HTMLElement).getByText("Fehlende Ausstempelung"),
+		).toBeTruthy();
+		expect(
+			within(adaMissingRow as HTMLElement).getByText("03.06.2026, 09:00"),
+		).toBeTruthy();
+		expect(
+			within(adaMissingRow as HTMLElement)
+				.getByRole("link", {
+					name: /Kalender öffnen.*Ada Lovelace.*Fehlende Ausstempelung.*03.06.2026, 09:00/,
+				})
+				.getAttribute("href"),
+		).toBe("/calendar/employee-1?date=2026-06-03");
+
+		const graceMissingRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="missing-grace"]',
+		);
+		expect(graceMissingRow).toBeTruthy();
+		expect(
+			within(graceMissingRow as HTMLElement).getByText("Grace Hopper"),
+		).toBeTruthy();
+		expect(
+			within(graceMissingRow as HTMLElement).getByText(
+				"Fehlende Ausstempelung",
+			),
+		).toBeTruthy();
+		expect(
+			within(graceMissingRow as HTMLElement).getByText("05.06.2026, 17:30"),
+		).toBeTruthy();
+		expect(
+			within(graceMissingRow as HTMLElement)
+				.getByRole("link", {
+					name: /Kalender öffnen.*Grace Hopper.*05.06.2026, 17:30/,
+				})
+				.getAttribute("href"),
+		).toBe("/calendar/employee-2?date=2026-06-05");
+
+		const correctionRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="correction-ada"]',
+		);
+		expect(correctionRow).toBeTruthy();
+		expect(
+			within(correctionRow as HTMLElement).getByText("Ada Lovelace"),
+		).toBeTruthy();
+		expect(
+			within(correctionRow as HTMLElement).getByText(
+				"Ausstehende Zeitkorrektur",
+			),
+		).toBeTruthy();
+		expect(
+			within(correctionRow as HTMLElement).getByText("07.06.2026, 14:15"),
+		).toBeTruthy();
+		expect(
+			within(correctionRow as HTMLElement)
+				.getByRole("link", {
+					name: /Genehmigungen öffnen.*Ada Lovelace.*07.06.2026, 14:15/,
+				})
+				.getAttribute("href"),
+		).toBe("/approvals/inbox?types=time_entry");
+
+		const absenceRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="absence-grace"]',
+		);
+		expect(absenceRow).toBeTruthy();
+		expect(
+			within(absenceRow as HTMLElement).getByText("Grace Hopper"),
+		).toBeTruthy();
+		expect(
+			within(absenceRow as HTMLElement).getByText("Ausstehende Abwesenheit"),
+		).toBeTruthy();
+		expect(
+			within(absenceRow as HTMLElement).getByText("08.06.2026"),
+		).toBeTruthy();
+		expect(
+			within(absenceRow as HTMLElement)
+				.getByRole("link", {
+					name: /Genehmigungen öffnen.*Grace Hopper.*08.06.2026/,
+				})
+				.getAttribute("href"),
+		).toBe("/approvals/inbox?types=absence_entry");
+
+		expect(
+			within(blockersRegion).queryByText("Backend label must not be displayed"),
+		).toBeNull();
+		expect(
+			within(blockersRegion).queryByText("Another backend label"),
+		).toBeNull();
+		expect(
+			within(blockersRegion).queryByText("Correction backend label"),
+		).toBeNull();
+		expect(
+			within(blockersRegion).queryByText("Absence backend label"),
+		).toBeNull();
+	});
+
+	it("falls back for an unscoped employee and an invalid blocker date", () => {
+		translateOverrides = {
+			"payroll.blockers.dateUnavailable": "Datum nicht verfügbar",
+			"payroll.blockers.missingClockOut": "Fehlende Ausstempelung",
+			"payroll.blockers.openCalendar": "Kalender öffnen",
+			"payroll.blockers.unknownEmployee": "Unbekannter Mitarbeiter",
+		};
+		const blockersSummary = buildSummary({
+			totals: { employeeCount: 2, totalWorkedHours: 8, blockerCount: 1 },
+			blockers: [
+				{
+					id: "missing-unknown",
+					employeeId: "employee-outside-scope",
+					type: "missing_clock_out",
+					label: "Backend label",
+					date: "2026-02-30",
+					time: null,
+				},
+			],
+		});
+
+		render(
+			<PayrollWorkspace
+				initialSummary={blockersSummary}
+				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
+			/>,
+		);
+
+		const blockersRegion = screen.getByRole("region", {
+			name: "1 payroll blockers need review",
+		});
+		const blockerRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="missing-unknown"]',
+		);
+		expect(blockerRow).toBeTruthy();
+		expect(
+			within(blockerRow as HTMLElement).getByText("Unbekannter Mitarbeiter"),
+		).toBeTruthy();
+		expect(
+			within(blockerRow as HTMLElement).getByText("Fehlende Ausstempelung"),
+		).toBeTruthy();
+		expect(
+			within(blockerRow as HTMLElement).getByText("Datum nicht verfügbar"),
+		).toBeTruthy();
+		expect(
+			within(blockerRow as HTMLElement).queryByText("Backend label"),
+		).toBeNull();
+		expect(
+			within(blockerRow as HTMLElement)
+				.getByRole("link", {
+					name: /Kalender öffnen.*Unbekannter Mitarbeiter.*Fehlende Ausstempelung.*Datum nicht verfügbar/,
+				})
+				.getAttribute("href"),
+		).toBe("/calendar/employee-outside-scope");
+	});
+
+	it("hides an employee ID used as the blocker employee name", () => {
+		const employeeId = "550e8400-e29b-41d4-a716-446655440000";
+		translateOverrides = {
+			"payroll.blockers.unknownEmployee": "Unbekannter Mitarbeiter",
+		};
+		const blockersSummary = buildSummary({
+			employees: [
+				{
+					...baseSummary.employees[0],
+					id: employeeId,
+					name: employeeId,
+				},
+			],
+			blockers: [
+				{
+					id: "uuid-name-blocker",
+					employeeId,
+					type: "missing_clock_out",
+					label: "Backend label",
+					date: "2026-06-09",
+					time: "08:00",
+				},
+			],
+		});
+
+		render(
+			<PayrollWorkspace
+				initialSummary={blockersSummary}
+				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
+			/>,
+		);
+
+		const blockersRegion = screen.getByRole("region", {
+			name: "1 payroll blockers need review",
+		});
+		const blockerRow = blockersRegion.querySelector(
+			'[data-payroll-blocker-id="uuid-name-blocker"]',
+		);
+		expect(blockerRow).toBeTruthy();
+		expect(
+			within(blockerRow as HTMLElement).getByText("Unbekannter Mitarbeiter"),
+		).toBeTruthy();
+		expect(blockerRow?.textContent).not.toContain(employeeId);
 	});
 
 	it("keeps payroll period controls on aligned grid rails", () => {

--- a/apps/webapp/src/components/payroll/payroll-workspace.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.tsx
@@ -13,6 +13,8 @@ import {
 } from "@tabler/icons-react";
 import { useTranslate } from "@tolgee/react";
 import { DateTime } from "luxon";
+import Link from "next/link";
+import { useLocale } from "next-intl";
 import type React from "react";
 import { useReducer, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -22,7 +24,6 @@ import {
 	type PayrollExportFormatOption,
 	startScopedPayrollExportAction,
 } from "@/app/[locale]/(app)/payroll/actions";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -384,7 +385,11 @@ export function PayrollWorkspace({ initialSummary, exportFormats }: PayrollWorks
 				t={t}
 			/>
 
-			<PayrollBlockersAlert blockers={displayedBlockers} t={t} />
+			<PayrollBlockersAlert
+				blockers={displayedBlockers}
+				employees={displayedEmployees}
+				t={t}
+			/>
 			<EmployeeTotalsCard employees={displayedEmployees} t={t} />
 		</div>
 	);
@@ -988,30 +993,163 @@ function getPayrollScopeSummary({
 
 function PayrollBlockersAlert({
 	blockers,
+	employees,
 	t,
 }: {
 	blockers: PayrollWorkspaceSummary["blockers"];
+	employees: PayrollWorkspaceSummary["employees"];
 	t: PayrollTranslate;
 }) {
+	const locale = useLocale();
 	if (blockers.length === 0) return null;
+	const employeeNames = new Map(
+		employees.map((employee) => [employee.id, employee.name]),
+	);
+	const title = t(
+		"payroll.blockers.needReview",
+		"{count} payroll blockers need review",
+		{
+			count: blockers.length,
+		},
+	);
 
 	return (
-		<Alert className="border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100">
-			<IconAlertTriangle aria-hidden="true" className="size-4" />
-			<AlertTitle>
-				{t("payroll.blockers.needReview", "{count} payroll blockers need review", {
-					count: blockers.length,
+		<section
+			aria-labelledby="payroll-blockers-title"
+			className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 text-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+		>
+			<header className="flex items-start gap-3">
+				<IconAlertTriangle
+					aria-hidden="true"
+					className="mt-0.5 size-4 shrink-0"
+				/>
+				<h2 className="font-medium leading-none" id="payroll-blockers-title">
+					{title}
+				</h2>
+			</header>
+			<ul className="mt-3 grid gap-2">
+				{blockers.map((blocker) => {
+					const summaryEmployeeName = employeeNames.get(blocker.employeeId);
+					const employeeName =
+						summaryEmployeeName && summaryEmployeeName !== blocker.employeeId
+							? summaryEmployeeName
+							: t("payroll.blockers.unknownEmployee", "Unknown employee");
+					const formattedDate = formatPayrollBlockerDate(blocker.date, locale);
+					const metadata = formattedDate
+						? [formattedDate, blocker.time].filter(Boolean).join(", ")
+						: t("payroll.blockers.dateUnavailable", "Date unavailable");
+					let blockerType: string;
+					let actionLabel: string;
+					let href: string;
+
+					switch (blocker.type) {
+						case "missing_clock_out":
+							blockerType = t(
+								"payroll.blockers.missingClockOut",
+								"Missing clock-out",
+							);
+							actionLabel = t("payroll.blockers.openCalendar", "Open calendar");
+							href = `/calendar/${encodeURIComponent(blocker.employeeId)}${
+								formattedDate && blocker.date
+									? `?date=${encodeURIComponent(blocker.date)}`
+									: ""
+							}`;
+							break;
+						case "pending_time_correction":
+							blockerType = t(
+								"payroll.blockers.pendingTimeCorrection",
+								"Pending time correction",
+							);
+							actionLabel = t(
+								"payroll.blockers.openApprovals",
+								"Open approvals",
+							);
+							href = "/approvals/inbox?types=time_entry";
+							break;
+						case "pending_absence":
+							blockerType = t(
+								"payroll.blockers.pendingAbsence",
+								"Pending absence",
+							);
+							actionLabel = t(
+								"payroll.blockers.openApprovals",
+								"Open approvals",
+							);
+							href = "/approvals/inbox?types=absence_entry";
+							break;
+					}
+
+					return (
+						<li
+							className="grid min-w-0 gap-2 rounded-md border bg-background px-3 py-2 text-foreground lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-4"
+							data-payroll-blocker-id={blocker.id}
+							key={blocker.id}
+						>
+							<div className="grid min-w-0 gap-1 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)_minmax(0,auto)] lg:items-center lg:gap-4">
+								<span className="min-w-0 break-words font-medium">
+									{employeeName}
+								</span>
+								<span className="min-w-0 break-words">{blockerType}</span>
+								{formattedDate && blocker.date ? (
+									<time
+										className="min-w-0 text-muted-foreground text-xs tabular-nums"
+										dateTime={`${blocker.date}${blocker.time ? `T${blocker.time}` : ""}`}
+									>
+										{metadata}
+									</time>
+								) : (
+									<span className="text-muted-foreground text-xs">
+										{metadata}
+									</span>
+								)}
+							</div>
+							<Button
+								asChild
+								className="w-full lg:w-auto"
+								size="sm"
+								variant="outline"
+							>
+								<Link
+									aria-label={`${actionLabel}: ${employeeName}, ${blockerType}, ${metadata}`}
+									href={href}
+								>
+									{actionLabel}
+								</Link>
+							</Button>
+						</li>
+					);
 				})}
-			</AlertTitle>
-			<AlertDescription>
-				<ul className="mt-2 grid gap-1">
-					{blockers.map((blocker) => (
-						<li key={blocker.id}>{blocker.label}</li>
-					))}
-				</ul>
-			</AlertDescription>
-		</Alert>
+			</ul>
+		</section>
 	);
+}
+
+function formatPayrollBlockerDate(
+	date: string | null,
+	locale: string,
+): string | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date ?? "");
+	if (!match) return null;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const bridgeDate = new Date(0);
+	bridgeDate.setUTCFullYear(year, month - 1, day);
+	bridgeDate.setUTCHours(0, 0, 0, 0);
+
+	if (
+		bridgeDate.getUTCFullYear() !== year ||
+		bridgeDate.getUTCMonth() !== month - 1 ||
+		bridgeDate.getUTCDate() !== day
+	) {
+		return null;
+	}
+
+	return Intl.DateTimeFormat(locale, {
+		dateStyle: "medium",
+		timeZone: "UTC",
+	}).format(bridgeDate);
 }
 
 function EmployeeTotalsCard({

--- a/apps/webapp/src/lib/calendar/initial-date.test.ts
+++ b/apps/webapp/src/lib/calendar/initial-date.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveCalendarInitialDate } from "./initial-date";
+
+describe("resolveCalendarInitialDate", () => {
+	it("accepts a valid strict calendar date", () => {
+		expect(resolveCalendarInitialDate("2026-06-12", "2026-06-01")).toBe(
+			"2026-06-12",
+		);
+	});
+
+	it.each([undefined, "", "2026-02-30", "06/12/2026"])(
+		"falls back for invalid requested date %s",
+		(requestedDate) => {
+			expect(resolveCalendarInitialDate(requestedDate, "2026-06-01")).toBe(
+				"2026-06-01",
+			);
+		},
+	);
+});

--- a/apps/webapp/src/lib/calendar/initial-date.ts
+++ b/apps/webapp/src/lib/calendar/initial-date.ts
@@ -1,0 +1,16 @@
+import { parsePlainDate } from "@/lib/datetime/temporal-core";
+
+export function resolveCalendarInitialDate(
+	requestedDate: string | undefined,
+	fallbackDate: string,
+): string {
+	if (!requestedDate) {
+		return fallbackDate;
+	}
+
+	try {
+		return parsePlainDate(requestedDate).toString();
+	} catch {
+		return fallbackDate;
+	}
+}

--- a/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
+++ b/apps/webapp/src/lib/payroll-workspace/pdf-exporter.test.tsx
@@ -58,6 +58,8 @@ const summary: PayrollWorkspaceSummary = {
 			employeeId: "employee-1",
 			type: "missing_clock_out",
 			label: "Missing clock-out",
+			date: "2026-06-03",
+			time: "09:00",
 		},
 	],
 };

--- a/apps/webapp/src/lib/payroll-workspace/summary.test.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.test.ts
@@ -2,6 +2,7 @@ import { DateTime } from "luxon";
 import { describe, expect, it } from "vitest";
 import {
 	buildPayrollSummaryFromRows,
+	buildPendingAbsenceBlockers,
 	calculatePayrollWorkedMinutes,
 	filterMissingClockOutBlockers,
 	filterPendingTimeApprovalBlockers,
@@ -286,6 +287,8 @@ describe("buildPayrollSummaryFromRows", () => {
 					employeeId: "employee-1",
 					type: "missing_clock_out",
 					label: "Missing clock-out",
+					date: "2026-06-10",
+					time: "09:00",
 				},
 			],
 		});
@@ -347,6 +350,64 @@ describe("calculatePayrollWorkedMinutes", () => {
 });
 
 describe("filterPendingTimeApprovalBlockers", () => {
+	it("uses the employee timezone to localize the correction start", () => {
+		const blockers = filterPendingTimeApprovalBlockers({
+			organizationId: "org-1",
+			allowedEmployeeIds: ["employee-1"],
+			period: {
+				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
+				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
+			},
+			timezoneByEmployeeId: new Map([["employee-1", "America/New_York"]]),
+			rows: [
+				{
+					id: "approval-1",
+					organizationId: "org-1",
+					requestedBy: "employee-1",
+					status: "pending",
+					entityType: "time_entry",
+					canonicalRecordId: "record-1",
+					recordId: "record-1",
+					recordOrganizationId: "org-1",
+					employeeId: "employee-1",
+					startAt: DateTime.fromISO("2026-06-01T01:30:00Z"),
+					endAt: DateTime.fromISO("2026-06-01T02:30:00Z"),
+				},
+			],
+		});
+
+		expect(blockers[0]).toMatchObject({ date: "2026-05-31", time: "21:30" });
+	});
+
+	it("retains a correction with invalid instant metadata without local date/time", () => {
+		const blockers = filterPendingTimeApprovalBlockers({
+			organizationId: "org-1",
+			allowedEmployeeIds: ["employee-1"],
+			period: {
+				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
+				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
+			},
+			timezoneByEmployeeId: new Map([["employee-1", "America/New_York"]]),
+			rows: [
+				{
+					id: "approval-1",
+					organizationId: "org-1",
+					requestedBy: "employee-1",
+					status: "pending",
+					entityType: "time_entry",
+					canonicalRecordId: "record-1",
+					recordId: "record-1",
+					recordOrganizationId: "org-1",
+					employeeId: "employee-1",
+					startAt: DateTime.invalid("invalid metadata"),
+					endAt: DateTime.fromISO("2026-06-01T02:30:00Z"),
+				},
+			],
+		});
+
+		expect(blockers[0]).toMatchObject({ date: null, time: null });
+	});
+
 	it("keeps only pending time approvals linked to overlapping canonical time records", () => {
 		const blockers = filterPendingTimeApprovalBlockers({
 			organizationId: "org-1",
@@ -355,6 +416,7 @@ describe("filterPendingTimeApprovalBlockers", () => {
 				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
 				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
 			},
+			timezoneByEmployeeId: new Map(),
 			rows: [
 				{
 					id: "approval-1",
@@ -404,18 +466,87 @@ describe("filterPendingTimeApprovalBlockers", () => {
 				employeeId: "employee-1",
 				type: "pending_time_correction",
 				label: "Pending time correction",
+				date: null,
+				time: null,
 			},
 		]);
 	});
 });
 
 describe("filterMissingClockOutBlockers", () => {
+	it("uses the employee timezone to localize the missing clock-out start", () => {
+		const blockers = filterMissingClockOutBlockers({
+			period: {
+				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
+				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
+			},
+			timezoneByEmployeeId: new Map([["employee-1", "America/New_York"]]),
+			rows: [
+				{
+					id: "record-1",
+					employeeId: "employee-1",
+					startAt: DateTime.fromISO("2026-06-01T01:30:00Z"),
+				},
+			],
+		});
+
+		expect(blockers[0]).toMatchObject({ date: "2026-05-31", time: "21:30" });
+	});
+
+	it("retains a missing clock-out when the employee timezone is invalid", () => {
+		const blockers = filterMissingClockOutBlockers({
+			period: {
+				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
+				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
+			},
+			timezoneByEmployeeId: new Map([["employee-1", "Invalid/Timezone"]]),
+			rows: [
+				{
+					id: "record-1",
+					employeeId: "employee-1",
+					startAt: DateTime.fromISO("2026-06-01T01:30:00Z"),
+				},
+			],
+		});
+
+		expect(blockers).toEqual([
+			{
+				id: "record-1",
+				employeeId: "employee-1",
+				type: "missing_clock_out",
+				label: "Missing clock-out",
+				date: null,
+				time: null,
+			},
+		]);
+	});
+
+	it("retains a missing clock-out with invalid instant metadata", () => {
+		const blockers = filterMissingClockOutBlockers({
+			period: {
+				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
+				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
+			},
+			timezoneByEmployeeId: new Map([["employee-1", "America/New_York"]]),
+			rows: [
+				{
+					id: "record-1",
+					employeeId: "employee-1",
+					startAt: DateTime.invalid("invalid metadata"),
+				},
+			],
+		});
+
+		expect(blockers[0]).toMatchObject({ date: null, time: null });
+	});
+
 	it("includes open work records that started before the payroll period", () => {
 		const blockers = filterMissingClockOutBlockers({
 			period: {
 				start: DateTime.fromISO("2026-06-01T00:00:00Z"),
 				end: DateTime.fromISO("2026-06-30T23:59:59Z"),
 			},
+			timezoneByEmployeeId: new Map(),
 			rows: [
 				{
 					id: "record-1",
@@ -436,6 +567,27 @@ describe("filterMissingClockOutBlockers", () => {
 				employeeId: "employee-1",
 				type: "missing_clock_out",
 				label: "Missing clock-out",
+				date: null,
+				time: null,
+			},
+		]);
+	});
+});
+
+describe("buildPendingAbsenceBlockers", () => {
+	it("uses the logical absence start date without an event time", () => {
+		expect(
+			buildPendingAbsenceBlockers([
+				{ id: "absence-1", employeeId: "employee-1", startDate: "2026-06-12" },
+			]),
+		).toEqual([
+			{
+				id: "absence-1",
+				employeeId: "employee-1",
+				type: "pending_absence",
+				label: "Pending absence",
+				date: "2026-06-12",
+				time: null,
 			},
 		]);
 	});

--- a/apps/webapp/src/lib/payroll-workspace/summary.ts
+++ b/apps/webapp/src/lib/payroll-workspace/summary.ts
@@ -1,15 +1,19 @@
 import { and, eq, gte, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
 import { DateTime } from "luxon";
+import { Temporal } from "temporal-polyfill";
 import { organization, user } from "@/db/auth-schema";
 import {
 	absenceCategory,
+	absenceEntry,
 	approvalRequest,
 	employee,
 	team,
 	timeRecord,
 	timeRecordAbsence,
+	userSettings,
 } from "@/db/schema";
 import { assertCanonicalCutoverReady } from "@/lib/time-record/migration/cutover-state";
+import { resolveEffectiveTimezone } from "@/lib/timezone/effective-timezone";
 import { buildPayrollAbsenceDetails, payrollAbsenceDetailDays } from "./absence-details";
 import type {
 	PayrollBlocker,
@@ -133,6 +137,7 @@ export function filterPendingTimeApprovalBlockers(input: {
 	organizationId: string;
 	allowedEmployeeIds: string[];
 	period: PayrollDateTimePeriod;
+	timezoneByEmployeeId: ReadonlyMap<string, string>;
 	rows: PendingTimeApprovalBlockerRow[];
 }): PayrollBlocker[] {
 	const allowedEmployeeIds = new Set(input.allowedEmployeeIds);
@@ -147,13 +152,24 @@ export function filterPendingTimeApprovalBlockers(input: {
 		allowedEmployeeIds.has(row.requestedBy) &&
 		allowedEmployeeIds.has(row.employeeId) &&
 		row.endAt !== null &&
-		intervalsOverlap(row.startAt.toUTC(), row.endAt.toUTC(), input.period.start, input.period.end)
+		(!row.startAt.isValid ||
+			!row.endAt.isValid ||
+			intervalsOverlap(
+				row.startAt.toUTC(),
+				row.endAt.toUTC(),
+				input.period.start,
+				input.period.end,
+			))
 			? [
 					{
 						id: row.id,
 						employeeId: row.employeeId,
 						type: "pending_time_correction" as const,
 						label: "Pending time correction",
+						...localizeBlockerInstant(
+							row.startAt,
+							input.timezoneByEmployeeId.get(row.employeeId),
+						),
 					},
 				]
 			: [],
@@ -162,20 +178,42 @@ export function filterPendingTimeApprovalBlockers(input: {
 
 export function filterMissingClockOutBlockers(input: {
 	period: PayrollDateTimePeriod;
+	timezoneByEmployeeId: ReadonlyMap<string, string>;
 	rows: MissingClockOutBlockerRow[];
 }): PayrollBlocker[] {
 	return input.rows.flatMap((row) =>
-		row.startAt.toUTC() <= input.period.end.toUTC()
+		!row.startAt.isValid || row.startAt.toUTC() <= input.period.end.toUTC()
 			? [
 					{
 						id: row.id,
 						employeeId: row.employeeId,
 						type: "missing_clock_out" as const,
 						label: "Missing clock-out",
+						...localizeBlockerInstant(
+							row.startAt,
+							input.timezoneByEmployeeId.get(row.employeeId),
+						),
 					},
 				]
 			: [],
 	);
+}
+
+export function buildPendingAbsenceBlockers(
+	rows: ReadonlyArray<{
+		id: string;
+		employeeId: string;
+		startDate: string | null;
+	}>,
+): PayrollBlocker[] {
+	return rows.map((row) => ({
+		id: row.id,
+		employeeId: row.employeeId,
+		type: "pending_absence",
+		label: "Pending absence",
+		date: row.startDate,
+		time: null,
+	}));
 }
 
 export async function getPayrollWorkspaceSummary(input: {
@@ -189,7 +227,7 @@ export async function getPayrollWorkspaceSummary(input: {
 
 	const { db } = await import("@/db");
 	const [organizationRow] = await db
-		.select({ name: organization.name })
+		.select({ name: organization.name, timezone: organization.timezone })
 		.from(organization)
 		.where(eq(organization.id, input.organizationId))
 		.limit(1);
@@ -216,7 +254,12 @@ export async function getPayrollWorkspaceSummary(input: {
 		getEmployeeRows(input.organizationId, allowedEmployeeIds),
 		getWorkRows(input.organizationId, allowedEmployeeIds, input.period),
 		getAbsenceRows(input.organizationId, allowedEmployeeIds, input.period),
-		getBlockers(input.organizationId, allowedEmployeeIds, input.period),
+		getBlockers(
+			input.organizationId,
+			allowedEmployeeIds,
+			input.period,
+			organizationRow?.timezone ?? null,
+		),
 	]);
 
 	return buildPayrollSummaryFromRows({
@@ -355,11 +398,16 @@ async function getBlockers(
 	organizationId: string,
 	allowedEmployeeIds: string[],
 	period: { start: DateTime; end: DateTime },
+	organizationTimezone: string | null,
 ): Promise<PayrollBlocker[]> {
 	const { db } = await import("@/db");
 	const [missingClockOutRows, pendingAbsenceRows, pendingApprovalRows] = await Promise.all([
 		db
-			.select({ id: timeRecord.id, employeeId: timeRecord.employeeId, startAt: timeRecord.startAt })
+			.select({
+				id: timeRecord.id,
+				employeeId: timeRecord.employeeId,
+				startAt: timeRecord.startAt,
+			})
 			.from(timeRecord)
 			.where(
 				and(
@@ -371,13 +419,24 @@ async function getBlockers(
 				),
 			),
 		db
-			.select({ id: timeRecord.id, employeeId: timeRecord.employeeId })
+			.select({
+				id: timeRecord.id,
+				employeeId: timeRecord.employeeId,
+				startDate: absenceEntry.startDate,
+			})
 			.from(timeRecord)
 			.innerJoin(
 				timeRecordAbsence,
 				and(
 					eq(timeRecord.id, timeRecordAbsence.recordId),
 					eq(timeRecordAbsence.organizationId, organizationId),
+				),
+			)
+			.leftJoin(
+				absenceEntry,
+				and(
+					eq(absenceEntry.canonicalRecordId, timeRecord.id),
+					eq(absenceEntry.organizationId, organizationId),
 				),
 			)
 			.where(
@@ -426,10 +485,56 @@ async function getBlockers(
 			),
 	]);
 
+	const affectedEmployeeIds = Array.from(
+		new Set(
+			[...missingClockOutRows, ...pendingAbsenceRows, ...pendingApprovalRows].map(
+				(row) => row.employeeId,
+			),
+		),
+	);
+	const timezoneByEmployeeId = new Map<string, string>();
+	if (affectedEmployeeIds.length > 0) {
+		const affectedEmployees = await db
+			.select({ id: employee.id, userId: employee.userId })
+			.from(employee)
+			.where(
+				and(
+					eq(employee.organizationId, organizationId),
+					inArray(employee.id, affectedEmployeeIds),
+				),
+			);
+		const affectedUserIds = Array.from(
+			new Set(affectedEmployees.map((employeeRow) => employeeRow.userId)),
+		);
+		const timezoneByUserId = new Map<string, string>();
+		if (affectedUserIds.length > 0) {
+			const timezoneRows = await db
+				.select({
+					userId: userSettings.userId,
+					timezone: userSettings.timezone,
+				})
+				.from(userSettings)
+				.where(inArray(userSettings.userId, affectedUserIds));
+			for (const row of timezoneRows) {
+				timezoneByUserId.set(row.userId, row.timezone);
+			}
+		}
+		for (const employeeRow of affectedEmployees) {
+			timezoneByEmployeeId.set(
+				employeeRow.id,
+				resolveEffectiveTimezone(
+					timezoneByUserId.get(employeeRow.userId),
+					organizationTimezone,
+				),
+			);
+		}
+	}
+
 	const pendingApprovalBlockers = filterPendingTimeApprovalBlockers({
 		organizationId,
 		allowedEmployeeIds,
 		period,
+		timezoneByEmployeeId,
 		rows: pendingApprovalRows.map((row) => ({
 			...row,
 			startAt: DateTime.fromJSDate(row.startAt, { zone: "utc" }),
@@ -439,6 +544,7 @@ async function getBlockers(
 
 	const missingClockOutBlockers = filterMissingClockOutBlockers({
 		period,
+		timezoneByEmployeeId,
 		rows: missingClockOutRows.map((row) => ({
 			...row,
 			startAt: DateTime.fromJSDate(row.startAt, { zone: "utc" }),
@@ -447,14 +553,27 @@ async function getBlockers(
 
 	return [
 		...missingClockOutBlockers,
-		...pendingAbsenceRows.map((row) => ({
-			id: row.id,
-			employeeId: row.employeeId,
-			type: "pending_absence" as const,
-			label: "Pending absence",
-		})),
+		...buildPendingAbsenceBlockers(pendingAbsenceRows),
 		...pendingApprovalBlockers,
 	];
+}
+
+function localizeBlockerInstant(
+	instant: DateTime,
+	timezone: string | undefined,
+): Pick<PayrollBlocker, "date" | "time"> {
+	const instantIso = instant.isValid ? instant.toUTC().toISO() : null;
+	if (!(instantIso && timezone)) return { date: null, time: null };
+
+	try {
+		const local = Temporal.Instant.from(instantIso).toZonedDateTimeISO(timezone);
+		return {
+			date: local.toPlainDate().toString(),
+			time: `${String(local.hour).padStart(2, "0")}:${String(local.minute).padStart(2, "0")}`,
+		};
+	} catch {
+		return { date: null, time: null };
+	}
 }
 
 function toPayrollPeriod(period: { start: DateTime; end: DateTime; label: string }): PayrollPeriod {

--- a/apps/webapp/src/lib/payroll-workspace/types.ts
+++ b/apps/webapp/src/lib/payroll-workspace/types.ts
@@ -59,6 +59,8 @@ export interface PayrollBlocker {
 	employeeId: string;
 	type: PayrollBlockerType;
 	label: string;
+	date: string | null;
+	time: string | null;
 }
 
 export interface PayrollAbsenceDaysByCategory {


### PR DESCRIPTION
This pull request introduces enhancements to the calendar and payroll features, focusing on improved date handling, localization, and test coverage. The main changes include passing and validating a requested date for employee calendar views, updating payroll blocker translations in multiple languages, and adding or updating tests to ensure correct behavior for these features.

**Calendar feature improvements:**

* The `CalendarEmployeePage` now receives a `requestedDate` from the URL's search parameters and passes it to `CalendarPageContent`, allowing the calendar to open to a user-requested date. ([apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.tsxR19-R31](diffhunk://#diff-aee8b1f439ed1a90ddaf427e28ec656a98adaf83227a5ebe2ba4ad9c47aaa9d7R19-R31))
* `CalendarPageContent` validates the `requestedDate` using `resolveCalendarInitialDate`, falling back to a default if the date is invalid or missing. ([apps/webapp/src/app/[locale]/(app)/calendar/page.tsxR8-R15](diffhunk://#diff-2aabe022615880070b48926ccea7483d4b7d2a6f8bee74081312f146a9560815R8-R15), [apps/webapp/src/app/[locale]/(app)/calendar/page.tsxL46-R53](diffhunk://#diff-2aabe022615880070b48926ccea7483d4b7d2a6f8bee74081312f146a9560815L46-R53))

**Test coverage:**

* Added tests for `CalendarEmployeePage` and `CalendarPageContent` to verify correct handling of valid, invalid, and unauthorized requested dates. ([apps/webapp/src/app/[locale]/(app)/calendar/[employeeId]/page.test.tsxR1-R19](diffhunk://#diff-38091ccc32adf48d1ae624cef5eac7eb775cd66ec433e3f283435f41ed3e8dbfR1-R19), [apps/webapp/src/app/[locale]/(app)/calendar/page.test.tsxR1-R72](diffhunk://#diff-16e28c4eb00b7339b34fce2ebaabf4ac030f017d41376a001f9cdc1c95fa51d6R1-R72))
* Improved payroll workspace test mocks to support locale-specific behavior and added date/time fields to payroll blocker test data. [[1]](diffhunk://#diff-2adca8c7876eb1f7cb43977632ebd01b0c08d196adefd305417f40595d1496feR15) [[2]](diffhunk://#diff-2adca8c7876eb1f7cb43977632ebd01b0c08d196adefd305417f40595d1496feR29-R31) [[3]](diffhunk://#diff-2adca8c7876eb1f7cb43977632ebd01b0c08d196adefd305417f40595d1496feR74-R83) [[4]](diffhunk://#diff-2adca8c7876eb1f7cb43977632ebd01b0c08d196adefd305417f40595d1496feR106)

**Localization updates:**

* Expanded payroll blocker translations in all supported languages (e.g., English, German, French, Spanish, Italian, Greek, Polish, Portuguese, Turkish, Swiss German) to include new blocker types such as "date unavailable", "missing clock-out", "open approvals", "open calendar", "pending absence", "pending time correction", and "unknown employee". [[1]](diffhunk://#diff-adbe0eb963508d8da9f9800acc8ac8cc5b5b94dd7a6decfa1b6b05b5d3db76c3L14-R21) [[2]](diffhunk://#diff-207bff41e350600b36c650ede03b0d8a151f6a97e2391b6884121fc45fa02c6dL14-R21) [[3]](diffhunk://#diff-7aaebd3b3062b1d2ce15cdc521222d19817a6fc917cda92be5c8c410a349ff6aL14-R21) [[4]](diffhunk://#diff-fa5b5910fbfb36dd8cf6a83963f3fcf6f0ccbbea7359f0c5d5ca16751fea7be6L14-R21) [[5]](diffhunk://#diff-6dd1b1f695ab5a6a7c67bdabb1c26ad158d8f346ea5ee7d5f52a3e64e6105d8aL14-R21) [[6]](diffhunk://#diff-5f974905f36fe8eceb679f267679f5a08545627d2c886128b15e6944d4f73096L14-R21) [[7]](diffhunk://#diff-2f183037aa08db7bc8969335b3aeb9acaed4806910bd13fafa11816d4e3f9941L14-R21) [[8]](diffhunk://#diff-f835becca6ce312302de859a4e1675b646be772af667f5d7de2f1bae2ed237b2L14-R21) [[9]](diffhunk://#diff-e6f17bf6bf23926452ade6baffe67a4bf83bde5a155724992a9bc7cbacf27835L14-R21) [[10]](diffhunk://#diff-6e55374f887e384c00502106912d4ce1095978c9026437541633e344b7443193L14-R21)

These changes improve the user experience for calendar navigation and payroll blocker visibility across different locales, while ensuring robust test coverage for new and existing features.