### PR TITLE
fix: improve approval and payroll readiness flows

### DIFF
--- a/apps/webapp/messages/approvals/de.json
+++ b/apps/webapp/messages/approvals/de.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Zeitkorrektur abgelehnt",
     "timeCorrections": "Zeitkorrekturen",
     "timeCorrectionsDescription": "Überprüfen und genehmigen Sie Anträge auf Zeitkorrekturen Ihrer Teammitglieder",
+    "timelineActor": "{at} von {actorName}",
     "title": "Genehmigungen",
     "totalCount": "${totalCount} ausstehend",
     "type": "Typ",

--- a/apps/webapp/messages/approvals/el.json
+++ b/apps/webapp/messages/approvals/el.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Η διόρθωση χρόνου απορρίφθηκε",
     "timeCorrections": "Διορθώσεις χρόνου",
     "timeCorrectionsDescription": "Ελέγξτε και εγκρίνετε αιτήματα διόρθωσης καταχώρισης χρόνου από τα μέλη της ομάδας σας",
+    "timelineActor": "{at} από {actorName}",
     "title": "Εγκρίσεις",
     "totalCount": "${totalCount} σε εκκρεμότητα",
     "type": "Τύπος",

--- a/apps/webapp/messages/approvals/en.json
+++ b/apps/webapp/messages/approvals/en.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Time correction rejected",
     "timeCorrections": "Time Corrections",
     "timeCorrectionsDescription": "Review and approve time entry correction requests from your team members",
+    "timelineActor": "{at} by {actorName}",
     "title": "Approvals",
     "totalCount": "${totalCount} pending",
     "type": "Type",

--- a/apps/webapp/messages/approvals/es.json
+++ b/apps/webapp/messages/approvals/es.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Corrección de tiempo rechazada",
     "timeCorrections": "Correcciones de tiempo",
     "timeCorrectionsDescription": "Revise y apruebe las solicitudes de corrección de registro de tiempo de los miembros de su equipo",
+    "timelineActor": "{at} por {actorName}",
     "title": "Aprobaciones",
     "totalCount": "${totalCount} pendientes",
     "type": "Tipo",

--- a/apps/webapp/messages/approvals/fr.json
+++ b/apps/webapp/messages/approvals/fr.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Correction de temps rejetée",
     "timeCorrections": "Corrections de temps",
     "timeCorrectionsDescription": "Examinez et approuvez les demandes de correction de saisie de temps des membres de votre équipe",
+    "timelineActor": "{at} par {actorName}",
     "title": "Approbations",
     "totalCount": "${totalCount} en attente",
     "type": "Type",

--- a/apps/webapp/messages/approvals/gsw.json
+++ b/apps/webapp/messages/approvals/gsw.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Ziitkorrektur abglähnt",
     "timeCorrections": "Ziitkorrekture",
     "timeCorrectionsDescription": "Prüfe und genehmige Aaträg für Ziitkorrekture vo dim Team",
+    "timelineActor": "{at} vo {actorName}",
     "title": "Genehmigunge",
     "totalCount": "${totalCount} usstehend",
     "type": "Typ",

--- a/apps/webapp/messages/approvals/it.json
+++ b/apps/webapp/messages/approvals/it.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Correzione orario respinta",
     "timeCorrections": "Correzioni orario",
     "timeCorrectionsDescription": "Esamina e approva le richieste di correzione delle registrazioni orarie dei membri del tuo team",
+    "timelineActor": "{at} da {actorName}",
     "title": "Approvazioni",
     "totalCount": "${totalCount} in sospeso",
     "type": "Tipo",

--- a/apps/webapp/messages/approvals/pl.json
+++ b/apps/webapp/messages/approvals/pl.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Korekta czasu odrzucona",
     "timeCorrections": "Korekty czasu pracy",
     "timeCorrectionsDescription": "Przeglądaj i zatwierdzaj wnioski o korektę czasu pracy członków swojego zespołu",
+    "timelineActor": "{at} przez {actorName}",
     "title": "Zatwierdzenia",
     "totalCount": "${totalCount} oczekujących",
     "type": "Typ",

--- a/apps/webapp/messages/approvals/pt.json
+++ b/apps/webapp/messages/approvals/pt.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Correção de tempo rejeitada",
     "timeCorrections": "Correções de Horário",
     "timeCorrectionsDescription": "Revise e aprove as solicitações de correção de registro de horas dos membros da sua equipe",
+    "timelineActor": "{at} por {actorName}",
     "title": "Aprovações",
     "totalCount": "${totalCount} pendente(s)",
     "type": "Tipo",

--- a/apps/webapp/messages/approvals/tr.json
+++ b/apps/webapp/messages/approvals/tr.json
@@ -65,6 +65,7 @@
     "timeCorrectionRejected": "Zaman düzeltmesi reddedildi",
     "timeCorrections": "Zaman Düzeltmeleri",
     "timeCorrectionsDescription": "Ekip üyelerinizden gelen zaman girişi düzeltme taleplerini inceleyin ve onaylayın",
+    "timelineActor": "{at}, {actorName} tarafından",
     "title": "Onaylar",
     "totalCount": "${totalCount} beklemede",
     "type": "Tür",

--- a/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.test.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.test.tsx
@@ -7,7 +7,12 @@ import { ApprovalDetailPanel } from "./approval-detail-panel";
 import { normalizeTravelExpenseDetailEntity } from "./approval-detail-utils";
 
 vi.mock("@tolgee/react", () => ({
-	useTranslate: () => ({ t: (_key: string, fallback: string) => fallback }),
+	useTranslate: () => ({
+		t: (key: string, fallback: string, params?: Record<string, string>) =>
+			key === "approvals:approvals.timelineActor"
+				? `${params?.at} durch ${params?.actorName}`
+				: fallback,
+	}),
 }));
 
 vi.mock("sonner", () => ({
@@ -51,6 +56,18 @@ vi.mock("@/lib/query/use-approval-inbox", () => ({
 					rows: [{ label: "Type", value: "Absence Request" }],
 				},
 				{ type: "callout", title: "Risk", body: "No conflicts detected.", tone: "info" },
+				{
+					type: "timeline",
+					title: "Timeline",
+					events: [
+						{
+							id: "event-1",
+							label: "Request created",
+							at: "May 1, 2026",
+							actorName: "Ada Lovelace",
+						},
+					],
+				},
 			],
 			actions: mockState.actions,
 		},
@@ -155,6 +172,19 @@ describe("ApprovalDetailPanel", () => {
 		expect(await screen.findByText("Request")).toBeTruthy();
 		expect(screen.getByText("Absence Request")).toBeTruthy();
 		expect(screen.getByText("No conflicts detected.")).toBeTruthy();
+	});
+
+	it("translates the timeline actor connector", async () => {
+		render(
+			<ApprovalDetailPanel
+				approval={approvalItem}
+				open={true}
+				onOpenChange={vi.fn()}
+				onActioned={vi.fn()}
+			/>,
+		);
+
+		expect(await screen.findByText("May 1, 2026 durch Ada Lovelace")).toBeTruthy();
 	});
 
 	it("keeps the header badge clear of the close button and pads the detail content", async () => {

--- a/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.tsx
+++ b/apps/webapp/src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.tsx
@@ -41,7 +41,10 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
 	);
 }
 
-function renderDetailSection(section: ApprovalInboxDetailSection) {
+function renderDetailSection(
+	t: ReturnType<typeof useTranslate>["t"],
+	section: ApprovalInboxDetailSection,
+) {
 	switch (section.type) {
 		case "key_value":
 			return (
@@ -86,8 +89,13 @@ function renderDetailSection(section: ApprovalInboxDetailSection) {
 							<div key={event.id} className="border-l-2 border-primary/30 pl-3">
 								<p className="text-sm font-semibold">{event.label}</p>
 								<p className="text-xs text-muted-foreground">
-									{event.at}
-									{event.actorName ? ` by ${event.actorName}` : ""}
+									{event.actorName
+										? t(
+												"approvals:approvals.timelineActor",
+												"{at} by {actorName}",
+												{ at: event.at, actorName: event.actorName },
+											)
+										: event.at}
 								</p>
 							</div>
 						))}
@@ -230,7 +238,7 @@ export function ApprovalDetailPanel({
 
 					{sections.length > 0 && <Separator />}
 
-					{sections.map(renderDetailSection)}
+					{sections.map((section) => renderDetailSection(t, section))}
 				</div>
 
 				<SheetFooter className="border-t bg-muted/95 px-5 py-4 sm:px-6">

--- a/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
@@ -178,6 +178,7 @@ describe("PayrollWorkspace", () => {
 		const trigger = screen.getByRole("button", {
 			name: "2 payroll blockers need review",
 		});
+		expect(trigger.classList.contains("min-h-11")).toBe(true);
 		expect(trigger.getAttribute("aria-expanded")).toBe("false");
 		expect(screen.queryByText("Missing clock-out")).toBeNull();
 

--- a/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.test.tsx
@@ -109,6 +109,13 @@ function blockerSelector(type: PayrollBlockerType, id: string) {
 	return `[data-payroll-blocker-key="${payrollBlockerIdentity({ id, type })}"]`;
 }
 
+function expandPayrollBlockers(name: string | RegExp = /payroll blockers need review/) {
+	const region = screen.getByRole("region", { name });
+	const trigger = within(region).getByRole("button", { name });
+	if (trigger.getAttribute("aria-expanded") === "false") fireEvent.click(trigger);
+	return region;
+}
+
 const summary = buildSummary();
 
 function deferred<T>() {
@@ -160,6 +167,31 @@ describe("PayrollWorkspace", () => {
 		expect(screen.getByRole("button", { name: "Translated trigger export" })).toBeTruthy();
 	});
 
+	it("collapses blocker rows by default", () => {
+		render(
+			<PayrollWorkspace
+				initialSummary={summary}
+				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
+			/>,
+		);
+
+		const trigger = screen.getByRole("button", {
+			name: "2 payroll blockers need review",
+		});
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		expect(screen.queryByText("Missing clock-out")).toBeNull();
+
+		fireEvent.click(trigger);
+
+		expect(trigger.getAttribute("aria-expanded")).toBe("true");
+		expect(screen.getByText("Missing clock-out")).toBeTruthy();
+
+		fireEvent.click(trigger);
+
+		expect(trigger.getAttribute("aria-expanded")).toBe("false");
+		expect(screen.queryByText("Missing clock-out")).toBeNull();
+	});
+
 	it("renders summary cards, employee rows, period controls, and blockers", () => {
 		render(
 			<PayrollWorkspace
@@ -167,6 +199,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		expect(screen.getByText("Payroll")).toBeTruthy();
 		expect(
 			screen.getByText("Review payroll totals, readiness, and exports for the selected period."),
@@ -259,9 +292,7 @@ describe("PayrollWorkspace", () => {
 			/>,
 		);
 
-		const blockersRegion = screen.getByRole("region", {
-			name: "4 Lohnblocker prüfen",
-		});
+		const blockersRegion = expandPayrollBlockers("4 Lohnblocker prüfen");
 		expect(screen.queryByRole("alert")).toBeNull();
 
 		const adaMissingRow = blockersRegion.querySelector(
@@ -377,6 +408,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const missingRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const absenceRow = document.querySelector(blockerSelector("pending_absence", "blocker-2"));
@@ -407,6 +439,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		fireEvent.click(screen.getByRole("button", { name: "Specific employees" }));
 		const sheet = await screen.findByRole("dialog");
@@ -452,6 +485,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const missingRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const absenceRow = document.querySelector(blockerSelector("pending_absence", "blocker-2"));
@@ -522,6 +556,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const missingRow = document.querySelector(
 			blockerSelector("missing_clock_out", sharedId),
@@ -650,6 +685,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const firstRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const secondRow = document.querySelector(blockerSelector("pending_absence", "blocker-2"));
@@ -748,6 +784,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
 			within(blockerRow as HTMLElement).getByRole("button", {
@@ -794,6 +831,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
 			within(blockerRow as HTMLElement).getByRole("button", {
@@ -858,6 +896,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
 			within(blockerRow as HTMLElement).getByRole("button", {
@@ -927,6 +966,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const firstRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const secondRow = document.querySelector(blockerSelector("pending_absence", "blocker-2"));
 		fireEvent.click(
@@ -961,6 +1001,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
 			within(blockerRow as HTMLElement).getByRole("button", {
@@ -995,6 +1036,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const firstRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const clearButton = within(firstRow as HTMLElement).getByRole("button", {
 			name: /Clear false positive.*Ada Lovelace.*Missing clock-out/,
@@ -1030,6 +1072,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const missingRow = document.querySelector(
 			blockerSelector("missing_clock_out", sharedId),
 		);
@@ -1061,6 +1104,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const firstRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const clearButton = within(firstRow as HTMLElement).getByRole("button", {
 			name: /Clear false positive.*Ada Lovelace.*Missing clock-out/,
@@ -1104,6 +1148,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const secondRow = document.querySelector(blockerSelector("pending_absence", "blocker-2"));
 		const clearButton = within(secondRow as HTMLElement).getByRole("button", {
 			name: /Clear false positive.*Ada Lovelace.*Pending absence/,
@@ -1141,6 +1186,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const clearButton = within(blockerRow as HTMLElement).getByRole("button", {
 			name: /Clear false positive.*Ada Lovelace.*Missing clock-out/,
@@ -1166,6 +1212,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		const clearButton = within(blockerRow as HTMLElement).getByRole("button", {
 			name: /Clear false positive.*Ada Lovelace.*Missing clock-out/,
@@ -1192,6 +1239,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
@@ -1235,6 +1283,7 @@ describe("PayrollWorkspace", () => {
 				exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 			/>,
 		);
+		expandPayrollBlockers();
 
 		const blockerRow = document.querySelector(blockerSelector("missing_clock_out", "blocker-1"));
 		fireEvent.click(
@@ -1280,6 +1329,7 @@ describe("PayrollWorkspace", () => {
 					exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
 				/>,
 			);
+			expandPayrollBlockers();
 
 			const blockerRow = document.querySelector(
 				blockerSelector("missing_clock_out", "blocker-1"),
@@ -1348,9 +1398,7 @@ describe("PayrollWorkspace", () => {
 			/>,
 		);
 
-		const blockersRegion = screen.getByRole("region", {
-			name: "1 payroll blockers need review",
-		});
+		const blockersRegion = expandPayrollBlockers("1 payroll blockers need review");
 		const blockerRow = blockersRegion.querySelector(
 			blockerSelector("missing_clock_out", "missing-unknown"),
 		);
@@ -1408,9 +1456,7 @@ describe("PayrollWorkspace", () => {
 			/>,
 		);
 
-		const blockersRegion = screen.getByRole("region", {
-			name: "1 payroll blockers need review",
-		});
+		const blockersRegion = expandPayrollBlockers("1 payroll blockers need review");
 		const blockerRow = blockersRegion.querySelector(
 			blockerSelector("missing_clock_out", "uuid-name-blocker"),
 		);

--- a/apps/webapp/src/components/payroll/payroll-workspace.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.tsx
@@ -1333,7 +1333,7 @@ function PayrollBlockersAlert({
 					<h2 id="payroll-blockers-title">
 						<CollapsibleTrigger asChild>
 							<button
-								className="flex w-full items-start gap-3 rounded-sm text-left font-medium leading-none outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&[data-panel-open]>svg:last-child]:rotate-180"
+								className="flex min-h-11 w-full items-start gap-3 rounded-sm text-left font-medium leading-none outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&[data-panel-open]>svg:last-child]:rotate-180"
 								ref={triggerRef}
 								type="button"
 							>

--- a/apps/webapp/src/components/payroll/payroll-workspace.tsx
+++ b/apps/webapp/src/components/payroll/payroll-workspace.tsx
@@ -3,6 +3,7 @@
 import {
 	IconAlertTriangle,
 	IconCalendarWeek,
+	IconChevronDown,
 	IconChevronLeft,
 	IconChevronRight,
 	IconDownload,
@@ -29,6 +30,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -1270,7 +1276,7 @@ function PayrollBlockersAlert({
 	t: PayrollTranslate;
 }) {
 	const locale = useLocale();
-	const headingRef = useRef<HTMLHeadingElement | null>(null);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const handledFocusRequestIdRef = useRef(0);
 	const blockerControlRefs = useRef(
 		new Map<
@@ -1298,7 +1304,7 @@ function PayrollBlockersAlert({
 			: undefined;
 		const targetControl =
 			controls?.clear && !controls.clear.disabled ? controls.clear : controls?.action;
-		const fallbackTarget = blockers.length === 0 ? fallbackFocusRef.current : headingRef.current;
+		const fallbackTarget = blockers.length === 0 ? fallbackFocusRef.current : triggerRef.current;
 		(targetControl ?? fallbackTarget)?.focus();
 	}, [blockers.length, fallbackFocusRef, focusRequest]);
 
@@ -1318,25 +1324,34 @@ function PayrollBlockersAlert({
 	if (blockers.length === 0) return null;
 
 	return (
-		<section
-			aria-labelledby="payroll-blockers-title"
-			className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 text-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
-		>
-			<header className="flex items-start gap-3">
-				<IconAlertTriangle
-					aria-hidden="true"
-					className="mt-0.5 size-4 shrink-0"
-				/>
-				<h2
-					className="rounded-sm font-medium leading-none focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-					id="payroll-blockers-title"
-					ref={headingRef}
-					tabIndex={-1}
-				>
-					{title}
-				</h2>
-			</header>
-			<ul className="mt-3 grid gap-2">
+		<Collapsible asChild>
+			<section
+				aria-labelledby="payroll-blockers-title"
+				className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 text-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+			>
+				<header>
+					<h2 id="payroll-blockers-title">
+						<CollapsibleTrigger asChild>
+							<button
+								className="flex w-full items-start gap-3 rounded-sm text-left font-medium leading-none outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&[data-panel-open]>svg:last-child]:rotate-180"
+								ref={triggerRef}
+								type="button"
+							>
+								<IconAlertTriangle
+									aria-hidden="true"
+									className="mt-0.5 size-4 shrink-0"
+								/>
+								<span className="min-w-0 flex-1">{title}</span>
+								<IconChevronDown
+									aria-hidden="true"
+									className="size-4 shrink-0 transition-transform"
+								/>
+							</button>
+						</CollapsibleTrigger>
+					</h2>
+				</header>
+				<CollapsibleContent asChild>
+					<ul className="mt-3 grid gap-2">
 				{blockers.map((blocker) => {
 					const blockerKey = payrollBlockerIdentity(blocker);
 					const isClearing = clearingBlockerKeys.has(blockerKey);
@@ -1464,8 +1479,10 @@ function PayrollBlockersAlert({
 						</li>
 					);
 				})}
-			</ul>
-		</section>
+					</ul>
+				</CollapsibleContent>
+			</section>
+		</Collapsible>
 	);
 }
 

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
@@ -1,5 +1,6 @@
 import { Cause, Effect, Exit, Option } from "effect";
 import { describe, expect, it, vi } from "vitest";
+import { absenceEntry, approvalRequest } from "@/db/schema";
 import {
 	AuthorizationError,
 	ConflictError,
@@ -23,6 +24,34 @@ function collectColumnNames(value: unknown): string[] {
 			? [candidate.config.name]
 			: []),
 		...(candidate.queryChunks?.flatMap(collectColumnNames) ?? []),
+	];
+}
+
+function collectColumns(value: unknown): object[] {
+	if (!value || typeof value !== "object") return [];
+	const candidate = value as {
+		config?: { name?: unknown };
+		queryChunks?: unknown[];
+	};
+	return [
+		...(typeof candidate.config?.name === "string" ? [value] : []),
+		...(candidate.queryChunks?.flatMap(collectColumns) ?? []),
+	];
+}
+
+function collectParamValues(value: unknown): unknown[] {
+	if (!value || typeof value !== "object") return [];
+	const candidate = value as {
+		value?: unknown;
+		queryChunks?: unknown[];
+	};
+	return [
+		...(Object.hasOwn(candidate, "value")
+			? Array.isArray(candidate.value)
+				? candidate.value
+				: [candidate.value]
+			: []),
+		...(candidate.queryChunks?.flatMap(collectParamValues) ?? []),
 	];
 }
 
@@ -167,36 +196,90 @@ describe("absence approval handler tenant scope", () => {
 		},
 	);
 
-	it("excludes stale absence requests from the pending count", async () => {
+	it("counts visible pending absences in an organization-scoped SQL join", async () => {
+		const approvals = ["absence-1", "absence-2", "absence-3", "absence-4"].map(
+			(entityId, index) => ({
+				...approval,
+				id: `approval-${index + 1}`,
+				entityId,
+			}),
+		);
+		const absences = (["pending", "pending", "approved", "rejected"] as const).map(
+			(status, index) => ({
+				...absence,
+				id: `absence-${index + 1}`,
+				status,
+			}),
+		);
+		const where = vi.fn().mockResolvedValue([{ count: 2 }]);
+		const innerJoin = vi.fn(() => ({ where }));
+		const from = vi.fn(() => ({ innerJoin }));
+		const select = vi.fn(() => ({ from }));
 		const dbService = DatabaseService.of({
 			db: {
 				query: {
 					approvalRequest: {
-						findMany: vi.fn().mockResolvedValue([approval]),
+						findMany: vi.fn().mockResolvedValue(approvals),
 					},
 					absenceEntry: {
-						findMany: vi
-							.fn()
-							.mockResolvedValue([{ ...absence, status: "approved" }]),
+						findMany: vi.fn().mockResolvedValue(absences),
 					},
 				},
-				select: vi.fn(() => ({
-					from: vi.fn(() => ({
-						where: vi.fn().mockResolvedValue([{ count: 1 }]),
-					})),
-				})),
+				select,
 			},
 			query: (_name: string, operation: () => Promise<unknown>) =>
 				Effect.promise(operation),
 		});
 
 		const result = await Effect.runPromise(
-			AbsenceRequestHandler.getCount("employee-2", "org-1").pipe(
+			AbsenceRequestHandler.getCount("employee-2", "org-1", {
+				includeAllApprovers: false,
+				eligibleApprovalScopes: [
+					{
+						requesterEmployeeId: "employee-3",
+						eligibleApproverIds: ["employee-4"],
+					},
+				],
+			}).pipe(
 				Effect.provideService(DatabaseService, dbService),
 			),
 		);
 
-		expect(result).toBe(0);
+		expect(result).toBe(2);
+		expect(select).toHaveBeenCalledTimes(1);
+		expect(from).toHaveBeenCalledWith(approvalRequest);
+		expect(innerJoin).toHaveBeenCalledWith(absenceEntry, expect.anything());
+
+		const joinColumns = collectColumns(innerJoin.mock.calls[0]?.[1]);
+		expect(joinColumns).toEqual(
+			expect.arrayContaining([
+				absenceEntry.id,
+				approvalRequest.entityId,
+				absenceEntry.organizationId,
+			]),
+		);
+		expect(collectParamValues(innerJoin.mock.calls[0]?.[1])).toContain("org-1");
+
+		const whereColumns = collectColumns(where.mock.calls[0]?.[0]);
+		expect(whereColumns).toEqual(
+			expect.arrayContaining([
+				approvalRequest.entityType,
+				approvalRequest.organizationId,
+				approvalRequest.status,
+				approvalRequest.approverId,
+				approvalRequest.requestedBy,
+				absenceEntry.status,
+			]),
+		);
+		expect(collectParamValues(where.mock.calls[0]?.[0])).toEqual(
+			expect.arrayContaining([
+				"absence_entry",
+				"org-1",
+				"pending",
+				"employee-2",
+				"employee-3",
+			]),
+		);
 	});
 
 	it("scopes both detail reads to the requested organization", async () => {

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
@@ -1,4 +1,5 @@
 import { Cause, Effect, Exit, Option } from "effect";
+import { PgDialect, type SQL } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 import { absenceEntry, approvalRequest } from "@/db/schema";
 import {
@@ -24,34 +25,6 @@ function collectColumnNames(value: unknown): string[] {
 			? [candidate.config.name]
 			: []),
 		...(candidate.queryChunks?.flatMap(collectColumnNames) ?? []),
-	];
-}
-
-function collectColumns(value: unknown): object[] {
-	if (!value || typeof value !== "object") return [];
-	const candidate = value as {
-		config?: { name?: unknown };
-		queryChunks?: unknown[];
-	};
-	return [
-		...(typeof candidate.config?.name === "string" ? [value] : []),
-		...(candidate.queryChunks?.flatMap(collectColumns) ?? []),
-	];
-}
-
-function collectParamValues(value: unknown): unknown[] {
-	if (!value || typeof value !== "object") return [];
-	const candidate = value as {
-		value?: unknown;
-		queryChunks?: unknown[];
-	};
-	return [
-		...(Object.hasOwn(candidate, "value")
-			? Array.isArray(candidate.value)
-				? candidate.value
-				: [candidate.value]
-			: []),
-		...(candidate.queryChunks?.flatMap(collectParamValues) ?? []),
 	];
 }
 
@@ -102,6 +75,36 @@ const approval = {
 	requester: absence.employee,
 	approver: null,
 };
+
+function createCountQueryDb(aggregateCount: number) {
+	const approvalFindMany = vi.fn();
+	const absenceFindMany = vi.fn();
+	const where = vi.fn().mockResolvedValue([{ count: aggregateCount }]);
+	const innerJoin = vi.fn(() => ({ where }));
+	const from = vi.fn(() => ({ innerJoin }));
+	const select = vi.fn((_selection?: unknown) => ({ from }));
+	const dbService = DatabaseService.of({
+		db: {
+			query: {
+				approvalRequest: { findMany: approvalFindMany },
+				absenceEntry: { findMany: absenceFindMany },
+			},
+			select,
+		},
+		query: (_name: string, operation: () => Promise<unknown>) =>
+			Effect.promise(operation),
+	});
+
+	return {
+		absenceFindMany,
+		approvalFindMany,
+		dbService,
+		from,
+		innerJoin,
+		select,
+		where,
+	};
+}
 
 describe("redactNonSickAbsenceSickDetail", () => {
 	it("redacts stale sick detail from non-sick absence entities", () => {
@@ -197,39 +200,15 @@ describe("absence approval handler tenant scope", () => {
 	);
 
 	it("counts visible pending absences in an organization-scoped SQL join", async () => {
-		const approvals = ["absence-1", "absence-2", "absence-3", "absence-4"].map(
-			(entityId, index) => ({
-				...approval,
-				id: `approval-${index + 1}`,
-				entityId,
-			}),
-		);
-		const absences = (["pending", "pending", "approved", "rejected"] as const).map(
-			(status, index) => ({
-				...absence,
-				id: `absence-${index + 1}`,
-				status,
-			}),
-		);
-		const where = vi.fn().mockResolvedValue([{ count: 2 }]);
-		const innerJoin = vi.fn(() => ({ where }));
-		const from = vi.fn(() => ({ innerJoin }));
-		const select = vi.fn(() => ({ from }));
-		const dbService = DatabaseService.of({
-			db: {
-				query: {
-					approvalRequest: {
-						findMany: vi.fn().mockResolvedValue(approvals),
-					},
-					absenceEntry: {
-						findMany: vi.fn().mockResolvedValue(absences),
-					},
-				},
-				select,
-			},
-			query: (_name: string, operation: () => Promise<unknown>) =>
-				Effect.promise(operation),
-		});
+		const {
+			absenceFindMany,
+			approvalFindMany,
+			dbService,
+			from,
+			innerJoin,
+			select,
+			where,
+		} = createCountQueryDb(2);
 
 		const result = await Effect.runPromise(
 			AbsenceRequestHandler.getCount("employee-2", "org-1", {
@@ -249,37 +228,85 @@ describe("absence approval handler tenant scope", () => {
 		expect(select).toHaveBeenCalledTimes(1);
 		expect(from).toHaveBeenCalledWith(approvalRequest);
 		expect(innerJoin).toHaveBeenCalledWith(absenceEntry, expect.anything());
+		expect(approvalFindMany).not.toHaveBeenCalled();
+		expect(absenceFindMany).not.toHaveBeenCalled();
 
-		const joinColumns = collectColumns(innerJoin.mock.calls[0]?.[1]);
-		expect(joinColumns).toEqual(
-			expect.arrayContaining([
-				absenceEntry.id,
-				approvalRequest.entityId,
-				absenceEntry.organizationId,
-			]),
-		);
-		expect(collectParamValues(innerJoin.mock.calls[0]?.[1])).toContain("org-1");
+		const dialect = new PgDialect();
+		const selection = select.mock.calls[0]?.[0] as { count: SQL };
+		expect(dialect.sqlToQuery(selection.count)).toEqual({
+			sql: "count(*)",
+			params: [],
+		});
+		const joinQuery = dialect.sqlToQuery(innerJoin.mock.calls[0]?.[1] as SQL);
+		expect(joinQuery.sql).toContain('"absence_entry"."id"');
+		expect(joinQuery.sql).toContain('"approval_request"."entity_id"');
+		expect(joinQuery.sql).toContain('"absence_entry"."organization_id"');
+		expect(joinQuery.params).toEqual(["org-1"]);
 
-		const whereColumns = collectColumns(where.mock.calls[0]?.[0]);
-		expect(whereColumns).toEqual(
-			expect.arrayContaining([
-				approvalRequest.entityType,
-				approvalRequest.organizationId,
-				approvalRequest.status,
-				approvalRequest.approverId,
-				approvalRequest.requestedBy,
-				absenceEntry.status,
-			]),
+		const whereQuery = dialect.sqlToQuery(where.mock.calls[0]?.[0] as SQL);
+		expect(whereQuery.sql).toContain('"approval_request"."entity_type"');
+		expect(whereQuery.sql).toContain('"approval_request"."organization_id"');
+		expect(whereQuery.sql).toContain('"approval_request"."status"');
+		expect(whereQuery.sql).toContain('"absence_entry"."status"');
+		expect(whereQuery.params).toEqual([
+			"absence_entry",
+			"org-1",
+			"pending",
+			"employee-2",
+			"employee-3",
+			"employee-4",
+			"pending",
+		]);
+		expect(whereQuery.sql).toContain(
+			'("approval_request"."approver_id" = $4 or ("approval_request"."requested_by" = $5 and "approval_request"."approver_id" in ($6)))',
 		);
-		expect(collectParamValues(where.mock.calls[0]?.[0])).toEqual(
-			expect.arrayContaining([
-				"absence_entry",
-				"org-1",
-				"pending",
-				"employee-2",
-				"employee-3",
-			]),
+	});
+
+	it("counts all approvers without assigned or eligible visibility restrictions", async () => {
+		const {
+			absenceFindMany,
+			approvalFindMany,
+			dbService,
+			innerJoin,
+			where,
+		} = createCountQueryDb(4);
+
+		const result = await Effect.runPromise(
+			AbsenceRequestHandler.getCount("employee-2", "org-1", {
+				includeAllApprovers: true,
+				eligibleApprovalScopes: [
+					{
+						requesterEmployeeId: "employee-3",
+						eligibleApproverIds: ["employee-4"],
+					},
+				],
+			}).pipe(Effect.provideService(DatabaseService, dbService)),
 		);
+
+		expect(result).toBe(4);
+		expect(approvalFindMany).not.toHaveBeenCalled();
+		expect(absenceFindMany).not.toHaveBeenCalled();
+
+		const dialect = new PgDialect();
+		const joinQuery = dialect.sqlToQuery(innerJoin.mock.calls[0]?.[1] as SQL);
+		expect(joinQuery.sql).toContain('"absence_entry"."id"');
+		expect(joinQuery.sql).toContain('"approval_request"."entity_id"');
+		expect(joinQuery.sql).toContain('"absence_entry"."organization_id"');
+		expect(joinQuery.params).toEqual(["org-1"]);
+
+		const whereQuery = dialect.sqlToQuery(where.mock.calls[0]?.[0] as SQL);
+		expect(whereQuery.sql).toContain('"approval_request"."entity_type"');
+		expect(whereQuery.sql).toContain('"approval_request"."organization_id"');
+		expect(whereQuery.sql).toContain('"approval_request"."status"');
+		expect(whereQuery.sql).toContain('"absence_entry"."status"');
+		expect(whereQuery.sql).not.toContain('"approver_id"');
+		expect(whereQuery.sql).not.toContain('"requested_by"');
+		expect(whereQuery.params).toEqual([
+			"absence_entry",
+			"org-1",
+			"pending",
+			"pending",
+		]);
 	});
 
 	it("scopes both detail reads to the requested organization", async () => {

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
@@ -138,6 +138,67 @@ describe("absence approval handler tenant scope", () => {
 		).toEqual(expect.arrayContaining(["id", "organization_id"]));
 	});
 
+	it.each(["approved", "rejected"] as const)(
+		"omits a pending approval request whose absence is already %s",
+		async (status) => {
+			const dbService = DatabaseService.of({
+				db: {
+					query: {
+						approvalRequest: {
+							findMany: vi.fn().mockResolvedValue([approval]),
+						},
+						absenceEntry: {
+							findMany: vi.fn().mockResolvedValue([{ ...absence, status }]),
+						},
+					},
+				},
+				query: (_name: string, operation: () => Promise<unknown>) =>
+					Effect.promise(operation),
+			});
+
+			const result = await Effect.runPromise(
+				AbsenceRequestHandler.getApprovals({
+					approverId: "employee-2",
+					organizationId: "org-1",
+				}).pipe(Effect.provideService(DatabaseService, dbService)),
+			);
+
+			expect(result).toEqual([]);
+		},
+	);
+
+	it("excludes stale absence requests from the pending count", async () => {
+		const dbService = DatabaseService.of({
+			db: {
+				query: {
+					approvalRequest: {
+						findMany: vi.fn().mockResolvedValue([approval]),
+					},
+					absenceEntry: {
+						findMany: vi
+							.fn()
+							.mockResolvedValue([{ ...absence, status: "approved" }]),
+					},
+				},
+				select: vi.fn(() => ({
+					from: vi.fn(() => ({
+						where: vi.fn().mockResolvedValue([{ count: 1 }]),
+					})),
+				})),
+			},
+			query: (_name: string, operation: () => Promise<unknown>) =>
+				Effect.promise(operation),
+		});
+
+		const result = await Effect.runPromise(
+			AbsenceRequestHandler.getCount("employee-2", "org-1").pipe(
+				Effect.provideService(DatabaseService, dbService),
+			),
+		);
+
+		expect(result).toBe(0);
+	});
+
 	it("scopes both detail reads to the requested organization", async () => {
 		const absenceFindFirst = vi.fn().mockResolvedValue(absence);
 		const requestFindFirst = vi.fn().mockResolvedValue(approval);
@@ -172,39 +233,42 @@ describe("absence approval handler tenant scope", () => {
 	it.each([
 		["approve", undefined],
 		["reject", "Needs clarification"],
-	] as const)("dispatches %s through authenticated identity resolution", async (action, reason) => {
-		const executeAuthenticatedAbsenceDecision = vi
-			.fn()
-			.mockResolvedValue(undefined);
-		vi.doMock("@/lib/approvals/server/absence-approvals", () => ({
-			executeAuthenticatedAbsenceDecision,
-		}));
+	] as const)(
+		"dispatches %s through authenticated identity resolution",
+		async (action, reason) => {
+			const executeAuthenticatedAbsenceDecision = vi
+				.fn()
+				.mockResolvedValue(undefined);
+			vi.doMock("@/lib/approvals/server/absence-approvals", () => ({
+				executeAuthenticatedAbsenceDecision,
+			}));
 
-		if (action === "approve") {
-			await Effect.runPromise(
-				AbsenceRequestHandler.approve("absence-1", "caller-employee", {
-					approvalRequestId: "approval-1",
-				}),
-			);
-		} else {
-			await Effect.runPromise(
-				AbsenceRequestHandler.reject("absence-1", "caller-employee", reason, {
-					approvalRequestId: "approval-1",
-				}),
-			);
-		}
+			if (action === "approve") {
+				await Effect.runPromise(
+					AbsenceRequestHandler.approve("absence-1", "caller-employee", {
+						approvalRequestId: "approval-1",
+					}),
+				);
+			} else {
+				await Effect.runPromise(
+					AbsenceRequestHandler.reject("absence-1", "caller-employee", reason, {
+						approvalRequestId: "approval-1",
+					}),
+				);
+			}
 
-		expect(executeAuthenticatedAbsenceDecision).toHaveBeenCalledWith(
-			"absence-1",
-			action,
-			reason,
-			{ approvalRequestId: "approval-1" },
-		);
-		expect(executeAuthenticatedAbsenceDecision.mock.calls[0]).not.toContain(
-			"caller-employee",
-		);
-		vi.doUnmock("@/lib/approvals/server/absence-approvals");
-	});
+			expect(executeAuthenticatedAbsenceDecision).toHaveBeenCalledWith(
+				"absence-1",
+				action,
+				reason,
+				{ approvalRequestId: "approval-1" },
+			);
+			expect(executeAuthenticatedAbsenceDecision.mock.calls[0]).not.toContain(
+				"caller-employee",
+			);
+			vi.doUnmock("@/lib/approvals/server/absence-approvals");
+		},
+	);
 
 	it.each([
 		new NotFoundError({

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.test.ts
@@ -1,5 +1,5 @@
-import { Cause, Effect, Exit, Option } from "effect";
 import { PgDialect, type SQL } from "drizzle-orm/pg-core";
+import { Cause, Effect, Exit, Option } from "effect";
 import { describe, expect, it, vi } from "vitest";
 import { absenceEntry, approvalRequest } from "@/db/schema";
 import {
@@ -219,9 +219,7 @@ describe("absence approval handler tenant scope", () => {
 						eligibleApproverIds: ["employee-4"],
 					},
 				],
-			}).pipe(
-				Effect.provideService(DatabaseService, dbService),
-			),
+			}).pipe(Effect.provideService(DatabaseService, dbService)),
 		);
 
 		expect(result).toBe(2);
@@ -263,13 +261,8 @@ describe("absence approval handler tenant scope", () => {
 	});
 
 	it("counts all approvers without assigned or eligible visibility restrictions", async () => {
-		const {
-			absenceFindMany,
-			approvalFindMany,
-			dbService,
-			innerJoin,
-			where,
-		} = createCountQueryDb(4);
+		const { absenceFindMany, approvalFindMany, dbService, innerJoin, where } =
+			createCountQueryDb(4);
 
 		const result = await Effect.runPromise(
 			AbsenceRequestHandler.getCount("employee-2", "org-1", {

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.ts
@@ -24,7 +24,7 @@ import type {
 	ApprovalTimelineEvent,
 	ApprovalTypeHandler,
 } from "../domain/types";
-import { buildSLAInfo, fetchApprovals, getApprovalCount } from "./base-handler";
+import { buildSLAInfo, fetchApprovals } from "./base-handler";
 
 // Type for absence entity with relations
 interface AbsenceWithRelations {
@@ -109,6 +109,10 @@ export const AbsenceRequestHandler: ApprovalTypeHandler<AbsenceWithRelations> =
 						return map;
 					}),
 				filterEntity: (entity, params) => {
+					if (entity.status !== (params.status ?? "pending")) {
+						return false;
+					}
+
 					// Apply team filter
 					if (params.teamId && entity.employee.teamId !== params.teamId) {
 						return false;
@@ -164,7 +168,13 @@ export const AbsenceRequestHandler: ApprovalTypeHandler<AbsenceWithRelations> =
 			}),
 
 		getCount: (approverId, organizationId, visibility) =>
-			getApprovalCount("absence_entry", approverId, organizationId, visibility),
+			AbsenceRequestHandler.getApprovals({
+				approverId,
+				organizationId,
+				status: "pending",
+				limit: 1,
+				...visibility,
+			}).pipe(Effect.map((approvals) => approvals.length)),
 
 		getDetail: (entityId, organizationId) =>
 			Effect.gen(function* (_) {

--- a/apps/webapp/src/lib/approvals/handlers/absence-request.handler.ts
+++ b/apps/webapp/src/lib/approvals/handlers/absence-request.handler.ts
@@ -6,7 +6,7 @@
  */
 
 import { IconCalendarOff } from "@tabler/icons-react";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, count, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { DateTime } from "luxon";
 import { absenceEntry, approvalRequest } from "@/db/schema";
@@ -24,7 +24,11 @@ import type {
 	ApprovalTimelineEvent,
 	ApprovalTypeHandler,
 } from "../domain/types";
-import { buildSLAInfo, fetchApprovals } from "./base-handler";
+import {
+	buildBaseConditions,
+	buildSLAInfo,
+	fetchApprovals,
+} from "./base-handler";
 
 // Type for absence entity with relations
 interface AbsenceWithRelations {
@@ -168,13 +172,34 @@ export const AbsenceRequestHandler: ApprovalTypeHandler<AbsenceWithRelations> =
 			}),
 
 		getCount: (approverId, organizationId, visibility) =>
-			AbsenceRequestHandler.getApprovals({
-				approverId,
-				organizationId,
-				status: "pending",
-				limit: 1,
-				...visibility,
-			}).pipe(Effect.map((approvals) => approvals.length)),
+			Effect.gen(function* (_) {
+				const dbService = yield* _(DatabaseService);
+				const conditions = buildBaseConditions("absence_entry", {
+					approverId,
+					organizationId,
+					status: "pending",
+					limit: 1,
+					...visibility,
+				});
+
+				const result = yield* _(
+					dbService.query("getabsence_entryCount", async () => {
+						return await dbService.db
+							.select({ count: count() })
+							.from(approvalRequest)
+							.innerJoin(
+								absenceEntry,
+								and(
+									eq(absenceEntry.id, approvalRequest.entityId),
+									eq(absenceEntry.organizationId, organizationId),
+								),
+							)
+							.where(and(...conditions, eq(absenceEntry.status, "pending")));
+					}),
+				);
+
+				return result[0]?.count ?? 0;
+			}),
 
 		getDetail: (entityId, organizationId) =>
 			Effect.gen(function* (_) {

--- a/apps/webapp/src/tolgee/shared.test.ts
+++ b/apps/webapp/src/tolgee/shared.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { LANGUAGE_CONFIG } from "@/lib/language-config";
@@ -28,6 +28,20 @@ describe("Tolgee route translations", () => {
 			}
 		}
 	});
+
+	it.each(ALL_LANGUAGES)(
+		"defines approval timeline actor placeholders in %s",
+		(locale) => {
+			const catalog = JSON.parse(
+				readFileSync(join(process.cwd(), `messages/approvals/${locale}.json`), "utf8"),
+			) as { approvals?: { timelineActor?: unknown } };
+			const message = catalog.approvals?.timelineActor;
+
+			expect(message, `${locale}: approvals.timelineActor`).toEqual(expect.any(String));
+			expect(message, `${locale}: approvals.timelineActor`).toContain("{at}");
+			expect(message, `${locale}: approvals.timelineActor`).toContain("{actorName}");
+		},
+	);
 
 	it("loads app search strings from the common namespace", async () => {
 		const translations = await loadRouteTranslations("de", "/");

--- a/apps/webapp/src/tolgee/shared.test.ts
+++ b/apps/webapp/src/tolgee/shared.test.ts
@@ -11,20 +11,39 @@ import {
 
 describe("Tolgee route translations", () => {
 	it("lists every language supported by Tolgee and the language switchers", () => {
-		expect(ALL_LANGUAGES).toEqual(["en", "de", "fr", "es", "it", "pt", "el", "pl", "tr", "gsw"]);
-		expect(Object.keys(LANGUAGE_CONFIG)).toEqual(expect.arrayContaining(ALL_LANGUAGES));
+		expect(ALL_LANGUAGES).toEqual([
+			"en",
+			"de",
+			"fr",
+			"es",
+			"it",
+			"pt",
+			"el",
+			"pl",
+			"tr",
+			"gsw",
+		]);
+		expect(Object.keys(LANGUAGE_CONFIG)).toEqual(
+			expect.arrayContaining(ALL_LANGUAGES),
+		);
 	});
 
 	it("does not keep unnamespaced root locale files", () => {
 		for (const locale of ALL_LANGUAGES) {
-			expect(existsSync(join(process.cwd(), `messages/${locale}.json`))).toBe(false);
+			expect(existsSync(join(process.cwd(), `messages/${locale}.json`))).toBe(
+				false,
+			);
 		}
 	});
 
 	it("keeps a namespace file for every supported locale", () => {
 		for (const namespace of ALL_NAMESPACES) {
 			for (const locale of ALL_LANGUAGES) {
-				expect(existsSync(join(process.cwd(), `messages/${namespace}/${locale}.json`))).toBe(true);
+				expect(
+					existsSync(
+						join(process.cwd(), `messages/${namespace}/${locale}.json`),
+					),
+				).toBe(true);
 			}
 		}
 	});
@@ -73,7 +92,10 @@ describe("Tolgee route translations", () => {
 	});
 
 	it("loads dedicated analytics route translations", async () => {
-		const translations = await loadRouteTranslations("en", "/analytics/work-hours");
+		const translations = await loadRouteTranslations(
+			"en",
+			"/analytics/work-hours",
+		);
 
 		expect(translations.en).toMatchObject({
 			analytics: {

--- a/apps/webapp/src/tolgee/shared.test.ts
+++ b/apps/webapp/src/tolgee/shared.test.ts
@@ -33,13 +33,20 @@ describe("Tolgee route translations", () => {
 		"defines approval timeline actor placeholders in %s",
 		(locale) => {
 			const catalog = JSON.parse(
-				readFileSync(join(process.cwd(), `messages/approvals/${locale}.json`), "utf8"),
+				readFileSync(
+					join(process.cwd(), `messages/approvals/${locale}.json`),
+					"utf8",
+				),
 			) as { approvals?: { timelineActor?: unknown } };
 			const message = catalog.approvals?.timelineActor;
 
-			expect(message, `${locale}: approvals.timelineActor`).toEqual(expect.any(String));
+			expect(message, `${locale}: approvals.timelineActor`).toEqual(
+				expect.any(String),
+			);
 			expect(message, `${locale}: approvals.timelineActor`).toContain("{at}");
-			expect(message, `${locale}: approvals.timelineActor`).toContain("{actorName}");
+			expect(message, `${locale}: approvals.timelineActor`).toContain(
+				"{actorName}",
+			);
 		},
 	);
 

--- a/docs/superpowers/plans/2026-08-03-collapsible-payroll-blockers.md
+++ b/docs/superpowers/plans/2026-08-03-collapsible-payroll-blockers.md
@@ -1,0 +1,246 @@
+# Collapsible Payroll Blockers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `/payroll` blocker notice collapsible and collapsed whenever the payroll workspace mounts, while leaving its blocker count visible.
+
+**Architecture:** Wrap the existing blocker notice in the shared Base UI `Collapsible` primitives. The notice header becomes the trigger, the blocker list becomes the content, and Base UI owns the unpersisted open state and accessibility attributes; existing blocker data and action logic stay unchanged.
+
+**Tech Stack:** React 19, Next.js 16, Base UI via Z8's `Collapsible` components, Tailwind CSS, Tabler Icons, Vitest, Testing Library
+
+---
+
+## File Structure
+
+- Modify `apps/webapp/src/components/payroll/payroll-workspace.tsx`: turn `PayrollBlockersAlert` into a default-collapsed notice using the existing design-system primitives.
+- Modify `apps/webapp/src/components/payroll/payroll-workspace.test.tsx`: specify collapsed/expanded behavior and open the notice before existing blocker-row interactions.
+
+### Task 1: Specify Default-Collapsed Interaction
+
+**Files:**
+- Test: `apps/webapp/src/components/payroll/payroll-workspace.test.tsx:108-205`
+
+- [ ] **Step 1: Add a reusable test helper**
+
+Add this helper below `blockerSelector` so existing behavioral tests can explicitly reveal blocker controls:
+
+```tsx
+function expandPayrollBlockers() {
+	const notice = document.querySelector(
+		'[aria-labelledby="payroll-blockers-title"]',
+	);
+	expect(notice).toBeTruthy();
+	const trigger = within(notice as HTMLElement).getByRole("button");
+	fireEvent.click(trigger);
+	return trigger;
+}
+```
+
+- [ ] **Step 2: Write the failing collapsible behavior test**
+
+Add this test after `renders summary cards, employee rows, period controls, and blockers`:
+
+```tsx
+it("collapses blocker rows by default and toggles them from the notice header", () => {
+	render(
+		<PayrollWorkspace
+			initialSummary={summary}
+			exportFormats={[{ id: "datev_lohn", label: "DATEV" }]}
+		/>,
+	);
+
+	const notice = screen.getByRole("region", {
+		name: "2 payroll blockers need review",
+	});
+	const trigger = within(notice).getByRole("button", {
+		name: "2 payroll blockers need review",
+	});
+	expect(trigger.getAttribute("aria-expanded")).toBe("false");
+	expect(within(notice).queryByText("Missing clock-out")).toBeNull();
+
+	fireEvent.click(trigger);
+	expect(trigger.getAttribute("aria-expanded")).toBe("true");
+	expect(within(notice).getByText("Missing clock-out")).toBeTruthy();
+
+	fireEvent.click(trigger);
+	expect(trigger.getAttribute("aria-expanded")).toBe("false");
+	expect(within(notice).queryByText("Missing clock-out")).toBeNull();
+});
+```
+
+- [ ] **Step 3: Run the new test and verify it fails**
+
+Run:
+
+```bash
+pnpm --filter webapp test -- src/components/payroll/payroll-workspace.test.tsx -t "collapses blocker rows by default"
+```
+
+Expected: FAIL because the notice has no button trigger and the blocker rows render immediately.
+
+### Task 2: Implement the Collapsible Notice
+
+**Files:**
+- Modify: `apps/webapp/src/components/payroll/payroll-workspace.tsx:3-58,1272-1468`
+- Test: `apps/webapp/src/components/payroll/payroll-workspace.test.tsx`
+
+- [ ] **Step 1: Import the shared collapsible primitives and chevron icon**
+
+Add `IconChevronDown` to the existing Tabler import and add the UI import beside the other design-system imports:
+
+```tsx
+import {
+	IconAlertTriangle,
+	IconCalendarWeek,
+	IconChevronDown,
+	IconChevronLeft,
+	IconChevronRight,
+	IconDownload,
+	IconFileExport,
+	IconLoader2,
+	IconRefresh,
+	IconUsers,
+} from "@tabler/icons-react";
+```
+
+```tsx
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+```
+
+- [ ] **Step 2: Focus the visible trigger instead of the former focus-only heading**
+
+Rename the heading ref and target the trigger in `PayrollBlockersAlert`:
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement | null>(null);
+```
+
+```tsx
+const fallbackTarget = blockers.length === 0 ? fallbackFocusRef.current : triggerRef.current;
+```
+
+This keeps post-dismissal focus on an available, visible control without adding local state.
+
+- [ ] **Step 3: Replace the notice shell with a default-collapsed structure**
+
+Replace the current opening `<section>`, `<header>`, and `<ul>` markup before
+`{blockers.map((blocker) => {` with:
+
+```tsx
+<Collapsible asChild>
+	<section
+		aria-labelledby="payroll-blockers-title"
+		className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 text-sm dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+	>
+		<CollapsibleTrigger asChild>
+			<button
+				className="group flex w-full items-start gap-3 rounded-sm text-left focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+				ref={triggerRef}
+				type="button"
+			>
+				<IconAlertTriangle
+					aria-hidden="true"
+					className="mt-0.5 size-4 shrink-0"
+				/>
+				<h2
+					className="min-w-0 flex-1 font-medium leading-none"
+					id="payroll-blockers-title"
+				>
+					{title}
+				</h2>
+				<IconChevronDown
+					aria-hidden="true"
+					className="size-4 shrink-0 transition-transform group-data-[panel-open]:rotate-180"
+				/>
+			</button>
+		</CollapsibleTrigger>
+		<CollapsibleContent asChild>
+			<ul className="mt-3 grid gap-2">
+```
+
+Leave the existing `blockers.map(...)` expression and blocker-row markup
+unchanged. Replace the closing `</ul>` and `</section>` after the map with:
+
+```tsx
+			</ul>
+		</CollapsibleContent>
+	</section>
+</Collapsible>
+```
+
+Do not pass `defaultOpen`, `open`, or `onOpenChange`; the shared primitive therefore starts collapsed on each mount and maintains state only for that mounted component.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+pnpm --filter webapp test -- src/components/payroll/payroll-workspace.test.tsx -t "collapses blocker rows by default"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Adapt existing blocker-content tests to the intentional collapsed state**
+
+Call `expandPayrollBlockers()` immediately after rendering in every test that reads or interacts with blocker rows. This includes the localized blocker rendering, clear controls, dismissal, concurrency, refresh, focus-management, fallback metadata, and employee-ID privacy tests. In the general rendering test, call it before the `Missing clock-out` assertion:
+
+```tsx
+expandPayrollBlockers();
+expect(screen.getByText("Missing clock-out")).toBeTruthy();
+```
+
+Do not expand the notice in no-blocker tests or in the new default-collapsed test.
+
+- [ ] **Step 6: Run the complete component test file**
+
+Run:
+
+```bash
+pnpm --filter webapp test -- src/components/payroll/payroll-workspace.test.tsx
+```
+
+Expected: all `PayrollWorkspace` tests PASS. If a test cannot find a blocker row or action, add `expandPayrollBlockers()` after that test's render rather than weakening role queries or exposing collapsed content.
+
+- [ ] **Step 7: Commit the tested component change**
+
+```bash
+git add apps/webapp/src/components/payroll/payroll-workspace.tsx apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+git commit -m "feat: collapse payroll blockers by default"
+```
+
+### Task 3: Verify the Frontend Change
+
+**Files:**
+- Verify: `apps/webapp/src/components/payroll/payroll-workspace.tsx`
+- Verify: `apps/webapp/src/components/payroll/payroll-workspace.test.tsx`
+
+- [ ] **Step 1: Run the webapp typecheck**
+
+Run:
+
+```bash
+pnpm --filter webapp typecheck
+```
+
+Expected: exit code 0 with no TypeScript errors.
+
+- [ ] **Step 2: Run React diagnostics for the modified component**
+
+Use the repository's `react-doctor` skill against the changed React files and resolve any newly introduced actionable findings without refactoring unrelated code.
+
+Expected: no new actionable diagnostic in `payroll-workspace.tsx` or its test.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff HEAD^ -- apps/webapp/src/components/payroll/payroll-workspace.tsx apps/webapp/src/components/payroll/payroll-workspace.test.tsx
+```
+
+Expected: only the collapsible notice, its focused tests, and test setup needed to expand blocker content are present; unrelated worktree changes remain untouched.

--- a/docs/superpowers/specs/2026-08-03-collapsible-payroll-blockers-design.md
+++ b/docs/superpowers/specs/2026-08-03-collapsible-payroll-blockers-design.md
@@ -1,0 +1,52 @@
+# Collapsible Payroll Blockers
+
+## Goal
+
+Reduce the visual weight of the payroll blocker notice while keeping the blocker
+count immediately visible and every blocker readily accessible.
+
+## User Interface
+
+The existing amber payroll blocker notice remains visible whenever the selected
+payroll scope contains blockers. Its header becomes a full-width collapsible
+trigger containing the existing warning icon and localized blocker count, plus a
+chevron that communicates the current state.
+
+The blocker rows are the collapsible content. They are hidden by default each
+time the payroll workspace mounts and become visible when the user activates the
+header. Activating the header again collapses the rows. The state is local to the
+mounted workspace and is not persisted across visits.
+
+The trigger exposes its expanded state through the existing design-system
+`Collapsible` primitives. Keyboard activation and focus indication remain
+available. The notice keeps its current light and dark theme styling and its
+responsive blocker-row layout.
+
+## Behavior
+
+Only presentation state changes. Payroll blocker data, counts, workflow links,
+false-positive dismissal, refresh behavior, authorization, and organization
+scoping remain unchanged. The notice still disappears when no blockers remain.
+
+Existing post-dismissal focus behavior remains intact: focus moves to another
+available blocker control, the notice heading, or the blocker summary card as
+appropriate. When focus must move to the notice heading, the blocker content
+must be expanded so the focused destination and surrounding controls are
+available to the user.
+
+## Testing
+
+- The notice header and blocker count render while blocker rows start hidden.
+- The trigger reports a collapsed state initially.
+- Activating the trigger expands the content and exposes blocker rows and their
+  existing actions.
+- Activating the trigger again collapses the content.
+- Existing dismissal and focus-management tests continue to pass, with tests
+  expanding the notice before interacting with blocker rows where necessary.
+- A summary with no blockers renders no notice.
+
+## Non-Goals
+
+- Persisting the user's expanded or collapsed preference.
+- Changing blocker data, actions, dismissal rules, or payroll readiness logic.
+- Changing the payroll summary cards or employee table.


### PR DESCRIPTION
## Summary
- hide stale absence approvals and count pending absence requests with an organization-scoped SQL aggregate
- make payroll blockers collapsible by default with an accessible mobile-sized trigger
- localize approval timeline actor labels across every supported locale

## Test Plan
- [x] `pnpm --filter webapp exec vitest run src/components/payroll/payroll-workspace.test.tsx src/lib/approvals/handlers/absence-request.handler.test.ts "src/app/[locale]/(app)/approvals/inbox/components/approval-detail-panel.test.tsx" src/tolgee/shared.test.ts`
- [x] `pnpm --filter webapp typecheck`
- [x] `git diff --check origin/main...dev`
- [x] React Doctor regression scan (no new findings)