### PR TITLE
Initialize and persist approval rollout configurations

### DIFF
--- a/apps/webapp/scripts/approval-workflow-rollout.ts
+++ b/apps/webapp/scripts/approval-workflow-rollout.ts
@@ -80,11 +80,12 @@ function bootstrapSql(): SQL {
 	const workflowRows = APPROVAL_WORKFLOW_TYPES.map(
 		(workflowType) => sql`(${workflowType}::approval_workflow_type)`,
 	);
+	const updatedAt = currentTimestamp();
 	return sql`
 		insert into approval_workflow_rollout (
-			organization_id, workflow_type, lifecycle_mode, side_effect_mode
+			organization_id, workflow_type, lifecycle_mode, side_effect_mode, updated_at
 		)
-		select organization.id, workflow_type.value, ${"legacy"}, ${"legacy"}
+		select organization.id, workflow_type.value, ${"legacy"}, ${"legacy"}, ${updatedAt}
 		from organization
 		cross join (values ${sql.join(workflowRows, sql`, `)}) as workflow_type(value)
 		on conflict (organization_id, workflow_type) do nothing

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
@@ -4134,6 +4134,9 @@ db.delete(approvalOutbox);`,
 				approval_request: ["insert", "update", "delete"],
 				approval_workflow_stage: ["update"],
 			},
+			"src/lib/approvals/workflow/cutover.ts": {
+				approval_workflow_rollout: ["insert"],
+			},
 			"src/lib/approvals/workflow/repository.ts": {
 				approval_stage_assignment: ["insert", "update"],
 				approval_workflow: ["insert", "update"],

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.ts
@@ -76,6 +76,9 @@ export const CANONICAL_WRITE_OWNERS = {
 		approval_request: ["insert", "update", "delete"],
 		approval_workflow_stage: ["update"],
 	},
+	"src/lib/approvals/workflow/cutover.ts": {
+		approval_workflow_rollout: ["insert"],
+	},
 	"src/lib/approvals/workflow/repository.ts": {
 		approval_stage_assignment: ["insert", "update"],
 		approval_workflow: ["insert", "update"],

--- a/apps/webapp/src/lib/approvals/workflow/cutover.test.ts
+++ b/apps/webapp/src/lib/approvals/workflow/cutover.test.ts
@@ -39,15 +39,18 @@ describe("approval workflow cutover", () => {
 		["ready", "legacy", true, true, false, "legacy_to_canonical"],
 		["canonical", "canonical", true, true, true, "canonical_to_legacy"],
 		["complete", "canonical", false, true, true, "none"],
-	] as const)("maps %s behavior exactly", (mode, serveFrom, writeLegacy, writeCanonical, decideCanonical, mirror) => {
-		expect(getCutoverBehavior(mode)).toEqual({
-			serveFrom,
-			writeLegacy,
-			writeCanonical,
-			decideCanonical,
-			mirror,
-		});
-	});
+	] as const)(
+		"maps %s behavior exactly",
+		(mode, serveFrom, writeLegacy, writeCanonical, decideCanonical, mirror) => {
+			expect(getCutoverBehavior(mode)).toEqual({
+				serveFrom,
+				writeLegacy,
+				writeCanonical,
+				decideCanonical,
+				mirror,
+			});
+		},
+	);
 
 	it.each([
 		["legacy", "shadow"],
@@ -108,11 +111,14 @@ describe("approval workflow cutover", () => {
 		["canonical", "ready"],
 		["complete", "canonical"],
 		["complete", "complete"],
-	] as const)("rejects invalid or irreversible %s -> %s transitions", (from, to) => {
-		expect(() => validateCutoverTransition(transition(from, to))).toThrow(
-			/transition/i,
-		);
-	});
+	] as const)(
+		"rejects invalid or irreversible %s -> %s transitions",
+		(from, to) => {
+			expect(() => validateCutoverTransition(transition(from, to))).toThrow(
+				/transition/i,
+			);
+		},
+	);
 
 	it("derives an unambiguous stable scope from organization and workflow type", () => {
 		expect(approvalRolloutLockScope("ab", "absence")).toBe(
@@ -156,10 +162,11 @@ describe("approval workflow cutover", () => {
 		const dialect = new PgDialect();
 		const rendered = calls.map((query) => dialect.sqlToQuery(query));
 		expect(rendered[0]?.sql).toContain("pg_advisory_xact_lock_shared");
-		expect(rendered[1]?.sql).toContain("from approval_workflow_rollout");
-		expect(rendered[2]?.sql).toMatch(/pg_advisory_xact_lock\(/);
-		expect(rendered[2]?.sql).not.toContain("lock_shared");
-		expect(rendered[0]?.params).toEqual(rendered[2]?.params);
+		expect(rendered[1]?.sql).toContain("insert into approval_workflow_rollout");
+		expect(rendered[2]?.sql).toContain("from approval_workflow_rollout");
+		expect(rendered[3]?.sql).toMatch(/pg_advisory_xact_lock\(/);
+		expect(rendered[3]?.sql).not.toContain("lock_shared");
+		expect(rendered[0]?.params).toEqual(rendered[3]?.params);
 		expect(transactionCalls).toBe(0);
 	});
 
@@ -172,6 +179,10 @@ describe("approval workflow cutover", () => {
 					const rendered = new PgDialect().sqlToQuery(query);
 					if (rendered.sql.includes("lock_shared")) {
 						timeline.push("lock");
+						return { rows: [] };
+					}
+					if (rendered.sql.includes("insert into approval_workflow_rollout")) {
+						timeline.push("initialize");
 						return { rows: [] };
 					}
 					timeline.push("mode");
@@ -192,21 +203,68 @@ describe("approval workflow cutover", () => {
 			mode: "canonical",
 			behavior: getCutoverBehavior("canonical"),
 		});
-		expect(timeline).toEqual(["lock", "mode"]);
+		expect(timeline).toEqual(["lock", "initialize", "mode"]);
 		expect(transactionCalls).toBe(0);
 	});
 
-	it("propagates write-gate lock and mode-read failures", async () => {
-		for (const failureAt of ["lock", "mode"] as const) {
+	it("initializes a missing rollout row in legacy mode under the write lock", async () => {
+		const timeline: string[] = [];
+		const service = {
+			db: {
+				execute: async (query: SQL) => {
+					const rendered = new PgDialect().sqlToQuery(query);
+					if (rendered.sql.includes("lock_shared")) {
+						timeline.push("lock");
+						return { rows: [] };
+					}
+					if (rendered.sql.includes("insert into approval_workflow_rollout")) {
+						timeline.push("initialize");
+						expect(rendered.sql).toContain("on conflict");
+						expect(rendered.sql).toContain("updated_at");
+						expect(rendered.params).toEqual([
+							"org-1",
+							"time_correction",
+							"legacy",
+							"legacy",
+							expect.any(Date),
+						]);
+						return { rows: [] };
+					}
+					timeline.push("mode");
+					return { rows: [{ lifecycle_mode: "legacy" }] };
+				},
+			},
+		} as unknown as ApprovalDbService;
+
+		await expect(
+			acquireApprovalWriteGate(service, {
+				organizationId: "org-1",
+				workflowType: "time_correction",
+			}),
+		).resolves.toEqual({
+			mode: "legacy",
+			behavior: getCutoverBehavior("legacy"),
+		});
+		expect(timeline).toEqual(["lock", "initialize", "mode"]);
+	});
+
+	it("propagates write-gate lock, initialization, and mode-read failures", async () => {
+		for (const [failureAt, failureCall] of [
+			["lock", 1],
+			["initialize", 2],
+			["mode", 3],
+		] as const) {
 			let calls = 0;
 			const service = {
 				db: {
 					execute: async () => {
 						calls += 1;
-						if (failureAt === "lock" || calls === 2) {
+						if (calls === failureCall) {
 							throw new Error(`${failureAt} failed`);
 						}
-						return { rows: [] };
+						return calls === 3
+							? { rows: [{ lifecycle_mode: "legacy" }] }
+							: { rows: [] };
 					},
 				},
 			} as ApprovalDbService;
@@ -216,7 +274,7 @@ describe("approval workflow cutover", () => {
 					workflowType: "absence",
 				}),
 			).rejects.toThrow(`${failureAt} failed`);
-			expect(calls).toBe(failureAt === "lock" ? 1 : 2);
+			expect(calls).toBe(failureCall);
 		}
 	});
 });

--- a/apps/webapp/src/lib/approvals/workflow/cutover.ts
+++ b/apps/webapp/src/lib/approvals/workflow/cutover.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import { currentTimestamp } from "@/lib/datetime/drizzle-schema";
 import type { Instant } from "@/lib/datetime/temporal-core";
 import type {
 	ApprovalCutoverBehavior,
@@ -182,6 +183,23 @@ export async function acquireApprovalWriteGate(
 	input: ApprovalRolloutLockInput,
 ): Promise<ApprovalWriteGateResult> {
 	await acquireApprovalWriteLock(dbService, input);
+	await dbService.db.execute(sql`
+		insert into approval_workflow_rollout (
+			organization_id,
+			workflow_type,
+			lifecycle_mode,
+			side_effect_mode,
+			updated_at
+		)
+		values (
+			${input.organizationId},
+			${input.workflowType},
+			${"legacy"},
+			${"legacy"},
+			${currentTimestamp()}
+		)
+		on conflict (organization_id, workflow_type) do nothing
+	`);
 	const mode = await readApprovalRolloutMode(dbService, input);
 	return { mode, behavior: getCutoverBehavior(mode) };
 }

--- a/apps/webapp/src/lib/approvals/workflow/rollout-script.test.ts
+++ b/apps/webapp/src/lib/approvals/workflow/rollout-script.test.ts
@@ -81,19 +81,20 @@ describe("approval workflow rollout CLI", () => {
 		expect(result.stderr).toBe("");
 	}, 15_000);
 
-	it.each([
-		[[]],
-		[["unknown"]],
-	] as const)("fails closed on a missing or unknown command before reading database env: %j", (args) => {
-		const result = cli(args);
-		expectChildCompleted(result);
-		expect(result.status).not.toBe(0);
-		expect(result.stderr).toMatch(/unknown approval rollout command/i);
-		expect(result.stderr).not.toMatch(
-			/temporal-polyfill|package_path_not_exported/i,
-		);
-		expect(result.stderr).not.toMatch(/missing required environment/i);
-	}, 15_000);
+	it.each([[[]], [["unknown"]]] as const)(
+		"fails closed on a missing or unknown command before reading database env: %j",
+		(args) => {
+			const result = cli(args);
+			expectChildCompleted(result);
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toMatch(/unknown approval rollout command/i);
+			expect(result.stderr).not.toMatch(
+				/temporal-polyfill|package_path_not_exported/i,
+			);
+			expect(result.stderr).not.toMatch(/missing required environment/i);
+		},
+		15_000,
+	);
 
 	it("reaches main and checks environment after parsing a valid command", () => {
 		const result = cli(["bootstrap"]);
@@ -192,37 +193,40 @@ describe("approval workflow rollout CLI", () => {
 	it.each([
 		["close success", false],
 		["close failure", true],
-	] as const)("preserves an undefined command rejection through %s", async (_name, closeFails) => {
-		const runCli = rolloutScript.runApprovalWorkflowRolloutCli;
-		const notRejected = Symbol("not rejected");
-		let rejection: unknown = notRejected;
-		await runCli(
-			["bootstrap"],
-			{
-				POSTGRES_HOST: "disposable",
-				POSTGRES_PORT: "5432",
-				POSTGRES_DB: "disposable",
-				POSTGRES_USER: "disposable",
-				POSTGRES_PASSWORD: "disposable",
-			},
-			async () => ({
-				db: { transaction: async () => Promise.reject(undefined) },
-				pool: {
-					end: async () => {
-						if (closeFails) throw new Error("close failed");
-					},
+	] as const)(
+		"preserves an undefined command rejection through %s",
+		async (_name, closeFails) => {
+			const runCli = rolloutScript.runApprovalWorkflowRolloutCli;
+			const notRejected = Symbol("not rejected");
+			let rejection: unknown = notRejected;
+			await runCli(
+				["bootstrap"],
+				{
+					POSTGRES_HOST: "disposable",
+					POSTGRES_PORT: "5432",
+					POSTGRES_DB: "disposable",
+					POSTGRES_USER: "disposable",
+					POSTGRES_PASSWORD: "disposable",
 				},
-			}),
-		).then(
-			() => undefined,
-			(error: unknown) => {
-				rejection = error;
-			},
-		);
+				async () => ({
+					db: { transaction: async () => Promise.reject(undefined) },
+					pool: {
+						end: async () => {
+							if (closeFails) throw new Error("close failed");
+						},
+					},
+				}),
+			).then(
+				() => undefined,
+				(error: unknown) => {
+					rejection = error;
+				},
+			);
 
-		expect(rejection).not.toBe(notRejected);
-		expect(rejection).toBeUndefined();
-	});
+			expect(rejection).not.toBe(notRejected);
+			expect(rejection).toBeUndefined();
+		},
+	);
 
 	it("rejects with the close error when the command succeeds", async () => {
 		await expect(
@@ -299,6 +303,7 @@ describe("approval workflow rollout CLI", () => {
 		await executeApprovalWorkflowRollout({ kind: "bootstrap" }, database);
 		const rendered = new PgDialect().sqlToQuery(calls[0] as SQL);
 		expect(rendered.sql).toContain("insert into approval_workflow_rollout");
+		expect(rendered.sql).toContain("updated_at");
 		expect(rendered.sql).toContain("cross join");
 		expect(rendered.sql.match(/::approval_workflow_type/g)).toHaveLength(7);
 		expect(rendered.sql).toContain(
@@ -313,6 +318,7 @@ describe("approval workflow rollout CLI", () => {
 				"travel_expense",
 				"shift_request",
 				"compliance_exception",
+				expect.any(Date),
 			]),
 		);
 	});


### PR DESCRIPTION
This pull request introduces improvements to the approval workflow rollout process, focusing on ensuring the `approval_workflow_rollout` table is correctly initialized and updated, especially regarding the `updated_at` field. It also expands test coverage for these changes and refines test formatting for clarity.

**Database and Workflow Initialization:**

* The `approval_workflow_rollout` table is now always initialized with an `updated_at` timestamp when acquiring the approval write gate, ensuring consistency and traceability of rollout state (`apps/webapp/src/lib/approvals/workflow/cutover.ts`, `apps/webapp/scripts/approval-workflow-rollout.ts`). [[1]](diffhunk://#diff-f3de358423fe79dfd77e176c86de58b97ab4c89311bd51828b0c2d4acce68c02R186-R202) [[2]](diffhunk://#diff-0589e30bbc2cd6ae8cc5957e6865abaa1aa47e6429f29f74a60244df22362a20R83-R88)
* The CLI bootstrap logic and tests have been updated to expect and validate the presence of the `updated_at` column and value (`apps/webapp/src/lib/approvals/workflow/rollout-script.test.ts`). [[1]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bR306) [[2]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bR321)

**Test Coverage and Robustness:**

* New and updated tests verify that the rollout initialization occurs under the write lock, that `updated_at` is present, and that error handling is robust for each step of the workflow rollout process (`apps/webapp/src/lib/approvals/workflow/cutover.test.ts`). [[1]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbL159-R169) [[2]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbR184-R187) [[3]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbL195-R267) [[4]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbL219-R277)
* Test formatting has been improved for readability and maintainability, especially for parameterized tests in both workflow cutover and CLI rollout scripts (`apps/webapp/src/lib/approvals/workflow/cutover.test.ts`, `apps/webapp/src/lib/approvals/workflow/rollout-script.test.ts`). [[1]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbL42-R53) [[2]](diffhunk://#diff-299cbed535d9643eeeb9c21470d9ee26a122fb28db78035ebee162ff9723ebdbL111-R121) [[3]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bL84-R86) [[4]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bL96-R97) [[5]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bL195-R198) [[6]](diffhunk://#diff-1bbb5d86a57f141013329d3b28d00872cc07ec6c24c3b727cda2cdb02efcc14bL225-R229)

**Ownership and Permissions:**

* Ownership mappings for write operations have been updated to reflect the new logic, ensuring that `approval_workflow_rollout` inserts are attributed to the correct module (`apps/webapp/src/lib/approvals/approval-write-boundary.ts`, `apps/webapp/src/lib/approvals/approval-write-boundary.test.ts`). [[1]](diffhunk://#diff-acb5d7375f71103e1d4b25d57ed557b507c5af297427b755f298cd6664362308R79-R81) [[2]](diffhunk://#diff-d20a410e1a1a3c44b618c230030cabe9ee572dd29589a75a496a4f1dfd1473acR4137-R4139)

**Dependency Updates:**

* The `currentTimestamp` utility is now imported and used to provide the `updated_at` value (`apps/webapp/src/lib/approvals/workflow/cutover.ts`).

These changes collectively ensure the rollout process is more reliable, auditable, and well-tested.