### PR TITLE
Unstick Historical Time Approvals and Stabilize Calendar Runtime

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -111,6 +111,7 @@
 		"pino-pretty": "^13.1.3",
 		"posthog-js": "^1.410.0",
 		"posthog-node": "^5.47.4",
+		"preact": "10.29.8",
 		"qrcode": "^1.5.4",
 		"qrcode.react": "^4.2.0",
 		"react": "19.2.8",

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
@@ -3480,6 +3480,12 @@ db.delete(approvalOutbox);`,
 			],
 			"src/lib/approvals/server/work-period-approvals.ts": [
 				{
+					columns: ["approval_workflow_id"],
+					functionName: "bindPreCanonicalOrdinaryWorkflow",
+					operation: "update",
+					table: "work_period",
+				},
+				{
 					columns: ["approval_status", "pending_changes"],
 					functionName: "finalizeOrdinaryWorkPeriodTerminal",
 					operation: "update",

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.ts
@@ -294,6 +294,12 @@ export const CANONICAL_SOURCE_WRITE_OWNERS = {
 	],
 	"src/lib/approvals/server/work-period-approvals.ts": [
 		{
+			columns: ["approval_workflow_id"],
+			functionName: "bindPreCanonicalOrdinaryWorkflow",
+			operation: "update",
+			table: "work_period",
+		},
+		{
 			columns: ["approval_status", "pending_changes"],
 			functionName: "finalizeOrdinaryWorkPeriodTerminal",
 			operation: "update",

--- a/apps/webapp/src/lib/approvals/server/work-period-approvals.integration.test.ts
+++ b/apps/webapp/src/lib/approvals/server/work-period-approvals.integration.test.ts
@@ -14,6 +14,7 @@ import * as authSchema from "@/db/auth-schema";
 import { configurePostgresUtcTypes } from "@/db/postgres-utc";
 import * as schema from "@/db/schema";
 import { TimeCorrectionHandler } from "@/lib/approvals/handlers/time-correction.handler";
+import { loadOrdinaryWorkPeriodLegacyDecisionEvidence } from "../domain-adapters/work-period-legacy-state";
 import { parseInstant, systemClock } from "@/lib/datetime/temporal-core";
 import { DatabaseService } from "@/lib/effect/services/database.service";
 import { calculateHash } from "@/lib/time-tracking/blockchain";
@@ -53,6 +54,7 @@ describe("ordinary work-period PostgreSQL case registration", () => {
 	it("registers the complete Task 11 mode, rollback, race, isolation, and split matrix", () => {
 		for (const scenario of [
 			"composes submission and terminal decisions in %s mode",
+			"bootstraps an unmarked pre-canonical manual $action in $mode mode",
 			"preserves policy snapshot through production submission capture in %s mode",
 			"retains terminal policy evidence for $action with split=$split in $mode mode",
 			"rolls back terminal policy $evidence evidence in $mode mode",
@@ -1698,6 +1700,81 @@ describeIntegration(
 			expect(typeof typedSource?.pendingChanges).toBe("string");
 			await expect(submit("manual_time_submission")).resolves.toMatchObject({
 				disposition: "executed",
+			});
+		});
+
+		it.each(
+			(["shadow", "ready"] as const).flatMap((mode) => [
+				{ mode, action: "approve" as const },
+				{ mode, action: "reject" as const },
+			]),
+		)("bootstraps an unmarked pre-canonical manual $action in $mode mode", async ({
+			mode,
+			action,
+		}) => {
+			await seed("manual_time_submission", false, "legacy");
+			const submitted = await submit("manual_time_submission");
+			await pool.query(
+				`update work_period set pending_changes = '{"isManualEntry":true}'
+				 where id = $1 and organization_id = $2 and employee_id = $3`,
+				[ids.period, ids.organization, ids.requester],
+			);
+			const unmarked = await pool.query(
+				`update approval_request set metadata = '{"timeRequest":{"kind":"manual_time_submission"}}'::jsonb
+				 where id = $1 and organization_id = $2 and entity_type = 'time_entry'
+				 and entity_id = $3 and status = 'pending' returning id`,
+				[submitted.result.approvalRequestId, ids.organization, ids.period],
+			);
+			expect(unmarked.rows).toEqual([
+				{ id: submitted.result.approvalRequestId },
+			]);
+			await expect(
+				loadOrdinaryWorkPeriodLegacyDecisionEvidence({
+					dbService: dbService(database),
+					organizationId: ids.organization,
+					workPeriodId: ids.period,
+					expectedRequesterEmployeeId: ids.requester,
+					approvalRequestId: submitted.result.approvalRequestId,
+					expectedRequestStatus: "pending",
+				}),
+			).resolves.toMatchObject({
+				source: { workflowType: "manual_time_submission" },
+			});
+			const before = await snapshot();
+			expect(before.approval_workflow).toEqual([]);
+			expect(
+				(before.work_period as Array<Record<string, unknown>>)[0]
+					?.approval_workflow_id,
+			).toBeNull();
+
+			await pool.query(
+				`update approval_workflow_rollout set lifecycle_mode = $1, updated_at = now()
+				 where organization_id = $2 and workflow_type = 'manual_time_submission'`,
+				[mode, ids.organization],
+			);
+			await expect(
+				decide(
+					submitted.result.approvalRequestId,
+					action === "approve"
+						? { kind: "approve", reason: null }
+						: { kind: "reject", reason: "Missing details" },
+				),
+			).resolves.toMatchObject({ result: { action } });
+
+			const graph = await snapshot();
+			const expectedStatus = action === "approve" ? "approved" : "rejected";
+			const periods = graph.work_period as Array<Record<string, unknown>>;
+			const workflows = graph.approval_workflow as Array<
+				Record<string, unknown>
+			>;
+			expect(workflows).toHaveLength(1);
+			expect(workflows[0]).toMatchObject({
+				status: expectedStatus,
+				version: 2,
+			});
+			expect(periods[0]).toMatchObject({
+				approval_status: expectedStatus,
+				approval_workflow_id: workflows[0]?.id,
 			});
 		});
 

--- a/apps/webapp/src/lib/approvals/server/work-period-approvals.test.ts
+++ b/apps/webapp/src/lib/approvals/server/work-period-approvals.test.ts
@@ -944,6 +944,97 @@ describe("stable ordinary work-period decisions", () => {
 	});
 
 	it.each([
+		["shadow", "approve"],
+		["shadow", "reject"],
+		["ready", "approve"],
+		["ready", "reject"],
+	] as const)(
+		"bootstraps a pre-canonical manual submission in %s mode for %s",
+		async (mode, action) => {
+			const dbService = createDecisionDbService({
+				unlinked: true,
+				autoApprovalRequest: {
+					metadata: { timeRequest: { kind: "manual_time_submission" } },
+				},
+			});
+			const database = dbService.db as unknown as {
+				query: Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+			};
+			database.query.employee.findMany = vi
+				.fn()
+				.mockResolvedValue([currentApprover]);
+			database.query.workPeriod.findFirst.mockResolvedValue({
+				...period,
+				approvalWorkflowId: null,
+			});
+			legacyCaptureMocks.capture.mockResolvedValue({
+				organizationId: "org-1",
+				source: {
+					organizationId: "org-1",
+					workflowType: "manual_time_submission",
+					sourceType: "time_entry",
+					sourceId: "period-1",
+				},
+				approvalRequest: {
+					...approval,
+					status: action === "approve" ? "approved" : "rejected",
+				},
+				chain: null,
+				chainRows: [],
+				sourceSnapshot: { timeRequest: { kind: "manual_time_submission" } },
+				capturedAt: parseInstant("2026-07-15T10:00:00Z"),
+			});
+			const mirrorLegacyToCanonical = vi.fn().mockResolvedValue({
+				snapshot: {
+					id: "workflow-bootstrapped",
+					status: action === "approve" ? "approved" : "rejected",
+				},
+			});
+			const context = {
+				dbService: { db: dbService.db },
+				writeGate: { acquire: vi.fn().mockResolvedValue({ mode }) },
+				compatibilityWriter: {
+					withWriteGate: vi.fn().mockReturnValue({
+						withWriteGate: vi.fn().mockReturnThis(),
+						mirrorLegacyToCanonical,
+					}),
+					mirrorLegacyToCanonical,
+				},
+				repository: { loadSnapshot: vi.fn() },
+			};
+
+			const executed = await executeOrdinaryWorkPeriodDecisionInTransaction({
+				dbService,
+				runtime: {
+					repository: { withTransaction: async (run) => run(context) },
+					transitionEngine: { executeInTransactionWithDisposition: vi.fn() },
+				} as never,
+				organizationId: "org-1",
+				approvalRequestId: "approval-1",
+				workPeriodId: "period-1",
+				actor: currentApprover,
+				decision:
+					action === "approve"
+						? { kind: "approve", reason: null }
+						: { kind: "reject", reason: "Orphaned request" },
+			});
+
+			expect(executed.result).toMatchObject({
+				kind: "manual_time_submission",
+				action,
+			});
+			expect(executed.postCommit).toMatchObject({
+				disposition: "dispatch",
+				event: action === "approve" ? "approved" : "rejected",
+			});
+			expect(context.repository.loadSnapshot).not.toHaveBeenCalled();
+			expect(mirrorLegacyToCanonical).toHaveBeenCalledWith(
+				expect.objectContaining({ expectedVersion: null }),
+			);
+		},
+	);
+
+	it.each([
 		"shadow",
 		"ready",
 	] as const)("captures an approved intermediate request with a pending %s source before terminal finalization", async (mode) => {

--- a/apps/webapp/src/lib/approvals/server/work-period-approvals.test.ts
+++ b/apps/webapp/src/lib/approvals/server/work-period-approvals.test.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { parseInstant } from "@/lib/datetime/temporal-core";
 import { deriveApprovalWorkflowId } from "../workflow/identity";
+import { createLegacyApprovalObservationPlanner } from "../workflow/legacy-observation-planner";
 import { fingerprintApprovalCommandActor } from "../workflow/state-machine";
 import { fingerprintApprovalWorkflowCommand } from "../workflow/transition-engine";
 import type { ApprovalDbService, CurrentApprover } from "./types";
@@ -951,6 +952,33 @@ describe("stable ordinary work-period decisions", () => {
 	] as const)(
 		"bootstraps a pre-canonical manual submission in %s mode for %s",
 		async (mode, action) => {
+			const pendingAt = parseInstant("2026-07-15T09:59:00Z");
+			const terminalAt = parseInstant("2026-07-15T10:00:00Z");
+			const pendingState = {
+				organizationId: "org-1",
+				source: {
+					organizationId: "org-1",
+					workflowType: "manual_time_submission" as const,
+					sourceType: "time_entry",
+					sourceId: "period-1",
+				},
+				approvalRequest: {
+					...approval,
+					metadata: {
+						timeRequest: { kind: "manual_time_submission" },
+						surchargeSnapshot,
+					},
+					updatedAt: pendingAt,
+				},
+				chain: null,
+				chainRows: [],
+				sourceSnapshot: {
+					status: "pending",
+					timeRequest: { kind: "manual_time_submission" },
+					surchargeSnapshot,
+				},
+				capturedAt: pendingAt,
+			};
 			const dbService = createDecisionDbService({
 				unlinked: true,
 				autoApprovalRequest: {
@@ -967,28 +995,65 @@ describe("stable ordinary work-period decisions", () => {
 				...period,
 				approvalWorkflowId: null,
 			});
-			legacyCaptureMocks.capture.mockResolvedValue({
-				organizationId: "org-1",
-				source: {
-					organizationId: "org-1",
-					workflowType: "manual_time_submission",
-					sourceType: "time_entry",
-					sourceId: "period-1",
-				},
+			legacyCaptureMocks.load.mockResolvedValue(pendingState);
+			const terminalState = {
+				...pendingState,
 				approvalRequest: {
-					...approval,
+					...pendingState.approvalRequest,
+					status: action === "approve" ? "approved" : "rejected",
+					approvedAt: action === "approve" ? terminalAt : null,
+					rejectionReason: action === "reject" ? "Orphaned request" : null,
+					updatedAt: terminalAt,
+				},
+				sourceSnapshot: {
+					...pendingState.sourceSnapshot,
 					status: action === "approve" ? "approved" : "rejected",
 				},
-				chain: null,
-				chainRows: [],
-				sourceSnapshot: { timeRequest: { kind: "manual_time_submission" } },
-				capturedAt: parseInstant("2026-07-15T10:00:00Z"),
+				capturedAt: terminalAt,
+			};
+			legacyCaptureMocks.capture.mockResolvedValue(terminalState);
+			const planner = createLegacyApprovalObservationPlanner({
+				clock: { nowInstant: () => terminalAt },
 			});
-			const mirrorLegacyToCanonical = vi.fn().mockResolvedValue({
-				snapshot: {
-					id: "workflow-bootstrapped",
-					status: action === "approve" ? "approved" : "rejected",
-				},
+			const mirrorLegacyToCanonical = vi.fn(async (transition) => {
+				const sourceId = "10000000-0000-4000-8000-000000000001";
+				const requesterId = "20000000-0000-4000-8000-000000000001";
+				const approverId = "30000000-0000-4000-8000-000000000001";
+				const sourceIdentity = { ...transition.before.source, sourceId };
+				const canonicalState = (state: typeof pendingState) => ({
+					...state,
+					source: sourceIdentity,
+					approvalRequest: state.approvalRequest
+						? {
+								...state.approvalRequest,
+								id: "40000000-0000-4000-8000-000000000001",
+								entityId: sourceId,
+								requestedBy: requesterId,
+								approverId,
+							}
+						: null,
+				});
+				const planned = await planner.plan({
+					...transition,
+					organizationId: transition.before.organizationId,
+					source: sourceIdentity,
+					before: canonicalState(transition.before),
+					after: canonicalState(transition.after),
+					actor: {
+						kind: "employee",
+						employeeId: approverId,
+						userId: "manager-user-1",
+					},
+				});
+				return {
+					...planned,
+					snapshot: {
+						...planned.snapshot,
+						organizationId: "org-1",
+						sourceId: "period-1",
+						requesterEmployeeId: "employee-1",
+					},
+				};
 			});
 			const context = {
 				dbService: { db: dbService.db },
@@ -1028,8 +1093,14 @@ describe("stable ordinary work-period decisions", () => {
 				event: action === "approve" ? "approved" : "rejected",
 			});
 			expect(context.repository.loadSnapshot).not.toHaveBeenCalled();
-			expect(mirrorLegacyToCanonical).toHaveBeenCalledWith(
-				expect.objectContaining({ expectedVersion: null }),
+			expect(mirrorLegacyToCanonical).toHaveBeenCalledTimes(2);
+			expect(
+				mirrorLegacyToCanonical.mock.calls.map(
+					([call]) => call.expectedVersion,
+				),
+			).toEqual([null, 1]);
+			expect(dbService.updateSets).toContainEqual(
+				expect.objectContaining({ approvalWorkflowId: expect.any(String) }),
 			);
 		},
 	);
@@ -1661,6 +1732,10 @@ function createDecisionDbService(options?: {
 }) {
 	const updateSets: Record<string, unknown>[] = [];
 	const insertedValues: Record<string, unknown>[] = [];
+	let currentApprovalWorkflowId =
+		options?.autoCompleted || options?.unlinked
+			? null
+			: period.approvalWorkflowId;
 	const returningResults = [
 		...(options?.autoCompleted ? [] : [[{ id: "approval-1" }]]),
 		options?.staleWorkPeriod ? [] : [{ id: "period-1" }],
@@ -1708,12 +1783,11 @@ function createDecisionDbService(options?: {
 				}),
 			},
 			workPeriod: {
-				findFirst: vi.fn().mockResolvedValue({
-					approvalWorkflowId:
-						options?.autoCompleted || options?.unlinked
-							? null
-							: period.approvalWorkflowId,
-				}),
+				findFirst: vi
+					.fn()
+					.mockImplementation(() =>
+						Promise.resolve({ approvalWorkflowId: currentApprovalWorkflowId }),
+					),
 			},
 			timeEntry: {
 				findFirst: vi.fn().mockResolvedValue({
@@ -1733,7 +1807,7 @@ function createDecisionDbService(options?: {
 									options?.autoCompleted || options?.unlinked
 										? {
 												...period,
-												approvalWorkflowId: null,
+												approvalWorkflowId: currentApprovalWorkflowId,
 												...(options?.kind === "policy_clock_out"
 													? {
 															pendingChanges: {
@@ -1771,6 +1845,23 @@ function createDecisionDbService(options?: {
 		update: vi.fn(() => ({
 			set: vi.fn((values: Record<string, unknown>) => {
 				updateSets.push(values);
+				const bindingWorkflowId = values.approvalWorkflowId;
+				if (typeof bindingWorkflowId === "string") {
+					currentApprovalWorkflowId = bindingWorkflowId;
+					return {
+						where: vi.fn(() => ({
+							returning: vi.fn().mockResolvedValue([
+								{
+									id: "period-1",
+									organizationId: "org-1",
+									employeeId: "employee-1",
+									canonicalRecordId: "record-1",
+									approvalWorkflowId: bindingWorkflowId,
+								},
+							]),
+						})),
+					};
+				}
 				return {
 					where: vi.fn(() => ({
 						returning: vi

--- a/apps/webapp/src/lib/approvals/server/work-period-approvals.ts
+++ b/apps/webapp/src/lib/approvals/server/work-period-approvals.ts
@@ -315,6 +315,50 @@ function isVerifiedLegacyIntermediateReplay(input: {
 	);
 }
 
+async function bindPreCanonicalOrdinaryWorkflow(input: {
+	dbService: ApprovalDbService;
+	organizationId: string;
+	workPeriodId: string;
+	requesterEmployeeId: string;
+	canonicalRecordId: string;
+	workflowId: string;
+	approvalStatus: "approved" | "rejected";
+}) {
+	const bound = await input.dbService.db
+		.update(workPeriod)
+		.set({ approvalWorkflowId: input.workflowId })
+		.where(
+			and(
+				eq(workPeriod.id, input.workPeriodId),
+				eq(workPeriod.organizationId, input.organizationId),
+				eq(workPeriod.employeeId, input.requesterEmployeeId),
+				eq(workPeriod.canonicalRecordId, input.canonicalRecordId),
+				isNull(workPeriod.approvalWorkflowId),
+				eq(workPeriod.approvalStatus, input.approvalStatus),
+				eq(workPeriod.isActive, false),
+				isNull(workPeriod.deletedAt),
+			),
+		)
+		.returning({
+			id: workPeriod.id,
+			organizationId: workPeriod.organizationId,
+			employeeId: workPeriod.employeeId,
+			canonicalRecordId: workPeriod.canonicalRecordId,
+			approvalWorkflowId: workPeriod.approvalWorkflowId,
+		});
+	const row = bound[0];
+	if (
+		bound.length !== 1 ||
+		row?.id !== input.workPeriodId ||
+		row.organizationId !== input.organizationId ||
+		row.employeeId !== input.requesterEmployeeId ||
+		row.canonicalRecordId !== input.canonicalRecordId ||
+		row.approvalWorkflowId !== input.workflowId
+	) {
+		throw new Error(ORDINARY_DECISION_ERROR);
+	}
+}
+
 export async function executeOrdinaryWorkPeriodDecisionInTransaction(input: {
 	dbService: ApprovalDbService;
 	runtime: ReturnType<typeof createProductionApprovalWorkflowRuntime>;
@@ -694,6 +738,44 @@ export async function executeOrdinaryWorkPeriodDecisionInTransaction(input: {
 				if (!requestRow || request.status !== "pending") {
 					throw new Error(ORDINARY_DECISION_ERROR);
 				}
+				let expectedObservedVersion = observedWorkflow?.version ?? null;
+				let bootstrappedWorkflowId: string | null = null;
+				if (authority.mode !== "legacy" && !observedWorkflow) {
+					if (!verifiedLegacyState) {
+						throw new Error(ORDINARY_DECISION_ERROR);
+					}
+					const bootstrapped =
+						await decisionContext.compatibilityWriter.mirrorLegacyToCanonical({
+							before: {
+								...verifiedLegacyState,
+								approvalRequest: null,
+								chain: null,
+								chainRows: [],
+							},
+							after: verifiedLegacyState,
+							actor: {
+								kind: "employee",
+								employeeId: actor.id,
+								userId: actor.userId,
+							},
+							idempotencyKey: `ordinary-bootstrap:${input.organizationId}:${period.id}:${input.approvalRequestId}`,
+							expectedVersion: null,
+						});
+					if (
+						!bootstrapped ||
+						bootstrapped.snapshot.organizationId !== input.organizationId ||
+						bootstrapped.snapshot.workflowType !== metadata.kind ||
+						bootstrapped.snapshot.sourceType !== "time_entry" ||
+						bootstrapped.snapshot.sourceId !== period.id ||
+						bootstrapped.snapshot.requesterEmployeeId !== period.employeeId ||
+						bootstrapped.snapshot.status !== "pending" ||
+						bootstrapped.snapshot.version !== 1
+					) {
+						throw new Error(ORDINARY_DECISION_ERROR);
+					}
+					bootstrappedWorkflowId = bootstrapped.snapshot.id;
+					expectedObservedVersion = bootstrapped.snapshot.version;
+				}
 				const coordinator = createLegacyApprovalWriteCoordinator({
 					writeGate: fixedGate,
 					compatibilityWriter: decisionContext.compatibilityWriter,
@@ -715,7 +797,7 @@ export async function executeOrdinaryWorkPeriodDecisionInTransaction(input: {
 						userId: actor.userId,
 					},
 					idempotencyKey: `ordinary-decision:${input.organizationId}:${period.id}:${input.approvalRequestId}:${input.decision.kind}:${input.decision.reason ?? ""}`,
-					expectedVersion: observedWorkflow?.version ?? null,
+					expectedVersion: expectedObservedVersion,
 					captureState:
 						authority.mode === "legacy"
 							? undefined
@@ -779,6 +861,30 @@ export async function executeOrdinaryWorkPeriodDecisionInTransaction(input: {
 							>,
 						);
 						return mutationResult;
+					},
+					afterMirror: async (observed) => {
+						if (!bootstrappedWorkflowId) return;
+						if (
+							observed.snapshot.id !== bootstrappedWorkflowId ||
+							observed.snapshot.organizationId !== input.organizationId ||
+							observed.snapshot.workflowType !== metadata.kind ||
+							observed.snapshot.sourceType !== "time_entry" ||
+							observed.snapshot.sourceId !== period.id ||
+							observed.snapshot.requesterEmployeeId !== period.employeeId ||
+							observed.snapshot.status !== expectedTerminalStatus ||
+							observed.snapshot.version !== 2
+						) {
+							throw new Error(ORDINARY_DECISION_ERROR);
+						}
+						await bindPreCanonicalOrdinaryWorkflow({
+							dbService: { db: database, query: input.dbService.query },
+							organizationId: input.organizationId,
+							workPeriodId: period.id,
+							requesterEmployeeId: period.employeeId,
+							canonicalRecordId: decisionPeriod.canonicalRecordId,
+							workflowId: bootstrappedWorkflowId,
+							approvalStatus: expectedTerminalStatus,
+						});
 					},
 				});
 				const result =

--- a/apps/webapp/src/lib/approvals/server/work-period-approvals.ts
+++ b/apps/webapp/src/lib/approvals/server/work-period-approvals.ts
@@ -698,14 +698,6 @@ export async function executeOrdinaryWorkPeriodDecisionInTransaction(input: {
 					writeGate: fixedGate,
 					compatibilityWriter: decisionContext.compatibilityWriter,
 				});
-				if (
-					authority.mode !== "legacy" &&
-					(!observedWorkflow ||
-						!Number.isSafeInteger(observedWorkflow.version) ||
-						observedWorkflow.version < 1)
-				) {
-					throw new Error(ORDINARY_DECISION_ERROR);
-				}
 				let mutationResult: WorkPeriodApprovalResult | undefined;
 				let captureCount = 0;
 				const domainResult = await coordinator.execute({

--- a/apps/webapp/src/lib/calendar/schedule-x-runtime.test.ts
+++ b/apps/webapp/src/lib/calendar/schedule-x-runtime.test.ts
@@ -1,0 +1,24 @@
+import { realpathSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Schedule-X runtime dependencies", () => {
+	it("uses one Preact runtime for the calendar and signals", () => {
+		const appRequire = createRequire(import.meta.url);
+		const calendarRequire = createRequire(
+			appRequire.resolve("@schedule-x/calendar/package.json"),
+		);
+		const signalsRequire = createRequire(
+			calendarRequire.resolve("@preact/signals"),
+		);
+		const calendarPreact = dirname(
+			realpathSync(calendarRequire.resolve("preact/package.json")),
+		);
+		const signalsPreact = dirname(
+			realpathSync(signalsRequire.resolve("preact/package.json")),
+		);
+
+		expect(signalsPreact).toBe(calendarPreact);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,7 +455,7 @@ importers:
         version: 4.5.1(react@19.2.8)
       '@schedule-x/calendar':
         specifier: ^4.6.1
-        version: 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)(temporal-polyfill@1.0.3)
+        version: 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)(temporal-polyfill@1.0.3)
       '@schedule-x/calendar-controls':
         specifier: ^4.6.1
         version: 4.6.1
@@ -464,10 +464,10 @@ importers:
         version: 3.7.3
       '@schedule-x/event-modal':
         specifier: ^4.6.1
-        version: 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)
+        version: 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)
       '@schedule-x/react':
         specifier: ^4.1.0
-        version: 4.1.0(@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)(temporal-polyfill@1.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 4.1.0(@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)(temporal-polyfill@1.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@schedule-x/theme-default':
         specifier: ^4.6.1
         version: 4.6.1
@@ -636,6 +636,9 @@ importers:
       posthog-node:
         specifier: ^5.47.4
         version: 5.47.4
+      preact:
+        specifier: 10.29.8
+        version: 10.29.8
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -10802,17 +10805,6 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
-  preact@10.28.4:
-    resolution: {integrity: sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==}
-
-  preact@10.29.7:
-    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
-    peerDependencies:
-      preact-render-to-string: '>=5'
-    peerDependenciesMeta:
-      preact-render-to-string:
-        optional: true
-
   preact@10.29.8:
     resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
     peerDependencies:
@@ -17298,22 +17290,22 @@ snapshots:
 
   '@schedule-x/calendar-controls@4.6.1': {}
 
-  '@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)(temporal-polyfill@1.0.3)':
+  '@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)(temporal-polyfill@1.0.3)':
     dependencies:
       '@preact/signals': 2.5.1(preact@10.29.8)
-      preact: 10.29.7
+      preact: 10.29.8
       temporal-polyfill: 1.0.3
 
   '@schedule-x/drag-and-drop@3.7.3': {}
 
-  '@schedule-x/event-modal@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)':
+  '@schedule-x/event-modal@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)':
     dependencies:
       '@preact/signals': 2.5.1(preact@10.29.8)
-      preact: 10.29.7
+      preact: 10.29.8
 
-  '@schedule-x/react@4.1.0(@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)(temporal-polyfill@1.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@schedule-x/react@4.1.0(@schedule-x/calendar@4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)(temporal-polyfill@1.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@schedule-x/calendar': 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.7)(temporal-polyfill@1.0.3)
+      '@schedule-x/calendar': 4.6.1(@preact/signals@2.5.1(preact@10.29.8))(preact@10.29.8)(temporal-polyfill@1.0.3)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
@@ -18606,7 +18598,7 @@ snapshots:
       mime-match: 1.0.2
       namespace-emitter: 2.0.1
       nanoid: 5.1.16
-      preact: 10.28.4
+      preact: 10.29.8
     transitivePeerDependencies:
       - preact-render-to-string
 
@@ -18630,7 +18622,7 @@ snapshots:
   '@uppy/utils@7.1.5':
     dependencies:
       lodash: 4.18.1
-      preact: 10.29.7
+      preact: 10.29.8
     transitivePeerDependencies:
       - preact-render-to-string
 
@@ -23914,10 +23906,6 @@ snapshots:
       '@posthog/core': 1.46.2
 
   powershell-utils@0.1.0: {}
-
-  preact@10.28.4: {}
-
-  preact@10.29.7: {}
 
   preact@10.29.8: {}
 


### PR DESCRIPTION
## Summary
- bootstrap pre-canonical manual time approvals as pending canonical workflows before terminal decisions
- atomically bind terminal workflows back to organization-scoped work periods
- deduplicate the Schedule-X Preact runtime to prevent calendar hook failures

## Changelog
- Fixed historical manual time approvals that could not be approved or rejected after the approval workflow rollout.
- Fixed Schedule-X calendar crashes caused by duplicate Preact runtimes.
- Added planner-backed unit coverage and PostgreSQL integration coverage for shadow/ready approval and rejection paths.

## Verification
- `pnpm --filter webapp exec vitest run src/lib/approvals/server/work-period-approvals.test.ts` (123 passed)
- approval write-boundary ownership test (passed)
- `pnpm --filter webapp typecheck`
- `pnpm --filter webapp test:approval-workflow-repository:integration` (265 passed)
- `src/lib/calendar/schedule-x-runtime.test.ts` (passed during prior verification)