### PR TITLE
Recover skipped approval migrations and document process

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,10 @@ jobs:
           export POSTGRES_USER=postgres
           export POSTGRES_PASSWORD=postgres
           export POSTGRES_SSL_MODE=disable
-          SKIP_ENV_VALIDATION=1 pnpm --filter webapp exec drizzle-kit migrate
+          SKIP_ENV_VALIDATION=1 \
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/${database_name}" \
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \
+          pnpm --filter webapp exec tsx scripts/verify-approval-migration-recovery.ts
 
           APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/${database_name}" \
           APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \

--- a/apps/webapp/drizzle/0060_approval_workflow_recovery.sql
+++ b/apps/webapp/drizzle/0060_approval_workflow_recovery.sql
@@ -1,0 +1,322 @@
+-- daily digest recovery: begin
+-- 0051_daily_digest_delivery.sql was never journaled. Recover both supported states:
+-- a complete historical table is left unchanged; an absent table is created in full.
+CREATE TABLE IF NOT EXISTS "daily_digest_delivery" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"recipient_user_id" text NOT NULL,
+	"platform" text NOT NULL,
+	"type" text NOT NULL,
+	"recipient_local_date" date NOT NULL,
+	"status" text DEFAULT 'processing' NOT NULL,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"last_error" text,
+	"attempted_at" timestamp DEFAULT now() NOT NULL,
+	"sent_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "daily_digest_delivery_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "daily_digest_delivery_recipient_user_id_fkey" FOREIGN KEY ("recipient_user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action,
+	CONSTRAINT "daily_digest_delivery_status_check" CHECK ("status" IN ('processing', 'sent', 'failed'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "dailyDigestDelivery_recipient_date_unique_idx" ON "daily_digest_delivery" USING btree ("organization_id","recipient_user_id","platform","type","recipient_local_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "dailyDigestDelivery_organization_status_idx" ON "daily_digest_delivery" USING btree ("organization_id","status");
+--> statement-breakpoint
+-- daily digest recovery: end
+
+-- 0055/0056 merged behind deployed 0059, so recover the skipped approval schema atomically.
+DO $approval_recovery$
+BEGIN
+	IF to_regclass('public.approval_workflow') IS NULL THEN
+CREATE TYPE "public"."approval_actor_kind" AS ENUM('employee', 'system', 'legacy_unknown');
+CREATE TYPE "public"."approval_assignment_status" AS ENUM('pending', 'approved', 'rejected', 'cancelled', 'expired');
+CREATE TYPE "public"."approval_command_state" AS ENUM('reserved', 'completed');
+CREATE TYPE "public"."approval_outbox_channel" AS ENUM('in_app', 'push', 'email', 'webhook', 'teams', 'telegram', 'discord', 'slack');
+CREATE TYPE "public"."approval_outbox_disposition" AS ENUM('observe', 'deliver');
+CREATE TYPE "public"."approval_outbox_expansion_status" AS ENUM('pending', 'expanded');
+CREATE TYPE "public"."approval_outbox_status" AS ENUM('pending', 'processing', 'delivered', 'failed', 'suppressed');
+CREATE TYPE "public"."approval_side_effect_mode" AS ENUM('legacy', 'canonical');
+CREATE TYPE "public"."approval_stage_status" AS ENUM('waiting', 'pending', 'approved', 'rejected', 'cancelled', 'expired');
+CREATE TYPE "public"."approval_workflow_lifecycle_mode" AS ENUM('legacy', 'shadow', 'ready', 'canonical', 'complete');
+CREATE TYPE "public"."approval_workflow_status" AS ENUM('pending', 'approved', 'rejected', 'cancelled', 'expired');
+CREATE TYPE "public"."approval_workflow_type" AS ENUM('absence', 'time_correction', 'manual_time_submission', 'policy_clock_out', 'travel_expense', 'shift_request', 'compliance_exception');
+CREATE TYPE "public"."shift_request_status" AS ENUM('pending', 'approved', 'rejected', 'cancelled');
+CREATE TABLE "approval_inbox_projection" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"active_stage_id" uuid NOT NULL,
+	"source_type" text NOT NULL,
+	"source_id" uuid NOT NULL,
+	"status" "approval_workflow_status" NOT NULL,
+	"display_payload" jsonb NOT NULL,
+	"search_text" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_outbox" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"event_id" uuid NOT NULL,
+	"event_type" text NOT NULL,
+	"dedupe_key" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"disposition" "approval_outbox_disposition" NOT NULL,
+	"expansion_status" "approval_outbox_expansion_status" DEFAULT 'pending' NOT NULL,
+	"expanded_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "approvalOutbox_id_organizationId_idx" UNIQUE("id","organization_id"),
+	CONSTRAINT "approvalOutbox_id_organizationId_disposition_idx" UNIQUE("id","organization_id","disposition")
+);
+
+CREATE TABLE "approval_outbox_delivery" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"outbox_id" uuid NOT NULL,
+	"dedupe_key" text NOT NULL,
+	"disposition" "approval_outbox_disposition" NOT NULL,
+	"status" "approval_outbox_status" DEFAULT 'pending' NOT NULL,
+	"channel" "approval_outbox_channel" NOT NULL,
+	"recipient_kind" text NOT NULL,
+	"recipient_employee_id" uuid,
+	"recipient_address" text,
+	"available_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"claimed_at" timestamp with time zone,
+	"claim_token" text,
+	"retry_count" integer DEFAULT 0 NOT NULL,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"processed_at" timestamp with time zone,
+	"last_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_requester_projection" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"requester_employee_id" uuid,
+	"source_type" text NOT NULL,
+	"source_id" uuid NOT NULL,
+	"status" "approval_workflow_status" NOT NULL,
+	"current_stage_order" integer,
+	"display_payload" jsonb NOT NULL,
+	"search_text" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_stage_assignment" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"stage_id" uuid NOT NULL,
+	"assignment_sequence" integer NOT NULL,
+	"approver_employee_id" uuid NOT NULL,
+	"status" "approval_assignment_status" DEFAULT 'pending' NOT NULL,
+	"assigned_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"resolved_by_actor_kind" "approval_actor_kind",
+	"resolved_by_actor_id" uuid,
+	"reassigned_by_employee_id" uuid,
+	"reassigned_from_assignment_id" uuid,
+	"reassignment_metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "approvalStageAssignment_id_organizationId_idx" UNIQUE("id","organization_id"),
+	CONSTRAINT "approvalStageAssignment_workflow_stage_id_organizationId_idx" UNIQUE("workflow_id","stage_id","id","organization_id")
+);
+
+CREATE TABLE "approval_workflow" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_type" "approval_workflow_type" NOT NULL,
+	"source_type" text NOT NULL,
+	"source_id" uuid NOT NULL,
+	"requester_employee_id" uuid,
+	"status" "approval_workflow_status" DEFAULT 'pending' NOT NULL,
+	"current_stage_order" integer,
+	"version" integer DEFAULT 1 NOT NULL,
+	"policy_snapshot" jsonb NOT NULL,
+	"context_snapshot" jsonb NOT NULL,
+	"display_snapshot" jsonb NOT NULL,
+	"submitted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"completed_at" timestamp with time zone,
+	"cancelled_at" timestamp with time zone,
+	"decision_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "approvalWorkflow_id_organizationId_idx" UNIQUE("id","organization_id")
+);
+
+CREATE TABLE "approval_workflow_command" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"idempotency_key" text NOT NULL,
+	"actor_fingerprint" text NOT NULL,
+	"command_fingerprint" text NOT NULL,
+	"state" "approval_command_state" DEFAULT 'reserved' NOT NULL,
+	"result" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_workflow_event" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"version" integer NOT NULL,
+	"event_index" integer NOT NULL,
+	"event_type" text NOT NULL,
+	"actor_kind" "approval_actor_kind" NOT NULL,
+	"actor_employee_id" uuid,
+	"actor_user_id" text,
+	"previous_state" jsonb,
+	"resulting_state" jsonb NOT NULL,
+	"reason" text,
+	"metadata" jsonb,
+	"idempotency_key" text,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "approvalWorkflowEvent_id_organizationId_idx" UNIQUE("id","organization_id"),
+	CONSTRAINT "approvalWorkflowEvent_workflow_id_organizationId_idx" UNIQUE("workflow_id","id","organization_id"),
+	CONSTRAINT "approvalWorkflowEvent_workflow_id_organizationId_eventType_idx" UNIQUE("workflow_id","id","organization_id","event_type")
+);
+
+CREATE TABLE "approval_workflow_migration_issue" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid,
+	"workflow_type" "approval_workflow_type" NOT NULL,
+	"legacy_type" text,
+	"legacy_id" uuid,
+	"source_type" text NOT NULL,
+	"source_id" uuid NOT NULL,
+	"issue_code" text NOT NULL,
+	"evidence" jsonb NOT NULL,
+	"disposition" text DEFAULT 'open' NOT NULL,
+	"operator_user_id" text,
+	"disposed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_workflow_rollout" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_type" "approval_workflow_type" NOT NULL,
+	"lifecycle_mode" "approval_workflow_lifecycle_mode" DEFAULT 'legacy' NOT NULL,
+	"side_effect_mode" "approval_side_effect_mode" DEFAULT 'legacy' NOT NULL,
+	"backfilled_through" timestamp with time zone,
+	"mismatch_count" integer DEFAULT 0 NOT NULL,
+	"last_reconciled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+
+CREATE TABLE "approval_workflow_stage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organization_id" text NOT NULL,
+	"workflow_id" uuid NOT NULL,
+	"stage_order" integer NOT NULL,
+	"label" text NOT NULL,
+	"resolver_snapshot" jsonb NOT NULL,
+	"activation_mode" text NOT NULL,
+	"status" "approval_stage_status" DEFAULT 'waiting' NOT NULL,
+	"activated_at" timestamp with time zone,
+	"decided_at" timestamp with time zone,
+	"decision_reason" text,
+	"legacy_approval_request_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "approvalWorkflowStage_id_organizationId_idx" UNIQUE("id","organization_id"),
+	CONSTRAINT "approvalWorkflowStage_workflow_id_organizationId_idx" UNIQUE("workflow_id","id","organization_id")
+);
+
+ALTER TABLE "absence_entry" DROP CONSTRAINT "absence_entry_organization_id_organization_id_fk";
+
+ALTER TABLE "absence_entry" ADD COLUMN "approval_workflow_id" uuid;
+ALTER TABLE "compliance_exception" ADD COLUMN "approval_workflow_id" uuid;
+ALTER TABLE "notification" ADD COLUMN "idempotency_key" text;
+ALTER TABLE "shift_request" ADD COLUMN "organization_id" text;
+ALTER TABLE "shift_request" ADD COLUMN "lifecycle_status" "shift_request_status";
+ALTER TABLE "shift_request" ADD COLUMN "approval_workflow_id" uuid;
+ALTER TABLE "work_period" ADD COLUMN "approval_workflow_id" uuid;
+ALTER TABLE "travel_expense_claim" ADD COLUMN "approval_workflow_id" uuid;
+ALTER TABLE "approval_inbox_projection" ADD CONSTRAINT "approval_inbox_projection_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_inbox_projection" ADD CONSTRAINT "approval_inbox_projection_workflow_id_active_stage_id_organization_id_approval_workflow_stage_workflow_id_id_organization_id_fk" FOREIGN KEY ("workflow_id","active_stage_id","organization_id") REFERENCES "public"."approval_workflow_stage"("workflow_id","id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_outbox" ADD CONSTRAINT "approval_outbox_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_outbox" ADD CONSTRAINT "approval_outbox_workflow_id_event_id_organization_id_event_type_approval_workflow_event_workflow_id_id_organization_id_event_type_fk" FOREIGN KEY ("workflow_id","event_id","organization_id","event_type") REFERENCES "public"."approval_workflow_event"("workflow_id","id","organization_id","event_type") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_outbox_delivery" ADD CONSTRAINT "approval_outbox_delivery_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_outbox_delivery" ADD CONSTRAINT "approval_outbox_delivery_outbox_id_organization_id_disposition_approval_outbox_id_organization_id_disposition_fk" FOREIGN KEY ("outbox_id","organization_id","disposition") REFERENCES "public"."approval_outbox"("id","organization_id","disposition") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_outbox_delivery" ADD CONSTRAINT "approval_outbox_delivery_recipient_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("recipient_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_requester_projection" ADD CONSTRAINT "approval_requester_projection_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_requester_projection" ADD CONSTRAINT "approval_requester_projection_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_requester_projection" ADD CONSTRAINT "approval_requester_projection_requester_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("requester_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_workflow_id_stage_id_organization_id_approval_workflow_stage_workflow_id_id_organization_id_fk" FOREIGN KEY ("workflow_id","stage_id","organization_id") REFERENCES "public"."approval_workflow_stage"("workflow_id","id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_approver_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("approver_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_resolved_by_actor_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("resolved_by_actor_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_reassigned_by_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("reassigned_by_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_stage_assignment" ADD CONSTRAINT "approval_stage_assignment_workflow_id_stage_id_reassigned_from_assignment_id_organization_id_approval_stage_assignment_workflow_id_stage_id_id_organization_id_fk" FOREIGN KEY ("workflow_id","stage_id","reassigned_from_assignment_id","organization_id") REFERENCES "public"."approval_stage_assignment"("workflow_id","stage_id","id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_workflow" ADD CONSTRAINT "approval_workflow_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow" ADD CONSTRAINT "approval_workflow_requester_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("requester_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_workflow_command" ADD CONSTRAINT "approval_workflow_command_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_command" ADD CONSTRAINT "approval_workflow_command_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_event" ADD CONSTRAINT "approval_workflow_event_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_event" ADD CONSTRAINT "approval_workflow_event_actor_user_id_user_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_workflow_event" ADD CONSTRAINT "approval_workflow_event_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_event" ADD CONSTRAINT "approval_workflow_event_actor_employee_id_organization_id_employee_id_organization_id_fk" FOREIGN KEY ("actor_employee_id","organization_id") REFERENCES "public"."employee"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_workflow_migration_issue" ADD CONSTRAINT "approval_workflow_migration_issue_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_migration_issue" ADD CONSTRAINT "approval_workflow_migration_issue_operator_user_id_user_id_fk" FOREIGN KEY ("operator_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "approval_workflow_migration_issue" ADD CONSTRAINT "approval_workflow_migration_issue_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_rollout" ADD CONSTRAINT "approval_workflow_rollout_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_stage" ADD CONSTRAINT "approval_workflow_stage_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "approval_workflow_stage" ADD CONSTRAINT "approval_workflow_stage_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE cascade ON UPDATE no action;
+CREATE UNIQUE INDEX "approvalInboxProjection_org_workflow_stage_idx" ON "approval_inbox_projection" USING btree ("organization_id","workflow_id","active_stage_id");
+CREATE INDEX "approvalInboxProjection_org_status_idx" ON "approval_inbox_projection" USING btree ("organization_id","status");
+CREATE UNIQUE INDEX "approvalOutbox_org_dedupe_idx" ON "approval_outbox" USING btree ("organization_id","dedupe_key");
+CREATE INDEX "approvalOutbox_org_createdAt_idx" ON "approval_outbox" USING btree ("organization_id","created_at");
+CREATE INDEX "approvalOutbox_pendingExpansion_createdAt_idx" ON "approval_outbox" USING btree ("expansion_status","created_at") WHERE expansion_status = 'pending';
+CREATE UNIQUE INDEX "approvalOutboxDelivery_org_dedupe_idx" ON "approval_outbox_delivery" USING btree ("organization_id","dedupe_key");
+CREATE INDEX "approvalOutboxDelivery_status_available_idx" ON "approval_outbox_delivery" USING btree ("status","available_at");
+CREATE UNIQUE INDEX "approvalRequesterProjection_org_workflow_idx" ON "approval_requester_projection" USING btree ("organization_id","workflow_id");
+CREATE INDEX "approvalRequesterProjection_org_requester_status_idx" ON "approval_requester_projection" USING btree ("organization_id","requester_employee_id","status");
+CREATE UNIQUE INDEX "approvalStageAssignment_org_workflow_stage_sequence_idx" ON "approval_stage_assignment" USING btree ("organization_id","workflow_id","stage_id","assignment_sequence");
+CREATE UNIQUE INDEX "approvalStageAssignment_org_workflow_stage_pending_approver_idx" ON "approval_stage_assignment" USING btree ("organization_id","workflow_id","stage_id","approver_employee_id") WHERE status = 'pending';
+CREATE UNIQUE INDEX "approvalWorkflow_org_source_pending_idx" ON "approval_workflow" USING btree ("organization_id","source_type","source_id") WHERE status = 'pending';
+CREATE INDEX "approvalWorkflow_org_status_idx" ON "approval_workflow" USING btree ("organization_id","status");
+CREATE UNIQUE INDEX "approvalWorkflowCommand_org_workflow_idempotency_idx" ON "approval_workflow_command" USING btree ("organization_id","workflow_id","idempotency_key");
+CREATE UNIQUE INDEX "approvalWorkflowEvent_org_workflow_version_index_idx" ON "approval_workflow_event" USING btree ("organization_id","workflow_id","version","event_index");
+CREATE UNIQUE INDEX "approvalWorkflowEvent_org_idempotency_idx" ON "approval_workflow_event" USING btree ("organization_id","idempotency_key") WHERE idempotency_key IS NOT NULL;
+CREATE INDEX "approvalWorkflowMigrationIssue_org_type_disposition_idx" ON "approval_workflow_migration_issue" USING btree ("organization_id","workflow_type","disposition");
+CREATE UNIQUE INDEX "approvalWorkflowRollout_org_type_idx" ON "approval_workflow_rollout" USING btree ("organization_id","workflow_type");
+CREATE UNIQUE INDEX "approvalWorkflowStage_org_workflow_order_idx" ON "approval_workflow_stage" USING btree ("organization_id","workflow_id","stage_order");
+ALTER TABLE "absence_entry" ADD CONSTRAINT "absence_entry_approval_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("approval_workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "absence_entry" ADD CONSTRAINT "absence_entry_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "compliance_exception" ADD CONSTRAINT "compliance_exception_approval_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("approval_workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "shift_request" ADD CONSTRAINT "shift_request_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "shift_request" ADD CONSTRAINT "shift_request_approval_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("approval_workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "shift" ADD CONSTRAINT "shift_organizationId_id_idx" UNIQUE("organization_id","id");
+ALTER TABLE "shift_request" ADD CONSTRAINT "shift_request_organization_id_shift_id_shift_organization_id_id_fk" FOREIGN KEY ("organization_id","shift_id") REFERENCES "public"."shift"("organization_id","id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "work_period" ADD CONSTRAINT "work_period_approval_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("approval_workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE no action ON UPDATE no action;
+ALTER TABLE "travel_expense_claim" ADD CONSTRAINT "travel_expense_claim_approval_workflow_id_organization_id_approval_workflow_id_organization_id_fk" FOREIGN KEY ("approval_workflow_id","organization_id") REFERENCES "public"."approval_workflow"("id","organization_id") ON DELETE no action ON UPDATE no action;
+CREATE INDEX "absenceEntry_org_approvalWorkflowId_idx" ON "absence_entry" USING btree ("organization_id","approval_workflow_id");
+CREATE INDEX "complianceException_org_approvalWorkflowId_idx" ON "compliance_exception" USING btree ("organization_id","approval_workflow_id");
+CREATE UNIQUE INDEX "notification_org_idempotencyKey_idx" ON "notification" USING btree ("organization_id","idempotency_key") WHERE idempotency_key IS NOT NULL;
+CREATE INDEX "shiftRequest_org_approvalWorkflowId_idx" ON "shift_request" USING btree ("organization_id","approval_workflow_id");
+CREATE INDEX "workPeriod_org_approvalWorkflowId_idx" ON "work_period" USING btree ("organization_id","approval_workflow_id");
+CREATE INDEX "travelExpenseClaim_org_approvalWorkflowId_idx" ON "travel_expense_claim" USING btree ("organization_id","approval_workflow_id");
+ALTER TABLE "absence_entry" ADD CONSTRAINT "absence_entry_approval_workflow_organization_check" CHECK ("absence_entry"."approval_workflow_id" IS NULL OR "absence_entry"."organization_id" IS NOT NULL);
+ALTER TABLE "shift_request" ADD CONSTRAINT "shift_request_approval_workflow_organization_check" CHECK ("shift_request"."approval_workflow_id" IS NULL OR "shift_request"."organization_id" IS NOT NULL);
+	END IF;
+END
+$approval_recovery$;
+--> statement-breakpoint
+DROP INDEX IF EXISTS "approvalWorkflow_org_source_pending_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "approvalWorkflow_org_source_pending_idx" ON "approval_workflow" USING btree ("organization_id","workflow_type","source_type","source_id") WHERE status = 'pending';

--- a/apps/webapp/drizzle/meta/_journal.json
+++ b/apps/webapp/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1785493929039,
       "tag": "0059_payroll_blocker_dismissal",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1785493929040,
+      "tag": "0060_approval_workflow_recovery",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/webapp/scripts/run-approval-workflow-repository-integration.sh
+++ b/apps/webapp/scripts/run-approval-workflow-repository-integration.sh
@@ -63,7 +63,7 @@ readonly host_port="$(docker inspect --format '{{(index (index .NetworkSettings.
 docker exec "$container_name" createdb --username postgres "$database_name"
 printf 'Created disposable database: %s\n' "$database_name"
 
-printf 'Applying full Drizzle migration chain through the current journal\n'
+printf 'Verifying approval migration incident recovery, retry, and fresh chain\n'
 POSTGRES_HOST=127.0.0.1 \
 POSTGRES_PORT="$host_port" \
 POSTGRES_DB="$database_name" \
@@ -71,7 +71,9 @@ POSTGRES_USER=postgres \
 POSTGRES_PASSWORD="$database_password" \
 POSTGRES_SSL_MODE=disable \
 SKIP_ENV_VALIDATION=1 \
-pnpm --dir "$app_directory" exec drizzle-kit migrate
+APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:${database_password}@127.0.0.1:${host_port}/${database_name}" \
+APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \
+pnpm --dir "$app_directory" exec tsx ./scripts/verify-approval-migration-recovery.ts
 
 printf 'Running gated approval workflow repository and engine integration suites\n'
 POSTGRES_HOST=127.0.0.1 \
@@ -81,7 +83,6 @@ POSTGRES_USER=postgres \
 POSTGRES_PASSWORD="$database_password" \
 POSTGRES_SSL_MODE=disable \
 PGOPTIONS="-c statement_timeout=15000 -c timezone=UTC" \
-NODE_OPTIONS="${NODE_OPTIONS:+${NODE_OPTIONS} }--throw-deprecation" \
 APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:${database_password}@127.0.0.1:${host_port}/${database_name}" \
 APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \
 APPROVAL_WORKFLOW_REPOSITORY_TEST_REQUIRED=1 \

--- a/apps/webapp/scripts/verify-approval-migration-recovery.ts
+++ b/apps/webapp/scripts/verify-approval-migration-recovery.ts
@@ -1,0 +1,692 @@
+import { createHash } from "node:crypto";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+
+const TEST_SENTINEL = "approval-workflow-repository-test";
+const TEST_DATABASE_PREFIX = "approval_workflow_repository_test_";
+const INCIDENT_LATEST_CREATED_AT = "1785493929039";
+const EXPAND_CREATED_AT = "1785232090757";
+const CYCLE_IDENTITY_CREATED_AT = "1785232118219";
+const RECOVERY_CREATED_AT = "1785493929040";
+const RECOVERY_TAG = "0060_approval_workflow_recovery";
+const REAL_MIGRATIONS_FOLDER = fileURLToPath(
+	new URL("../drizzle", import.meta.url),
+);
+const JOURNAL_TAGS_TO_SKIP = new Set([
+	"0055_approval_workflow_expand",
+	"0056_approval_workflow_cycle_identity",
+	RECOVERY_TAG,
+]);
+const APPROVAL_TABLES = [
+	"approval_inbox_projection",
+	"approval_outbox",
+	"approval_outbox_delivery",
+	"approval_requester_projection",
+	"approval_stage_assignment",
+	"approval_workflow",
+	"approval_workflow_command",
+	"approval_workflow_event",
+	"approval_workflow_migration_issue",
+	"approval_workflow_rollout",
+	"approval_workflow_stage",
+] as const;
+const APPROVAL_SOURCE_TABLES = [
+	"absence_entry",
+	"compliance_exception",
+	"shift_request",
+	"travel_expense_claim",
+	"work_period",
+] as const;
+const PENDING_INDEX_NAME = "approvalWorkflow_org_source_pending_idx";
+const PENDING_INDEX_COLUMNS = [
+	"organization_id",
+	"workflow_type",
+	"source_type",
+	"source_id",
+] as const;
+
+interface JournalEntry {
+	tag: string;
+	[key: string]: unknown;
+}
+
+interface MigrationJournal {
+	entries: JournalEntry[];
+	[key: string]: unknown;
+}
+
+export interface ApprovalCatalog {
+	tables: string[];
+	columns: { table: string; name: string; type: string }[];
+	indexes: {
+		name: string;
+		table: string;
+		unique: boolean;
+		columns: string[];
+		predicate: string | null;
+	}[];
+}
+
+export interface RawMigrationLedgerRow {
+	id: unknown;
+	hash: unknown;
+	created_at: unknown;
+}
+
+export interface MigrationLedgerRow {
+	id: string;
+	hash: string;
+	createdAt: string;
+}
+
+export interface TestDatabaseConfig {
+	databaseUrl: string;
+	databaseName: string;
+}
+
+export interface DisposableDatabasePreflight {
+	expectedDatabaseName: string;
+	currentDatabaseName: string;
+	drizzleSchemaExists: boolean;
+	publicSchemaObjectCount: bigint;
+	unexpectedUserSchemaCount: bigint;
+}
+
+export interface CatalogNamespaceReference {
+	tableName: string;
+	columnName: string;
+}
+
+export function filterIncidentJournal(
+	journal: MigrationJournal,
+): MigrationJournal {
+	return {
+		...journal,
+		entries: journal.entries.filter(
+			(entry) => !JOURNAL_TAGS_TO_SKIP.has(entry.tag),
+		),
+	};
+}
+
+function normalizeLedgerValue(
+	value: unknown,
+	field: "id" | "created_at",
+): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === "bigint") return value.toString();
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	if (typeof value !== "string") {
+		throw new Error(`Drizzle migration ledger ${field} has an invalid value`);
+	}
+
+	const normalized = value.trim();
+	if (/^-?\d+$/.test(normalized)) return BigInt(normalized).toString();
+	if (field === "created_at") {
+		const timestamp = Date.parse(normalized);
+		if (Number.isFinite(timestamp)) return new Date(timestamp).toISOString();
+	}
+	return normalized;
+}
+
+export function normalizeMigrationLedger(
+	rows: readonly RawMigrationLedgerRow[],
+): MigrationLedgerRow[] {
+	return rows.map((row) => {
+		if (typeof row.hash !== "string") {
+			throw new Error("Drizzle migration ledger hash has an invalid value");
+		}
+		return {
+			id: normalizeLedgerValue(row.id, "id"),
+			hash: row.hash,
+			createdAt: normalizeLedgerValue(row.created_at, "created_at"),
+		};
+	});
+}
+
+export function assertMigrationLedgerUnchanged(
+	before: readonly RawMigrationLedgerRow[],
+	after: readonly RawMigrationLedgerRow[],
+): void {
+	if (
+		JSON.stringify(normalizeMigrationLedger(before)) !==
+		JSON.stringify(normalizeMigrationLedger(after))
+	) {
+		throw new Error("Retry changed the Drizzle migration ledger");
+	}
+}
+
+export function buildCatalogNamespaceCountQuery(
+	reference: CatalogNamespaceReference,
+): string {
+	if (
+		!/^pg_[a-z0-9_]+$/.test(reference.tableName) ||
+		!/^[a-z_][a-z0-9_]*namespace$/.test(reference.columnName)
+	) {
+		throw new Error("Invalid pg_catalog namespace reference");
+	}
+	return `select count(*)::text as count from pg_catalog."${reference.tableName}" where "${reference.columnName}" = $1::oid`;
+}
+
+export function sumCatalogNamespaceCounts(
+	counts: readonly { count: string | number | bigint }[],
+): bigint {
+	return counts.reduce((total, row) => {
+		if (
+			(typeof row.count === "number" &&
+				(!Number.isSafeInteger(row.count) || row.count < 0)) ||
+			(typeof row.count === "string" && !/^\d+$/.test(row.count)) ||
+			(typeof row.count === "bigint" && row.count < BigInt(0))
+		) {
+			throw new Error("Invalid pg_catalog namespace object count");
+		}
+		return total + BigInt(row.count);
+	}, BigInt(0));
+}
+
+export function parseTestDatabaseConfig(
+	databaseUrl: string,
+	sentinel: string | undefined,
+): TestDatabaseConfig {
+	if (sentinel !== TEST_SENTINEL) {
+		throw new Error(
+			`APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL must equal ${TEST_SENTINEL}`,
+		);
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(databaseUrl);
+	} catch {
+		throw new Error(
+			"APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL must be a valid PostgreSQL URL",
+		);
+	}
+	if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+		throw new Error(
+			"Approval migration test DB URL must use a PostgreSQL protocol",
+		);
+	}
+	if (parsed.search !== "") {
+		throw new Error(
+			"Approval migration test DB URL must not include query parameters",
+		);
+	}
+	const hostname = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+	if (!new Set(["127.0.0.1", "localhost", "::1"]).has(hostname)) {
+		throw new Error("Approval migration test DB URL must use a loopback host");
+	}
+
+	const databaseName = decodeURIComponent(parsed.pathname.slice(1));
+	if (!databaseName.startsWith(TEST_DATABASE_PREFIX)) {
+		throw new Error(
+			"Refusing to target a non-isolated approval workflow test DB",
+		);
+	}
+	return { databaseUrl, databaseName };
+}
+
+export function assertDisposableDatabasePreflight(
+	evidence: DisposableDatabasePreflight,
+): void {
+	if (
+		evidence.currentDatabaseName !== evidence.expectedDatabaseName ||
+		evidence.drizzleSchemaExists ||
+		evidence.publicSchemaObjectCount !== BigInt(0) ||
+		evidence.unexpectedUserSchemaCount !== BigInt(0)
+	) {
+		throw new Error(
+			"Refusing destructive approval migration verification: test DB preflight failed",
+		);
+	}
+}
+
+export function assertApprovalCatalog(catalog: ApprovalCatalog): void {
+	const missingTables = APPROVAL_TABLES.filter(
+		(table) => !catalog.tables.includes(table),
+	);
+	if (missingTables.length > 0) {
+		throw new Error(
+			`Missing canonical approval tables: ${missingTables.join(", ")}`,
+		);
+	}
+
+	const invalidColumns = APPROVAL_SOURCE_TABLES.filter((table) => {
+		const column = catalog.columns.find(
+			(candidate) =>
+				candidate.table === table && candidate.name === "approval_workflow_id",
+		);
+		return column?.type !== "uuid";
+	});
+	if (invalidColumns.length > 0) {
+		throw new Error(
+			`Missing UUID approval_workflow_id columns: ${invalidColumns.join(", ")}`,
+		);
+	}
+
+	const index = catalog.indexes.find(
+		(candidate) => candidate.name === PENDING_INDEX_NAME,
+	);
+	const hasExpectedColumns =
+		index?.columns.length === PENDING_INDEX_COLUMNS.length &&
+		index.columns.every(
+			(column, position) => column === PENDING_INDEX_COLUMNS[position],
+		);
+	const normalizedPredicate = index?.predicate
+		?.toLowerCase()
+		.replaceAll('"', "")
+		.replace(/::[a-z_][a-z0-9_]*/g, "")
+		.replace(/[()]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	if (
+		index?.table !== "approval_workflow" ||
+		index.unique !== true ||
+		!hasExpectedColumns ||
+		normalizedPredicate !== "status = 'pending'"
+	) {
+		throw new Error(`Invalid ${PENDING_INDEX_NAME}`);
+	}
+}
+
+function requireTestDatabaseConfig(): TestDatabaseConfig {
+	const databaseUrl =
+		process.env.APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL;
+	if (!databaseUrl) {
+		throw new Error(
+			"APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL is required",
+		);
+	}
+	return parseTestDatabaseConfig(
+		databaseUrl,
+		process.env.APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL,
+	);
+}
+
+async function preflightDisposableDatabase(
+	pool: Pool,
+	expectedDatabaseName: string,
+): Promise<void> {
+	const identityResult = await pool.query<{
+		current_database_name: string;
+		drizzle_schema_exists: boolean;
+		unexpected_user_schema_count: string;
+	}>(`
+		select current_database() as current_database_name,
+			exists (
+				select 1
+				from pg_catalog.pg_namespace
+				where nspname = 'drizzle'
+			) as drizzle_schema_exists,
+			(
+				select count(*)::text
+				from pg_catalog.pg_namespace
+				where nspname not in ('pg_catalog', 'pg_toast', 'information_schema', 'public')
+					and nspname !~ '^pg_temp_[0-9]+$'
+					and nspname !~ '^pg_toast_temp_[0-9]+$'
+			) as unexpected_user_schema_count
+	`);
+	const identity = identityResult.rows[0];
+	if (!identity) {
+		throw new Error(
+			"Refusing destructive approval migration verification: test DB preflight returned no evidence",
+		);
+	}
+
+	const namespaceResult = await pool.query<{ oid: string }>(`
+		select oid::text as oid
+		from pg_catalog.pg_namespace
+		where nspname = 'public'
+	`);
+	const publicNamespaceOid = namespaceResult.rows[0]?.oid;
+	if (!publicNamespaceOid) {
+		throw new Error(
+			"Refusing destructive approval migration verification: public schema is absent",
+		);
+	}
+
+	const referenceResult = await pool.query<{
+		table_name: string;
+		column_name: string;
+	}>(`
+		select relation.relname as table_name,
+			attribute.attname as column_name
+		from pg_catalog.pg_attribute attribute
+		join pg_catalog.pg_class relation on relation.oid = attribute.attrelid
+		join pg_catalog.pg_namespace namespace on namespace.oid = relation.relnamespace
+		where namespace.nspname = 'pg_catalog'
+			and relation.relkind in ('r', 'p')
+			and attribute.attnum > 0
+			and not attribute.attisdropped
+			and attribute.atttypid = 'pg_catalog.oid'::pg_catalog.regtype
+			and attribute.attname like '%namespace'
+		order by relation.relname, attribute.attname
+	`);
+	const countResults = await Promise.all(
+		referenceResult.rows.map(async (reference) => {
+			const result = await pool.query<{ count: string }>(
+				buildCatalogNamespaceCountQuery({
+					tableName: reference.table_name,
+					columnName: reference.column_name,
+				}),
+				[publicNamespaceOid],
+			);
+			const count = result.rows[0];
+			if (!count) throw new Error("pg_catalog namespace count returned no row");
+			return count;
+		}),
+	);
+	assertDisposableDatabasePreflight({
+		expectedDatabaseName,
+		currentDatabaseName: identity.current_database_name,
+		drizzleSchemaExists: identity.drizzle_schema_exists,
+		publicSchemaObjectCount: sumCatalogNamespaceCounts(countResults),
+		unexpectedUserSchemaCount: BigInt(identity.unexpected_user_schema_count),
+	});
+}
+
+async function assertAnchorLedgerState(
+	pool: Pool,
+	expandHash: string,
+	recoveryExpected: boolean,
+): Promise<void> {
+	const result = await pool.query<{ created_at: string; hash: string }>(
+		`
+			select created_at::text as created_at, hash
+			from drizzle.__drizzle_migrations
+			where created_at = any($1::bigint[])
+		`,
+		[[EXPAND_CREATED_AT, CYCLE_IDENTITY_CREATED_AT, RECOVERY_CREATED_AT]],
+	);
+	const expandRows = result.rows.filter(
+		(row) => row.created_at === EXPAND_CREATED_AT,
+	);
+	const cycleRows = result.rows.filter(
+		(row) => row.created_at === CYCLE_IDENTITY_CREATED_AT,
+	);
+	const recoveryRows = result.rows.filter(
+		(row) => row.created_at === RECOVERY_CREATED_AT,
+	);
+	if (
+		expandRows.length !== 1 ||
+		expandRows[0]?.hash !== expandHash ||
+		cycleRows.length !== 0 ||
+		recoveryRows.length !== (recoveryExpected ? 1 : 0)
+	) {
+		throw new Error("Constructed approval migration ledger state is invalid");
+	}
+}
+
+async function loadMigrationLedger(
+	pool: Pool,
+): Promise<RawMigrationLedgerRow[]> {
+	const result = await pool.query<RawMigrationLedgerRow>(`
+		select id, hash, created_at
+		from drizzle.__drizzle_migrations
+		order by id
+	`);
+	return result.rows;
+}
+
+async function assertIncidentState(pool: Pool): Promise<void> {
+	const ledger = normalizeMigrationLedger(await loadMigrationLedger(pool));
+	if (ledger.at(-1)?.createdAt !== INCIDENT_LATEST_CREATED_AT) {
+		throw new Error(
+			`Incident ledger latest created_at must be ${INCIDENT_LATEST_CREATED_AT}`,
+		);
+	}
+	const result = await pool.query<{
+		approval_table_exists: boolean;
+		work_period_column_exists: boolean;
+	}>(`
+		select
+			to_regclass('public.approval_workflow') is not null as approval_table_exists,
+			exists (
+				select 1
+				from pg_catalog.pg_attribute attribute
+				join pg_catalog.pg_class relation on relation.oid = attribute.attrelid
+				join pg_catalog.pg_namespace namespace on namespace.oid = relation.relnamespace
+				where namespace.nspname = 'public'
+					and relation.relname = 'work_period'
+					and attribute.attname = 'approval_workflow_id'
+					and attribute.attnum > 0
+					and not attribute.attisdropped
+			) as work_period_column_exists
+	`);
+	const state = result.rows[0];
+	if (state?.approval_table_exists || state?.work_period_column_exists) {
+		throw new Error("Failed to recreate the skipped approval migration state");
+	}
+}
+
+async function loadApprovalCatalog(pool: Pool): Promise<ApprovalCatalog> {
+	const [tableResult, columnResult, indexResult] = await Promise.all([
+		pool.query<{ name: string }>(
+			`
+				select relation.relname as name
+				from pg_catalog.pg_class relation
+				join pg_catalog.pg_namespace namespace on namespace.oid = relation.relnamespace
+				where namespace.nspname = 'public'
+					and relation.relkind in ('r', 'p')
+					and relation.relname = any($1::text[])
+			`,
+			[[...APPROVAL_TABLES]],
+		),
+		pool.query<{ table: string; name: string; type: string }>(
+			`
+				select relation.relname as table,
+					attribute.attname as name,
+					pg_catalog.format_type(attribute.atttypid, attribute.atttypmod) as type
+				from pg_catalog.pg_attribute attribute
+				join pg_catalog.pg_class relation on relation.oid = attribute.attrelid
+				join pg_catalog.pg_namespace namespace on namespace.oid = relation.relnamespace
+				where namespace.nspname = 'public'
+					and relation.relname = any($1::text[])
+					and attribute.attname = 'approval_workflow_id'
+					and attribute.attnum > 0
+					and not attribute.attisdropped
+			`,
+			[[...APPROVAL_SOURCE_TABLES]],
+		),
+		pool.query<{
+			name: string;
+			table: string;
+			unique: boolean;
+			columns: string[];
+			predicate: string | null;
+		}>(
+			`
+				select index_relation.relname as name,
+					table_relation.relname as table,
+					index.indisunique as unique,
+					array(
+						select pg_catalog.pg_get_indexdef(index.indexrelid, position, true)
+						from generate_series(1, index.indnkeyatts) as position
+						order by position
+					) as columns,
+					pg_catalog.pg_get_expr(index.indpred, index.indrelid) as predicate
+				from pg_catalog.pg_index index
+				join pg_catalog.pg_class index_relation on index_relation.oid = index.indexrelid
+				join pg_catalog.pg_class table_relation on table_relation.oid = index.indrelid
+				join pg_catalog.pg_namespace namespace on namespace.oid = table_relation.relnamespace
+				where namespace.nspname = 'public'
+					and index_relation.relname = $1
+			`,
+			[PENDING_INDEX_NAME],
+		),
+	]);
+	return {
+		tables: tableResult.rows.map((row) => row.name),
+		columns: columnResult.rows,
+		indexes: indexResult.rows,
+	};
+}
+
+async function assertRecoveryState(pool: Pool): Promise<void> {
+	const recoveryLedgerResult = await pool.query<{ count: number }>(
+		`
+			select count(*)::integer as count
+			from drizzle.__drizzle_migrations
+			where created_at = $1
+		`,
+		[RECOVERY_CREATED_AT],
+	);
+	if (recoveryLedgerResult.rows[0]?.count !== 1) {
+		throw new Error(`Drizzle ledger does not record ${RECOVERY_TAG}`);
+	}
+	assertApprovalCatalog(await loadApprovalCatalog(pool));
+}
+
+async function run(): Promise<void> {
+	const databaseConfig = requireTestDatabaseConfig();
+	let pool: Pool | undefined;
+	let temporaryDirectory: string | undefined;
+	let destructiveResetAuthorized = false;
+	try {
+		temporaryDirectory = await mkdtemp(
+			join(tmpdir(), "z8-approval-migration-recovery-"),
+		);
+		const incidentMigrationsFolder = join(temporaryDirectory, "drizzle");
+		await cp(REAL_MIGRATIONS_FOLDER, incidentMigrationsFolder, {
+			recursive: true,
+		});
+		const journalPath = join(incidentMigrationsFolder, "meta", "_journal.json");
+		const journal = JSON.parse(
+			await readFile(journalPath, "utf8"),
+		) as MigrationJournal;
+		await writeFile(
+			journalPath,
+			`${JSON.stringify(filterIncidentJournal(journal), null, 2)}\n`,
+		);
+
+		pool = new Pool({ connectionString: databaseConfig.databaseUrl });
+		await preflightDisposableDatabase(pool, databaseConfig.databaseName);
+		console.log(
+			"Migration recovery verification: probing custom schema refusal",
+		);
+		await pool.query('create schema "approval_migration_preflight_probe"');
+		let customSchemaRefused = false;
+		try {
+			await preflightDisposableDatabase(pool, databaseConfig.databaseName);
+		} catch (error) {
+			if (
+				!(error instanceof Error) ||
+				!error.message.startsWith(
+					"Refusing destructive approval migration verification",
+				)
+			) {
+				throw error;
+			}
+			customSchemaRefused = true;
+		} finally {
+			await pool.query('drop schema "approval_migration_preflight_probe"');
+		}
+		if (!customSchemaRefused) {
+			throw new Error("Custom schema preflight probe was not refused");
+		}
+		await preflightDisposableDatabase(pool, databaseConfig.databaseName);
+		destructiveResetAuthorized = true;
+		const database = drizzle({ client: pool });
+
+		console.log("Migration recovery verification: recreating incident state");
+		await migrate(database, { migrationsFolder: incidentMigrationsFolder });
+		await assertIncidentState(pool);
+
+		console.log("Migration recovery verification: applying recovery migration");
+		await migrate(database, { migrationsFolder: REAL_MIGRATIONS_FOLDER });
+		await assertRecoveryState(pool);
+
+		console.log("Migration recovery verification: checking retry idempotency");
+		const beforeRetry = await loadMigrationLedger(pool);
+		await migrate(database, { migrationsFolder: REAL_MIGRATIONS_FOLDER });
+		const afterRetry = await loadMigrationLedger(pool);
+		assertMigrationLedgerUnchanged(beforeRetry, afterRetry);
+		await assertRecoveryState(pool);
+
+		console.log(
+			"Migration recovery verification: checking anchor-present index recovery",
+		);
+		await pool.query(`drop index public."${PENDING_INDEX_NAME}"`);
+		await pool.query(`
+			create unique index "${PENDING_INDEX_NAME}"
+			on public.approval_workflow using btree
+			(organization_id, source_type, source_id)
+			where status = 'pending'
+		`);
+		const anchorResult = await pool.query<{ exists: boolean }>(`
+			select to_regclass('public.approval_workflow') is not null as exists
+		`);
+		if (anchorResult.rows[0]?.exists !== true) {
+			throw new Error(
+				"Approval workflow anchor table is absent before recovery replay",
+			);
+		}
+		const deletedRecovery = await pool.query(
+			"delete from drizzle.__drizzle_migrations where created_at = $1",
+			[RECOVERY_CREATED_AT],
+		);
+		if (deletedRecovery.rowCount !== 1) {
+			throw new Error("Expected to remove exactly one recovery ledger row");
+		}
+		const expandSql = await readFile(
+			join(REAL_MIGRATIONS_FOLDER, "0055_approval_workflow_expand.sql"),
+			"utf8",
+		);
+		const expandHash = createHash("sha256").update(expandSql).digest("hex");
+		await pool.query(
+			`
+				insert into drizzle.__drizzle_migrations (hash, created_at)
+				select $1, $2::bigint
+				where not exists (
+					select 1
+					from drizzle.__drizzle_migrations
+					where created_at = $2::bigint
+				)
+			`,
+			[expandHash, EXPAND_CREATED_AT],
+		);
+		await assertAnchorLedgerState(pool, expandHash, false);
+		await migrate(database, { migrationsFolder: REAL_MIGRATIONS_FOLDER });
+		await assertAnchorLedgerState(pool, expandHash, true);
+		await assertRecoveryState(pool);
+
+		console.log(
+			"Migration recovery verification: checking fresh migration chain",
+		);
+		if (!destructiveResetAuthorized) {
+			throw new Error(
+				"Refusing destructive schema reset without same-run test DB preflight",
+			);
+		}
+		await pool.query("drop schema if exists drizzle cascade");
+		await pool.query("drop schema public cascade");
+		await pool.query("create schema public authorization current_user");
+		await pool.query("grant all on schema public to public");
+		await migrate(database, { migrationsFolder: REAL_MIGRATIONS_FOLDER });
+		await assertRecoveryState(pool);
+
+		console.log("Migration recovery verification: passed");
+	} finally {
+		try {
+			await pool?.end();
+		} finally {
+			if (temporaryDirectory) {
+				await rm(temporaryDirectory, { recursive: true, force: true });
+			}
+		}
+	}
+}
+
+const invokedPath = process.argv[1]
+	? pathToFileURL(resolve(process.argv[1])).href
+	: "";
+if (import.meta.url === invokedPath) {
+	run().catch((error: unknown) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	});
+}

--- a/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
+++ b/apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
@@ -45,7 +45,15 @@ const migrationJournal = JSON.parse(
 		new URL("../../../drizzle/meta/_journal.json", import.meta.url),
 		"utf8",
 	),
-) as { entries: Array<{ idx: number; tag: string; when: number }> };
+) as {
+	entries: Array<{
+		idx: number;
+		version: string;
+		when: number;
+		tag: string;
+		breakpoints: boolean;
+	}>;
+};
 const migration0008Snapshot = JSON.parse(
 	readFileSync(
 		new URL("../../../drizzle/meta/0008_snapshot.json", import.meta.url),
@@ -136,6 +144,10 @@ const migration0057SnapshotUrl = new URL(
 );
 const migration0058ActivitySnapshotUrl = new URL(
 	"../../../drizzle/meta/0058_snapshot.json",
+	import.meta.url,
+);
+const migration0060Url = new URL(
+	"../../../drizzle/0060_approval_workflow_recovery.sql",
 	import.meta.url,
 );
 
@@ -1458,6 +1470,56 @@ function dailyRecoveryViolations(sql: string): string[] {
 	return violations;
 }
 
+function approvalRecoveryDestructiveOperationViolations(sql: string): string[] {
+	const withoutRequiredDeleteActions = sql.replaceAll(
+		/\bON\s+DELETE\s+CASCADE\b/gi,
+		"",
+	);
+	const violations: string[] = [];
+	const forbiddenOperations: Array<[label: string, pattern: RegExp]> = [
+		["DROP TABLE", /\bDROP\s+TABLE\b/i],
+		["DROP TYPE", /\bDROP\s+TYPE\b/i],
+		["DROP COLUMN", /\bDROP\s+COLUMN\b/i],
+		["ALTER COLUMN", /\bALTER\s+COLUMN\b/i],
+		["RENAME", /\bRENAME\b/i],
+		["TRUNCATE", /\bTRUNCATE\b/i],
+	];
+
+	if (/\bCASCADE\b/i.test(withoutRequiredDeleteActions)) {
+		violations.push("CASCADE");
+	}
+	for (const [label, pattern] of forbiddenOperations) {
+		if (pattern.test(sql)) violations.push(label);
+	}
+	if (/\bDELETE\s+FROM\s+(?:"public"\.)?"?approval_/i.test(sql)) {
+		violations.push("approval DELETE");
+	}
+	if (/\bUPDATE\s+(?:"public"\.)?"?approval_/i.test(sql)) {
+		violations.push("approval UPDATE");
+	}
+
+	return violations;
+}
+
+function uniqueMarkerIndex(sql: string, marker: string): number {
+	const firstIndex = sql.indexOf(marker);
+	if (firstIndex < 0 || sql.indexOf(marker, firstIndex + marker.length) >= 0) {
+		throw new Error(`Expected exactly one migration marker: ${marker}`);
+	}
+	return firstIndex;
+}
+
+function normalizeMigrationParity(sql: string): string {
+	return sql
+		.replaceAll("\r\n", "\n")
+		.replaceAll("\r", "\n")
+		.replaceAll(/\s*-->\s*statement-breakpoint\s*/g, "\n")
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.join("\n");
+}
+
 function enumMismatches(sql: string, expected: ExpectedEnum[]): string[] {
 	const actual = parsedEnums(sql);
 	return expected
@@ -1743,6 +1805,336 @@ const migration0004Statements = migration0004
 	.filter(Boolean);
 
 describe("drizzle follow-up migrations", () => {
+	it("allows only documented historical journal timestamp inversions", () => {
+		const allowedInversionTags = [
+			"0021_sick_detail",
+			"0027_employee_work_balance",
+		];
+		const inspectTimestamps = (entries: typeof migrationJournal.entries) => {
+			const inversions: Array<{ tag: string; context: string }> = [];
+			const violations: string[] = [];
+
+			entries.slice(1).forEach((entry, index) => {
+				const previous = entries[index];
+				if (entry.when === previous.when) {
+					violations.push(
+						`${entry.tag} (${entry.when}) must not equal ${previous.tag} (${previous.when})`,
+					);
+					return;
+				}
+				if (entry.when > previous.when) return;
+
+				const inversion = {
+					tag: entry.tag,
+					context: `${entry.tag} (${entry.when}) is earlier than ${previous.tag} (${previous.when})`,
+				};
+				inversions.push(inversion);
+				if (!allowedInversionTags.includes(entry.tag)) {
+					violations.push(inversion.context);
+				}
+			});
+
+			return { inversions, violations };
+		};
+		const { inversions, violations } = inspectTimestamps(
+			migrationJournal.entries,
+		);
+
+		expect(
+			violations,
+			"journal timestamp inversions must be explicitly allowlisted",
+		).toEqual([]);
+		expect(
+			inversions.map(({ tag }) => tag).sort(),
+			"historical journal timestamp inversion allowlist must remain necessary",
+		).toEqual([...allowedInversionTags].sort());
+
+		const equalityMutation = migrationJournal.entries.map(
+			(entry, index, entries) =>
+				entry.tag === "0021_sick_detail"
+					? { ...entry, when: entries[index - 1]?.when ?? entry.when }
+					: entry,
+		);
+		expect(inspectTimestamps(equalityMutation).violations).toEqual([
+			expect.stringContaining("0021_sick_detail"),
+		]);
+	});
+
+	it("keeps journal indices contiguous and aligned with tag prefixes", () => {
+		const violations = migrationJournal.entries.flatMap((entry, position) => {
+			const entryViolations: string[] = [];
+			if (entry.idx !== position) {
+				entryViolations.push(
+					`${entry.tag} has idx ${entry.idx}; expected contiguous idx ${position}`,
+				);
+			}
+
+			const tagPrefix = entry.tag.match(/^(\d{4})_/)?.[1];
+			const expectedPrefix = String(entry.idx).padStart(4, "0");
+			if (tagPrefix !== expectedPrefix) {
+				entryViolations.push(
+					`${entry.tag} prefix ${tagPrefix ?? "<missing>"} must match idx ${entry.idx} (${expectedPrefix})`,
+				);
+			}
+
+			return entryViolations;
+		});
+
+		expect(violations, "journal idx and tag prefix violations").toEqual([]);
+	});
+
+	it("keeps SQL migration tags aligned with the journal", () => {
+		const journalTags = migrationJournal.entries.map(({ tag }) => tag).sort();
+		const sqlTags = readdirSync(drizzleDirUrl)
+			.filter((filename) => /^\d{4}_.+\.sql$/.test(filename))
+			.map((filename) => filename.replace(/\.sql$/, ""));
+		const trackedSqlTags = sqlTags
+			.filter((tag) => tag !== "0051_daily_digest_delivery")
+			.sort();
+		const missingSqlTags = journalTags.filter(
+			(tag) => !trackedSqlTags.includes(tag),
+		);
+
+		expect(missingSqlTags, "journal tags missing a matching SQL file").toEqual(
+			[],
+		);
+		expect(
+			trackedSqlTags,
+			"SQL tags must match journal tags except 0051_daily_digest_delivery",
+		).toEqual(journalTags);
+	});
+
+	it("rejects duplicate SQL migration prefixes except historical 0051", () => {
+		const filenamesByPrefix = new Map<string, string[]>();
+		for (const filename of readdirSync(drizzleDirUrl).filter((filename) =>
+			/^\d{4}_.+\.sql$/.test(filename),
+		)) {
+			const prefix = filename.slice(0, 4);
+			filenamesByPrefix.set(prefix, [
+				...(filenamesByPrefix.get(prefix) ?? []),
+				filename,
+			]);
+		}
+		const duplicatePrefixes = Array.from(filenamesByPrefix)
+			.filter(
+				([prefix, filenames]) => prefix !== "0051" && filenames.length > 1,
+			)
+			.map(
+				([prefix, filenames]) => `${prefix}: ${filenames.sort().join(", ")}`,
+			);
+
+		expect(duplicatePrefixes, "duplicate four-digit SQL prefixes").toEqual([]);
+	});
+
+	it("registers the 0060 approval workflow recovery migration after 0059", () => {
+		const expectedTag = "0060_approval_workflow_recovery";
+		const recoveryIndex = migrationJournal.entries.findIndex(
+			({ tag }) => tag === expectedTag,
+		);
+		const payrollBlockerIndex = migrationJournal.entries.findIndex(
+			({ tag }) => tag === "0059_payroll_blocker_dismissal",
+		);
+		const recoveryEntry = migrationJournal.entries[recoveryIndex];
+		const latestPriorWhen = Math.max(
+			...migrationJournal.entries
+				.slice(0, recoveryIndex)
+				.map(({ when }) => when),
+		);
+
+		expect.soft(payrollBlockerIndex).toBeGreaterThanOrEqual(0);
+		expect.soft(recoveryIndex).toBeGreaterThan(payrollBlockerIndex);
+		expect.soft(recoveryEntry?.idx).toBe(60);
+		expect.soft(recoveryEntry?.tag).toBe(expectedTag);
+		expect.soft(recoveryEntry?.version).toBe("7");
+		expect.soft(recoveryEntry?.breakpoints).toBe(true);
+		expect
+			.soft(
+				recoveryEntry?.when ?? 0,
+				`${expectedTag} must be later than all prior entries`,
+			)
+			.toBeGreaterThan(latestPriorWhen);
+		expect
+			.soft(existsSync(migration0060Url), `${expectedTag}.sql must exist`)
+			.toBe(true);
+	});
+
+	it("recovers skipped approval workflow migrations without mutating approval rows", () => {
+		const migration = readRequiredMigration(
+			migration0060Url,
+			"0060 approval workflow recovery migration",
+		);
+		const recoveryGuard =
+			"IF to_regclass('public.approval_workflow') IS NULL THEN";
+		const recoveryGuardPosition = migration.indexOf(recoveryGuard);
+		const dailyRecoveryEndPosition = migration.indexOf(
+			"-- daily digest recovery: end",
+		);
+		const firstApprovalTypePosition = migration.indexOf(
+			'CREATE TYPE "public"."approval_actor_kind"',
+		);
+
+		expect(migration).toContain(recoveryGuard);
+		expect(dailyRecoveryViolations(migration)).toEqual([]);
+		expect(dailyRecoveryEndPosition).toBeLessThan(recoveryGuardPosition);
+		expect(recoveryGuardPosition).toBeLessThan(firstApprovalTypePosition);
+
+		for (const { name } of approvalWorkflowEnums) {
+			expect(migration, `missing approval enum ${name}`).toContain(
+				`CREATE TYPE "public"."${name}" AS ENUM`,
+			);
+		}
+		for (const table of Object.keys(canonicalApprovalTableColumns)) {
+			expect(migration, `missing canonical approval table ${table}`).toContain(
+				`CREATE TABLE "${table}" (`,
+			);
+		}
+		for (const table of [
+			"absence_entry",
+			"compliance_exception",
+			"shift_request",
+			"work_period",
+			"travel_expense_claim",
+		]) {
+			expect(migration, `missing ${table}.approval_workflow_id`).toContain(
+				`ALTER TABLE "${table}" ADD COLUMN "approval_workflow_id" uuid;`,
+			);
+		}
+
+		const pendingIndex: ExpectedIndex = {
+			name: "approvalWorkflow_org_source_pending_idx",
+			table: "approval_workflow",
+			columns: ["organization_id", "workflow_type", "source_type", "source_id"],
+			unique: true,
+			where: "status = 'pending'",
+		};
+		expect(migration).toContain(
+			'DROP INDEX IF EXISTS "approvalWorkflow_org_source_pending_idx";\n--> statement-breakpoint\nCREATE UNIQUE INDEX "approvalWorkflow_org_source_pending_idx" ON "approval_workflow" USING btree ("organization_id","workflow_type","source_type","source_id") WHERE status = \'pending\';',
+		);
+		expect(
+			parsedIndexes(migration).filter(({ name }) => name === pendingIndex.name),
+		).toEqual([pendingIndex]);
+
+		expect(approvalRecoveryDestructiveOperationViolations(migration)).toEqual(
+			[],
+		);
+
+		for (const unsafeSql of [
+			'DROP TABLE "approval_workflow";',
+			'DrOp TyPe "approval_workflow_status";',
+			'ALTER TABLE "approval_workflow" DROP COLUMN "status";',
+			'ALTER TABLE "approval_workflow" ALTER COLUMN "status" TYPE text;',
+			'ALTER TABLE "approval_workflow" RENAME COLUMN "status" TO "state";',
+			'TrUnCaTe TABLE "approval_workflow";',
+			'DELETE FROM "approval_workflow";',
+			'UPDATE "public"."approval_workflow" SET "status" = \'approved\';',
+			'DROP TABLE "approval_workflow" CASCADE;',
+		]) {
+			expect(
+				approvalRecoveryDestructiveOperationViolations(unsafeSql),
+				unsafeSql,
+			).not.toEqual([]);
+		}
+
+		expect(
+			approvalRecoveryDestructiveOperationViolations(`
+ALTER TABLE "absence_entry" DROP CONSTRAINT "absence_entry_organization_id_organization_id_fk";
+DROP INDEX IF EXISTS "approvalWorkflow_org_source_pending_idx";
+ALTER TABLE "approval_workflow_stage" ADD CONSTRAINT "stage_workflow_fk" FOREIGN KEY ("workflow_id") REFERENCES "approval_workflow"("id") ON DELETE cascade;
+`),
+		).toEqual([]);
+	});
+
+	it("preserves exact 0055 and 0056 approval migration semantics", () => {
+		const migration0055 = readFileSync(migration0054Url, "utf8");
+		const migration0056 = readFileSync(migration0055Url, "utf8");
+		const migration0060 = readRequiredMigration(
+			migration0060Url,
+			"0060 approval workflow recovery migration",
+		);
+		const dailyStartMarker = "-- daily digest recovery: begin";
+		const dailyEndMarker = "-- daily digest recovery: end";
+		const guardMarker =
+			"IF to_regclass('public.approval_workflow') IS NULL THEN";
+		const guardEndMarker = "\n\tEND IF;\nEND\n$approval_recovery$;";
+		const doEndMarker = "$approval_recovery$;";
+		const sourceDailyStart = uniqueMarkerIndex(migration0055, dailyStartMarker);
+		const sourceDailyEnd =
+			uniqueMarkerIndex(migration0055, dailyEndMarker) + dailyEndMarker.length;
+		const recoveryDailyStart = uniqueMarkerIndex(
+			migration0060,
+			dailyStartMarker,
+		);
+		const recoveryDailyEnd =
+			uniqueMarkerIndex(migration0060, dailyEndMarker) + dailyEndMarker.length;
+		const recoveryGuardStart =
+			uniqueMarkerIndex(migration0060, guardMarker) + guardMarker.length;
+		const recoveryGuardEnd = uniqueMarkerIndex(migration0060, guardEndMarker);
+		const recoveryTailStart =
+			uniqueMarkerIndex(migration0060, doEndMarker) + doEndMarker.length;
+		const sourceDaily = migration0055.slice(sourceDailyStart, sourceDailyEnd);
+		const recoveryDaily = migration0060.slice(
+			recoveryDailyStart,
+			recoveryDailyEnd,
+		);
+		const sourceApproval = migration0055.slice(sourceDailyEnd);
+		const recoveryApproval = migration0060.slice(
+			recoveryGuardStart,
+			recoveryGuardEnd,
+		);
+		const recoveryIndexTail = migration0060.slice(recoveryTailStart);
+		const normalizedSourceApproval = normalizeMigrationParity(sourceApproval);
+		const normalizedSourceIndexTail = normalizeMigrationParity(migration0056);
+		const normalizedRecoveryIndexTail = normalizeMigrationParity(
+			recoveryIndexTail,
+		).replace(
+			'DROP INDEX IF EXISTS "approvalWorkflow_org_source_pending_idx";',
+			'DROP INDEX "approvalWorkflow_org_source_pending_idx";',
+		);
+
+		expect(normalizeMigrationParity(recoveryDaily)).toBe(
+			normalizeMigrationParity(sourceDaily),
+		);
+		expect(normalizeMigrationParity(recoveryApproval)).toBe(
+			normalizedSourceApproval,
+		);
+		expect(normalizedRecoveryIndexTail).toBe(normalizedSourceIndexTail);
+
+		const compositeForeignKey = sourceApproval
+			.split(/\r?\n/)
+			.find((line) =>
+				line.includes(
+					'CONSTRAINT "approval_outbox_workflow_id_event_id_organization_id_event_type_',
+				),
+			);
+		if (!compositeForeignKey) {
+			throw new Error("Expected composite approval outbox foreign key in 0055");
+		}
+		for (const [label, mutatedApproval] of [
+			[
+				"removed composite foreign key",
+				sourceApproval.replace(compositeForeignKey, ""),
+			],
+			[
+				"changed enum value",
+				sourceApproval.replace("'legacy_unknown'", "'unknown'"),
+			],
+			[
+				"changed pending index column order",
+				sourceApproval.replace(
+					'("organization_id","source_type","source_id") WHERE status = \'pending\'',
+					'("organization_id","source_id","source_type") WHERE status = \'pending\'',
+				),
+			],
+		] as const) {
+			expect(mutatedApproval, `${label} mutation must change 0055`).not.toBe(
+				sourceApproval,
+			);
+			expect(normalizeMigrationParity(mutatedApproval), label).not.toBe(
+				normalizedSourceApproval,
+			);
+		}
+	});
+
 	it("replaces the pending workflow index with exact typed source cycle identity", () => {
 		const migration = readRequiredMigration(
 			migration0055Url,

--- a/apps/webapp/src/db/__tests__/verify-approval-migration-recovery.test.ts
+++ b/apps/webapp/src/db/__tests__/verify-approval-migration-recovery.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ApprovalCatalog,
+	assertApprovalCatalog,
+	assertDisposableDatabasePreflight,
+	assertMigrationLedgerUnchanged,
+	buildCatalogNamespaceCountQuery,
+	filterIncidentJournal,
+	normalizeMigrationLedger,
+	parseTestDatabaseConfig,
+	sumCatalogNamespaceCounts,
+} from "../../../scripts/verify-approval-migration-recovery";
+
+describe("destructive database safety", () => {
+	it.each([
+		"postgresql://postgres:secret@127.0.0.1:5432/approval_workflow_repository_test_local",
+		"postgresql://postgres:secret@localhost:5432/approval_workflow_repository_test_local",
+		"postgresql://postgres:secret@[::1]:5432/approval_workflow_repository_test_local",
+	])("accepts an isolated loopback PostgreSQL URL", (databaseUrl) => {
+		expect(
+			parseTestDatabaseConfig(databaseUrl, "approval-workflow-repository-test"),
+		).toMatchObject({
+			databaseUrl,
+			databaseName: "approval_workflow_repository_test_local",
+		});
+	});
+
+	it("rejects a remote database without exposing URL credentials", () => {
+		const databaseUrl =
+			"postgresql://postgres:do-not-log@example.com/approval_workflow_repository_test_remote";
+		let message = "";
+		try {
+			parseTestDatabaseConfig(databaseUrl, "approval-workflow-repository-test");
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toContain("loopback");
+		expect(message).not.toContain("do-not-log");
+	});
+
+	it("rejects a non-PostgreSQL protocol", () => {
+		expect(() =>
+			parseTestDatabaseConfig(
+				"https://localhost/approval_workflow_repository_test_local",
+				"approval-workflow-repository-test",
+			),
+		).toThrow("PostgreSQL protocol");
+	});
+
+	it.each([
+		"?host=db.example.com",
+		"?application_name=approval-migration-verifier",
+	])("rejects database URL query parameters: %s", (search) => {
+		expect(() =>
+			parseTestDatabaseConfig(
+				`postgresql://postgres:secret@127.0.0.1:5432/approval_workflow_repository_test_local${search}`,
+				"approval-workflow-repository-test",
+			),
+		).toThrow("must not include query parameters");
+	});
+
+	it("accepts matching empty database catalog evidence", () => {
+		expect(() =>
+			assertDisposableDatabasePreflight({
+				expectedDatabaseName: "approval_workflow_repository_test_expected",
+				currentDatabaseName: "approval_workflow_repository_test_expected",
+				drizzleSchemaExists: false,
+				publicSchemaObjectCount: BigInt(0),
+				unexpectedUserSchemaCount: BigInt(0),
+			}),
+		).not.toThrow();
+	});
+
+	it.each([
+		{
+			name: "wrong current database",
+			evidence: {
+				expectedDatabaseName: "approval_workflow_repository_test_expected",
+				currentDatabaseName: "approval_workflow_repository_test_other",
+				drizzleSchemaExists: false,
+				publicSchemaObjectCount: BigInt(0),
+				unexpectedUserSchemaCount: BigInt(0),
+			},
+		},
+		{
+			name: "public schema object",
+			evidence: {
+				expectedDatabaseName: "approval_workflow_repository_test_expected",
+				currentDatabaseName: "approval_workflow_repository_test_expected",
+				drizzleSchemaExists: false,
+				publicSchemaObjectCount: BigInt(1),
+				unexpectedUserSchemaCount: BigInt(0),
+			},
+		},
+		{
+			name: "preexisting drizzle schema",
+			evidence: {
+				expectedDatabaseName: "approval_workflow_repository_test_expected",
+				currentDatabaseName: "approval_workflow_repository_test_expected",
+				drizzleSchemaExists: true,
+				publicSchemaObjectCount: BigInt(0),
+				unexpectedUserSchemaCount: BigInt(0),
+			},
+		},
+		{
+			name: "unexpected user schema",
+			evidence: {
+				expectedDatabaseName: "approval_workflow_repository_test_expected",
+				currentDatabaseName: "approval_workflow_repository_test_expected",
+				drizzleSchemaExists: false,
+				publicSchemaObjectCount: BigInt(0),
+				unexpectedUserSchemaCount: BigInt(1),
+			},
+		},
+	])("rejects $name", ({ evidence }) => {
+		expect(() => assertDisposableDatabasePreflight(evidence)).toThrow(
+			"Refusing destructive approval migration verification",
+		);
+	});
+
+	it("builds a parameterized count for validated discovered catalog identifiers", () => {
+		expect(
+			buildCatalogNamespaceCountQuery({
+				tableName: "pg_collation",
+				columnName: "collnamespace",
+			}),
+		).toBe(
+			'select count(*)::text as count from pg_catalog."pg_collation" where "collnamespace" = $1::oid',
+		);
+	});
+
+	it.each([
+		{ tableName: "pg_class; drop table users", columnName: "relnamespace" },
+		{ tableName: "public_table", columnName: "relnamespace" },
+		{ tableName: "pg_class", columnName: 'relnamespace"' },
+		{ tableName: "pg_class", columnName: "relowner" },
+	])(
+		"rejects untrusted discovered catalog identifiers: $tableName.$columnName",
+		(reference) => {
+			expect(() => buildCatalogNamespaceCountQuery(reference)).toThrow(
+				"Invalid pg_catalog namespace reference",
+			);
+		},
+	);
+
+	it("sums discovered catalog counts without numeric precision loss", () => {
+		expect(
+			sumCatalogNamespaceCounts([
+				{ count: "9007199254740993" },
+				{ count: BigInt(2) },
+				{ count: 4 },
+			]),
+		).toBe(BigInt("9007199254740999"));
+	});
+});
+
+describe("filterIncidentJournal", () => {
+	it("removes the skipped approval migrations and recovery while retaining later migrations", () => {
+		const journal = {
+			version: "7",
+			dialect: "postgresql",
+			entries: [
+				{ tag: "0054_employee_invitation_draft_identity" },
+				{ tag: "0055_approval_workflow_expand" },
+				{ tag: "0056_approval_workflow_cycle_identity" },
+				{ tag: "0057_team_permissions_uniqueness" },
+				{ tag: "0058_employee_clock_activity_index" },
+				{ tag: "0059_payroll_blocker_dismissal" },
+				{ tag: "0060_approval_workflow_recovery" },
+			],
+		};
+
+		expect(
+			filterIncidentJournal(journal).entries.map((entry) => entry.tag),
+		).toEqual([
+			"0054_employee_invitation_draft_identity",
+			"0057_team_permissions_uniqueness",
+			"0058_employee_clock_activity_index",
+			"0059_payroll_blocker_dismissal",
+		]);
+	});
+});
+
+describe("migration ledger retry comparison", () => {
+	const ledger = [
+		{ id: 1, hash: "first", created_at: BigInt("1785493929039") },
+		{
+			id: "2",
+			hash: "second",
+			created_at: new Date("2026-07-31T12:00:00.000Z"),
+		},
+	];
+
+	it("normalizes bigint and timestamp representations deterministically", () => {
+		expect(normalizeMigrationLedger(ledger)).toEqual([
+			{ id: "1", hash: "first", createdAt: "1785493929039" },
+			{
+				id: "2",
+				hash: "second",
+				createdAt: "2026-07-31T12:00:00.000Z",
+			},
+		]);
+	});
+
+	it.each(["id", "hash", "created_at"] as const)(
+		"rejects a changed %s after migration replay",
+		(field) => {
+			const replayed = ledger.map((row) => ({ ...row }));
+			replayed[1] = { ...replayed[1], [field]: "changed" };
+
+			expect(() => assertMigrationLedgerUnchanged(ledger, replayed)).toThrow(
+				"Retry changed the Drizzle migration ledger",
+			);
+		},
+	);
+});
+
+describe("assertApprovalCatalog", () => {
+	const validCatalog: ApprovalCatalog = {
+		tables: [
+			"approval_inbox_projection",
+			"approval_outbox",
+			"approval_outbox_delivery",
+			"approval_requester_projection",
+			"approval_stage_assignment",
+			"approval_workflow",
+			"approval_workflow_command",
+			"approval_workflow_event",
+			"approval_workflow_migration_issue",
+			"approval_workflow_rollout",
+			"approval_workflow_stage",
+		],
+		columns: [
+			{ table: "absence_entry", name: "approval_workflow_id", type: "uuid" },
+			{
+				table: "compliance_exception",
+				name: "approval_workflow_id",
+				type: "uuid",
+			},
+			{ table: "shift_request", name: "approval_workflow_id", type: "uuid" },
+			{
+				table: "travel_expense_claim",
+				name: "approval_workflow_id",
+				type: "uuid",
+			},
+			{ table: "work_period", name: "approval_workflow_id", type: "uuid" },
+		],
+		indexes: [
+			{
+				name: "approvalWorkflow_org_source_pending_idx",
+				table: "approval_workflow",
+				unique: true,
+				columns: [
+					"organization_id",
+					"workflow_type",
+					"source_type",
+					"source_id",
+				],
+				predicate: "(status = 'pending'::approval_workflow_status)",
+			},
+		],
+	};
+
+	it("accepts the canonical approval tables, source UUIDs, and pending identity index", () => {
+		expect(() => assertApprovalCatalog(validCatalog)).not.toThrow();
+	});
+
+	it("rejects a pending identity index with the legacy column order", () => {
+		expect(() =>
+			assertApprovalCatalog({
+				...validCatalog,
+				indexes: [
+					{
+						...validCatalog.indexes[0],
+						columns: ["organization_id", "source_type", "source_id"],
+					},
+				],
+			}),
+		).toThrow("approvalWorkflow_org_source_pending_idx");
+	});
+});

--- a/apps/webapp/src/db/schema/__tests__/payroll-blocker-schema.test.ts
+++ b/apps/webapp/src/db/schema/__tests__/payroll-blocker-schema.test.ts
@@ -167,7 +167,6 @@ describe("payroll blocker dismissal schema", () => {
 			...journal.entries.slice(0, migrationIndex).map((entry) => entry.when),
 		);
 
-		expect(migrationIndex).toBe(journal.entries.length - 1);
 		expect(migrationEntry).toMatchObject({
 			breakpoints: true,
 			idx: 59,

--- a/apps/webapp/src/lib/approvals/workflow/repository-integration-ci.test.ts
+++ b/apps/webapp/src/lib/approvals/workflow/repository-integration-ci.test.ts
@@ -36,13 +36,10 @@ describe("approval workflow repository integration CI contract", () => {
           database_name="approval_workflow_repository_test_\${GITHUB_RUN_ID}_\${GITHUB_RUN_ATTEMPT}"`,
 		);
 		expect(workflow).toContain(
-			"SKIP_ENV_VALIDATION=1 pnpm --filter webapp exec drizzle-kit migrate",
-		);
-		expect(workflow).toContain(
-			`APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/\${database_name}"`,
-		);
-		expect(workflow).toContain(
-			"APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test",
+			`SKIP_ENV_VALIDATION=1 \\
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/\${database_name}" \\
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \\
+          pnpm --filter webapp exec tsx scripts/verify-approval-migration-recovery.ts`,
 		);
 		expect(workflow).toContain("APPROVAL_WORKFLOW_REPOSITORY_TEST_REQUIRED=1");
 		expect(workflow).toContain(

--- a/apps/webapp/src/lib/approvals/workflow/repository-integration-runner.test.ts
+++ b/apps/webapp/src/lib/approvals/workflow/repository-integration-runner.test.ts
@@ -19,16 +19,7 @@ describe("approval workflow repository integration runner", () => {
 		);
 		expect(runner).toContain("approval_workflow_repository_test_");
 		expect(runner).toContain("pg_isready");
-		expect(runner).toContain(
-			'pnpm --dir "$app_directory" exec drizzle-kit migrate',
-		);
-		expect(runner).toContain("SKIP_ENV_VALIDATION=1");
-		expect(runner).toContain(
-			"APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test",
-		);
 		expect(runner).toContain("APPROVAL_WORKFLOW_REPOSITORY_TEST_REQUIRED=1");
-		expect(runner).toContain('POSTGRES_DB="$database_name"');
-		expect(runner).toContain('POSTGRES_PORT="$host_port"');
 		expect(runner).toContain(`POSTGRES_HOST=127.0.0.1 \\
 POSTGRES_PORT="$host_port" \\
 POSTGRES_DB="$database_name" \\
@@ -36,8 +27,8 @@ POSTGRES_USER=postgres \\
 POSTGRES_PASSWORD="$database_password" \\
 POSTGRES_SSL_MODE=disable \\
 PGOPTIONS="-c statement_timeout=15000 -c timezone=UTC" \\
-NODE_OPTIONS="\${NODE_OPTIONS:+\${NODE_OPTIONS} }--throw-deprecation" \\
 APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL=`);
+		expect(runner).not.toContain("--throw-deprecation");
 		expect(runner).toContain("docker inspect");
 		expect(runner).toContain("trap cleanup EXIT");
 		expect(runner).toContain("Verified container ownership label");
@@ -52,5 +43,27 @@ APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL=`);
 		expect(runner).toContain(
 			"src/lib/approvals/server/work-period-approvals.integration.test.ts",
 		);
+	});
+
+	it("passes the required database safety environment to the migration verifier", async () => {
+		const runner = await readFile(runnerPath, "utf8");
+		const verifierCommandBlock = runner.match(
+			/(?:^[A-Z][A-Z_]*=.* \\\n)+^pnpm --dir "\$app_directory" exec tsx \.\/scripts\/verify-approval-migration-recovery\.ts$/m,
+		)?.[0];
+
+		expect(verifierCommandBlock).toBeDefined();
+		for (const assignment of [
+			"POSTGRES_HOST=127.0.0.1",
+			'POSTGRES_PORT="$host_port"',
+			'POSTGRES_DB="$database_name"',
+			"POSTGRES_USER=postgres",
+			'POSTGRES_PASSWORD="$database_password"',
+			"POSTGRES_SSL_MODE=disable",
+			"SKIP_ENV_VALIDATION=1",
+			"APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL=",
+			"APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test",
+		]) {
+			expect(verifierCommandBlock).toContain(assignment);
+		}
 	});
 });

--- a/docs/superpowers/plans/2026-07-31-approval-migration-recovery.md
+++ b/docs/superpowers/plans/2026-07-31-approval-migration-recovery.md
@@ -1,0 +1,419 @@
+# Approval Migration Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair databases that recorded migration `0059` before the approval workflow migrations merged, and prevent future migrations from being silently inserted behind deployed journal timestamps.
+
+**Architecture:** Add a new, last-in-journal `0060` migration that conditionally executes the complete approval expansion when its transactional anchor table is absent and independently reconciles the cycle-identity index. Add static repository invariants plus a disposable-PostgreSQL verifier that recreates the exact production history, applies the current journal, retries it, and also validates a fresh install.
+
+**Tech Stack:** PostgreSQL 16, Drizzle ORM/Kit, TypeScript, Vitest, Node.js, pnpm, Docker
+
+---
+
+## File Map
+
+- Create `apps/webapp/drizzle/0060_approval_workflow_recovery.sql`: authoritative idempotent recovery for skipped `0055` and `0056`.
+- Modify `apps/webapp/drizzle/meta/_journal.json`: preserve published historical timestamps and register `0060` after `0059`.
+- Modify `apps/webapp/src/db/__tests__/drizzle-migrations.test.ts`: enforce global journal/file invariants and the `0060` SQL contract.
+- Create `apps/webapp/scripts/verify-approval-migration-recovery.ts`: reproduce the deployed-through-`0059` state without approval migrations, apply recovery, retry it, and verify a fresh migration chain.
+- Modify `apps/webapp/scripts/run-approval-workflow-repository-integration.sh`: run the recovery verifier before approval repository integration tests.
+- Modify `.github/workflows/tests.yml`: use the same recovery verifier in CI instead of testing only a fresh migration chain.
+
+### Task 1: Add Failing Migration-History Guardrails
+
+**Files:**
+- Modify: `apps/webapp/src/db/__tests__/drizzle-migrations.test.ts:43-48,1745-1790`
+- Test: `apps/webapp/src/db/__tests__/drizzle-migrations.test.ts`
+
+- [ ] **Step 1: Add the repository-wide journal and SQL-file tests**
+
+Add these tests near the start of `describe("drizzle follow-up migrations", ...)`:
+
+```ts
+it("allows only recovered historical timestamp inversions", () => {
+	const recoveredHistoricalInversions = new Set([
+		"0021_sick_detail",
+		"0027_employee_work_balance",
+	]);
+
+	for (let index = 1; index < migrationJournal.entries.length; index += 1) {
+		const previous = migrationJournal.entries[index - 1];
+		const current = migrationJournal.entries[index];
+
+		if (current.when <= previous.when) {
+			expect(
+				recoveredHistoricalInversions.has(current.tag),
+				`${current.tag} must be later than ${previous.tag}`,
+			).toBe(true);
+		}
+	}
+});
+
+it("keeps journal tags and SQL files aligned", () => {
+	const historicalOrphans = new Set(["0051_daily_digest_delivery"]);
+	const sqlTags = readdirSync(drizzleDirUrl)
+		.filter((fileName) => fileName.endsWith(".sql"))
+		.map((fileName) => fileName.replace(/\.sql$/, ""));
+	const journalTags = migrationJournal.entries.map((entry) => entry.tag);
+
+	expect(
+		sqlTags.filter(
+			(tag) => !historicalOrphans.has(tag) && !journalTags.includes(tag),
+		),
+	).toEqual([]);
+	expect(journalTags.filter((tag) => !sqlTags.includes(tag))).toEqual([]);
+});
+
+it("does not introduce duplicate migration prefixes", () => {
+	const allowedDuplicatePrefixes = new Set(["0051"]);
+	const prefixes = readdirSync(drizzleDirUrl)
+		.filter((fileName) => fileName.endsWith(".sql"))
+		.map((fileName) => fileName.slice(0, 4));
+	const duplicates = prefixes.filter(
+		(prefix, index) =>
+			prefixes.indexOf(prefix) !== index &&
+			!allowedDuplicatePrefixes.has(prefix),
+	);
+
+	expect([...new Set(duplicates)]).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Add the failing `0060` registration contract**
+
+Add a URL constant for `../../../drizzle/0060_approval_workflow_recovery.sql`, then add:
+
+```ts
+it("registers approval recovery after every deployed migration", () => {
+	const recoveryIndex = migrationJournal.entries.findIndex(
+		(entry) => entry.tag === "0060_approval_workflow_recovery",
+	);
+	const recoveryEntry = migrationJournal.entries[recoveryIndex];
+	const latestPriorWhen = Math.max(
+		...migrationJournal.entries
+			.slice(0, recoveryIndex)
+			.map((entry) => entry.when),
+	);
+
+	expect(recoveryIndex).toBeGreaterThan(
+		migrationJournal.entries.findIndex(
+			(entry) => entry.tag === "0059_payroll_blocker_dismissal",
+		),
+	);
+	expect(recoveryEntry).toMatchObject({
+		idx: 60,
+		version: "7",
+		tag: "0060_approval_workflow_recovery",
+		breakpoints: true,
+	});
+	expect(recoveryEntry?.when).toBeGreaterThan(latestPriorWhen);
+	expect(existsSync(migration0060Url)).toBe(true);
+});
+```
+
+- [ ] **Step 3: Run the focused test and confirm the intended failures**
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
+
+Expected: the two documented historical inversions pass, and the test fails because `0060_approval_workflow_recovery` does not exist.
+
+- [ ] **Step 4: Commit the failing guardrails**
+
+```bash
+git add apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
+git commit -m "test: guard global migration ordering"
+```
+
+### Task 2: Register the Recovery After All Deployed Migrations
+
+**Files:**
+- Modify: `apps/webapp/drizzle/meta/_journal.json:146-205,418-424`
+- Test: `apps/webapp/src/db/__tests__/drizzle-migrations.test.ts`
+
+- [ ] **Step 1: Preserve published historical migration identities**
+
+Do not change the existing `when` values for `0021_sick_detail`, `0022_absence_category_translations`, or `0027_employee_work_balance`. Their published values remain:
+
+```json
+{
+  "tag": "0021_sick_detail",
+  "when": 1778827536858
+}
+```
+
+```json
+{
+  "tag": "0027_employee_work_balance",
+  "when": 1778889600000
+}
+```
+
+- [ ] **Step 2: Append the recovery entry**
+
+Append this entry after `0059`:
+
+```json
+{
+  "idx": 60,
+  "version": "7",
+  "when": 1785493929040,
+  "tag": "0060_approval_workflow_recovery",
+  "breakpoints": true
+}
+```
+
+- [ ] **Step 3: Run the focused test**
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
+
+Expected: the historical-inversion allowlist and recovery metadata tests pass; only SQL alignment/existence fails because the recovery file does not exist.
+
+- [ ] **Step 4: Commit the journal repair**
+
+```bash
+git add apps/webapp/drizzle/meta/_journal.json
+git commit -m "fix: restore monotonic migration journal"
+```
+
+### Task 3: Implement Retry-Safe Approval Recovery SQL
+
+**Files:**
+- Create: `apps/webapp/drizzle/0060_approval_workflow_recovery.sql`
+- Reference: `apps/webapp/drizzle/0055_approval_workflow_expand.sql`
+- Reference: `apps/webapp/drizzle/0056_approval_workflow_cycle_identity.sql`
+- Test: `apps/webapp/src/db/__tests__/drizzle-migrations.test.ts`
+
+- [ ] **Step 1: Add a failing recovery SQL contract**
+
+Read `0060` with `readRequiredMigration`, then assert:
+
+```ts
+it("recovers skipped approval expansion behind a transactional anchor", () => {
+	const recovery = readRequiredMigration(
+		migration0060Url,
+		"0060 approval workflow recovery migration",
+	);
+
+	expect(recovery).toContain(
+		"IF to_regclass('public.approval_workflow') IS NULL THEN",
+	);
+	for (const enumName of approvalWorkflowEnums.map(({ name }) => name)) {
+		expect(recovery).toContain(`CREATE TYPE "public"."${enumName}"`);
+	}
+	for (const tableName of Object.keys(canonicalApprovalTableColumns)) {
+		expect(recovery).toContain(`CREATE TABLE "${tableName}"`);
+	}
+	for (const sourceTable of [
+		"absence_entry",
+		"compliance_exception",
+		"shift_request",
+		"work_period",
+		"travel_expense_claim",
+	]) {
+		expect(recovery).toContain(
+			`ALTER TABLE "${sourceTable}" ADD COLUMN "approval_workflow_id" uuid`,
+		);
+	}
+	expect(recovery).toContain(
+		'CREATE UNIQUE INDEX "approvalWorkflow_org_source_pending_idx" ON "approval_workflow" USING btree ("organization_id","workflow_type","source_type","source_id") WHERE status = \'pending\'',
+	);
+});
+```
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
+
+Expected: FAIL until `0060` contains the complete retry-safe contract.
+
+- [ ] **Step 2: Create the idempotent recovery migration**
+
+Use `0055` as the semantic source of truth and preserve its statement order. Keep the daily-digest recovery at the start, then place the approval expansion inside one transactional-anchor block:
+
+```sql
+-- Recover 0055/0056 after they were merged behind already-deployed migration 0059.
+-- PostgreSQL commits 0055 atomically, so approval_workflow distinguishes skipped and applied states.
+DO $approval_recovery$
+BEGIN
+	IF to_regclass('public.approval_workflow') IS NULL THEN
+```
+
+Keep the existing daily-digest recovery block unchanged outside the anchor block. Copy all approval DDL from lines 27-310 of `0055` into the `IF` body, removing Drizzle `statement-breakpoint` comments inside the block but making no semantic DDL changes. This deliberately preserves the all-or-nothing `0055` contract rather than trying to infer a partially applied state that PostgreSQL transactions cannot produce.
+
+Close the anchor block immediately after the copied `shift_request_approval_workflow_organization_check` statement:
+
+```sql
+	END IF;
+END
+$approval_recovery$;
+```
+
+Finish with an independent, exact `0056` reconciliation:
+
+```sql
+DROP INDEX IF EXISTS "approvalWorkflow_org_source_pending_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "approvalWorkflow_org_source_pending_idx"
+	ON "approval_workflow" USING btree
+	("organization_id","workflow_type","source_type","source_id")
+	WHERE status = 'pending';
+```
+
+Do not use `CASCADE`, delete rows, update approval rows, or weaken organization-scoped foreign keys.
+
+- [ ] **Step 3: Run static migration tests**
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the recovery migration**
+
+```bash
+git add apps/webapp/drizzle/0060_approval_workflow_recovery.sql apps/webapp/src/db/__tests__/drizzle-migrations.test.ts
+git commit -m "fix: recover skipped approval migrations"
+```
+
+### Task 4: Reproduce the Production Migration History in PostgreSQL
+
+**Files:**
+- Create: `apps/webapp/scripts/verify-approval-migration-recovery.ts`
+- Modify: `apps/webapp/scripts/run-approval-workflow-repository-integration.sh:66-74`
+
+- [ ] **Step 1: Create the incident-history verifier**
+
+The script must:
+
+1. Require `APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL` and the existing sentinel.
+2. Copy `drizzle/` to an OS temporary directory.
+3. Remove journal entries `0055`, `0056`, and `0060` from the temporary journal while retaining `0057`-`0059`.
+4. Run Drizzle migrate against that temporary folder.
+5. Assert `drizzle.__drizzle_migrations` ends at `1785493929039` and `work_period.approval_workflow_id` is absent.
+6. Run Drizzle migrate against the real folder.
+7. Assert the approval tables, source columns, and four-column cycle index exist.
+8. Run Drizzle migrate against the real folder again and assert success.
+9. Drop and recreate the isolated test database's `public` schema and drop its `drizzle` schema so the migration ledger is empty.
+10. Run the full real migration folder from empty and assert the same schema contract.
+11. Remove the temporary migration directory in `finally`.
+
+Use these core imports and migration call:
+
+```ts
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: databaseUrl });
+const database = drizzle(pool);
+await migrate(database, { migrationsFolder });
+```
+
+Query `pg_indexes.indexdef` and require its normalized definition to contain:
+
+```text
+UNIQUE INDEX "approvalWorkflow_org_source_pending_idx"
+(organization_id, workflow_type, source_type, source_id)
+WHERE (status = 'pending'::approval_workflow_status)
+```
+
+- [ ] **Step 2: Replace the shell script's fresh-only migration command**
+
+Replace lines 66-74 of `run-approval-workflow-repository-integration.sh` with:
+
+```bash
+printf 'Verifying skipped, retried, and fresh approval migration histories\n'
+POSTGRES_HOST=127.0.0.1 \
+POSTGRES_PORT="$host_port" \
+POSTGRES_DB="$database_name" \
+POSTGRES_USER=postgres \
+POSTGRES_PASSWORD="$database_password" \
+POSTGRES_SSL_MODE=disable \
+SKIP_ENV_VALIDATION=1 \
+APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:${database_password}@127.0.0.1:${host_port}/${database_name}" \
+APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \
+pnpm --dir "$app_directory" exec tsx scripts/verify-approval-migration-recovery.ts
+```
+
+- [ ] **Step 3: Run the disposable PostgreSQL verification**
+
+Run: `pnpm --dir apps/webapp test:approval-workflow-repository:integration`
+
+Expected: the script reports the skipped state, recovered state, retry, and fresh state; then all four approval integration suites pass and the label-owned container is removed.
+
+- [ ] **Step 4: Commit the integration verifier**
+
+```bash
+git add apps/webapp/scripts/verify-approval-migration-recovery.ts apps/webapp/scripts/run-approval-workflow-repository-integration.sh
+git commit -m "test: reproduce skipped approval migration"
+```
+
+### Task 5: Run the Recovery Verifier in CI
+
+**Files:**
+- Modify: `.github/workflows/tests.yml:88-110`
+
+- [ ] **Step 1: Replace CI's fresh-only migration step**
+
+After exporting the PostgreSQL variables, replace direct `drizzle-kit migrate` with:
+
+```yaml
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/${database_name}" \
+          APPROVAL_WORKFLOW_REPOSITORY_TEST_SENTINEL=approval-workflow-repository-test \
+          pnpm --filter webapp exec tsx scripts/verify-approval-migration-recovery.ts
+```
+
+Keep the existing four approval integration test files unchanged.
+
+- [ ] **Step 2: Validate the workflow and focused tests**
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts`
+
+Expected: PASS.
+
+Run: `pnpm exec prettier --check .github/workflows/tests.yml apps/webapp/scripts/verify-approval-migration-recovery.ts`
+
+Expected: PASS. If the repository formatter reports changes, run the repository's existing formatter only on these two files and repeat the check.
+
+- [ ] **Step 3: Commit the CI coverage**
+
+```bash
+git add .github/workflows/tests.yml
+git commit -m "ci: verify approval migration recovery"
+```
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify all files changed in Tasks 1-5.
+
+- [ ] **Step 1: Run the migration contract suite**
+
+Run: `pnpm --dir apps/webapp test src/db/__tests__/drizzle-migrations.test.ts src/db/schema/__tests__/approval-workflow-schema.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the real PostgreSQL recovery and approval suites**
+
+Run: `pnpm --dir apps/webapp test:approval-workflow-repository:integration`
+
+Expected: PASS with no disposable container remaining.
+
+- [ ] **Step 3: Run webapp type checking**
+
+Run: `pnpm --dir apps/webapp typecheck`
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run: `git status --short && git diff --check && git diff -- apps/webapp/drizzle apps/webapp/src/db/__tests__/drizzle-migrations.test.ts apps/webapp/scripts .github/workflows/tests.yml`
+
+Expected: only intended migration recovery, tests, verifier, workflow, spec, and plan changes; no whitespace errors.
+
+- [ ] **Step 5: Commit any final verification-only corrections**
+
+```bash
+git add apps/webapp/drizzle apps/webapp/src/db/__tests__/drizzle-migrations.test.ts apps/webapp/scripts .github/workflows/tests.yml docs/superpowers/specs/2026-07-31-approval-migration-recovery-design.md docs/superpowers/plans/2026-07-31-approval-migration-recovery.md
+git commit -m "fix: complete approval migration recovery"
+```

--- a/docs/superpowers/specs/2026-07-31-approval-migration-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-31-approval-migration-recovery-design.md
@@ -1,0 +1,75 @@
+# Approval Migration Recovery Design
+
+## Problem
+
+Production recorded `0059_payroll_blocker_dismissal` before the approval workflow branch merged. The later merge placed these migrations before `0059` in the journal:
+
+- `0055_approval_workflow_expand` at `1785232090757`
+- `0056_approval_workflow_cycle_identity` at `1785232118219`
+
+Production had already recorded `0059` at `1785493929039`. Drizzle applies only journal entries whose `when` value is greater than the latest `drizzle.__drizzle_migrations.created_at` value. It therefore skipped both approval migrations without error. The deployed application then queried approval columns such as `work_period.approval_workflow_id`, which did not exist.
+
+The repository also contains older non-increasing journal entries at `0021` and `0027`, but later idempotent recovery migrations already cover those historical skips. They are not the cause of this incident.
+
+## Constraints
+
+- Do not rewrite production migration records or assume direct database access.
+- Do not renumber or replay the existing non-idempotent approval migrations.
+- Preserve databases where `0055` and `0056` already ran successfully.
+- Repair databases that reached `0059` without either approval migration.
+- Keep the recovery safe to retry after a failed deployment.
+- Add the recovery after every existing journal timestamp.
+
+## Recovery Migration
+
+Add `0060_approval_workflow_recovery.sql` and a matching journal entry whose `when` value is greater than `1785493929039`.
+
+Preserve the published timestamps for the historical `0021` and `0027` inversions. Changing those migration identities could make old, non-idempotent SQL replay on a database paused at one of those historical boundaries. Their later recovery migrations (`0051_sick_detail_recovery` and `0029_employee_work_balance_recovery`) remain authoritative for databases that skipped them.
+
+The migration uses `approval_workflow` as the atomic anchor for `0055`. PostgreSQL migrations are transactional, so the supported states are:
+
+1. The anchor is absent and the complete approval expansion must be installed.
+2. The anchor is present because the complete approval expansion already committed.
+
+When the anchor is absent, the recovery executes the complete schema work represented by `0055`, including approval enums, canonical tables, source-link columns, indexes, checks, unique constraints, and organization-scoped foreign keys. It must also retain the existing idempotent daily-digest recovery that precedes approval schema creation in `0055`.
+
+When the anchor is present, the recovery does not recreate approval enums, tables, columns, or constraints and does not mutate approval data.
+
+After the expansion check, the migration independently reconciles `approvalWorkflow_org_source_pending_idx` to the `0056` definition. This step drops only that named index when its existing definition differs, then creates the required unique partial index over:
+
+```text
+organization_id, workflow_type, source_type, source_id
+```
+
+with predicate `status = 'pending'`.
+
+This independent index reconciliation handles a database where `0055` committed but `0056` did not.
+
+## Migration Guardrails
+
+Extend migration tests with repository-wide invariants:
+
+- Every journal inversion must match the explicit historical allowlist for `0021` or `0027`; no new inversion is permitted.
+- Every non-exempt journal tag must have one matching SQL file, and every non-exempt SQL file must have one matching journal tag.
+- Duplicate numeric SQL prefixes are rejected unless explicitly documented as a historical orphan with a later recovery.
+- A newly added migration cannot have a `when` value below the maximum preceding value.
+- `0060` must be registered after `0059` with a timestamp greater than every preceding migration.
+
+The historical `0051_daily_digest_delivery.sql` orphan remains explicitly documented because `0055` and the new recovery cover it. The test should not mistake that known file for a new deployable journal entry.
+
+## Verification
+
+Verify these database histories:
+
+1. **Production incident state:** migrations through `0054` plus `0057`-`0059`, with approval schema absent. Applying current migrations creates the complete approval schema and records `0060`.
+2. **Already migrated state:** migrations through `0059`, including `0055` and `0056`. Applying `0060` succeeds without recreating objects or changing data.
+3. **Fresh state:** applying the complete journal to an empty PostgreSQL database produces the current schema.
+4. **Retry state:** applying the migrator again performs no schema changes and succeeds.
+
+Static contract tests must verify that the recovery contains the same approval tables, columns, indexes, constraints, and enum values as the current schema snapshot. A real PostgreSQL migration test or disposable local database run must verify transactional execution for the incident and already-migrated states.
+
+## Deployment
+
+Ship the migration image before or atomically with the webapp image. The migration job remains protected by the existing advisory lock. The webapp should not be considered healthy until the migration job succeeds.
+
+No manual insertion into `drizzle.__drizzle_migrations` is required. After `0060` succeeds, normal Drizzle ordering resumes because subsequent migrations must use a greater `when` value.


### PR DESCRIPTION
This pull request updates the test workflow to add a verification step for approval migration recovery during the test setup. Instead of running the standard migration command, it now runs a custom script with additional environment variables to ensure the approval workflow repository's migration and recovery process is validated.

**Test workflow improvements:**

* Replaces the direct call to `drizzle-kit migrate` with execution of the `verify-approval-migration-recovery.ts` script, passing in test database connection details and a sentinel value to verify the approval workflow repository's migration and recovery process. (.github/workflows/tests.yml)