### PR TITLE
fix: finalize active time corrections

### DIFF
--- a/apps/webapp/src/lib/approvals/domain-adapters/time-correction.adapter.test.ts
+++ b/apps/webapp/src/lib/approvals/domain-adapters/time-correction.adapter.test.ts
@@ -562,6 +562,86 @@ describe("time correction approval adapter", () => {
 		}
 	});
 
+	it("loads and approves an active correction before canonical materialization", async () => {
+		const fixture = createFixture();
+		const activeCorrection = {
+			action: "edit" as const,
+			clockInCorrectionId: ids.correctionIn,
+			workLocationType: "office" as const,
+			workCategoryId: null,
+		};
+		Object.assign(fixture.value.period, {
+			clockOutId: null,
+			canonicalRecordId: null,
+			endTime: null,
+			durationMinutes: null,
+			isActive: true,
+			workLocationType: "office",
+		});
+		fixture.value.canonical = null as never;
+		fixture.value.canonicalWork = null as never;
+		fixture.value.entries = [
+			required(fixture.value.entries[0]),
+			required(fixture.value.entries[2]),
+		];
+		const activeContext = {
+			timeCorrection: activeCorrection,
+			timeCorrectionOriginalWorkMetadata: {
+				workLocationType: "office" as const,
+				workCategoryId: null,
+			},
+		};
+
+		const { adapter, source, finalizeTimeCorrectionTerminal } = await loadSource(
+			fixture,
+			{
+				contextSnapshot: activeContext,
+			},
+		);
+		const dbService = { db: {} } as never;
+
+		await adapter.finalizeTerminal({
+			...context(source, {
+				status: "approved",
+				version: 5,
+				completedAt: finalizedAt,
+				contextSnapshot: activeContext,
+			}),
+			dbService,
+			finalizationCause: "command",
+			transition: {
+				kind: "approve",
+				from: "pending",
+				to: "approved",
+				reason: "verified",
+			},
+			finalizedAt,
+		});
+
+		expect(source).toMatchObject({
+			canonicalRecordId: null,
+			canonicalRecord: null,
+			canonicalWork: null,
+			workPeriod: {
+				clockOutId: null,
+				endTime: null,
+				durationMinutes: null,
+				isActive: true,
+			},
+		});
+		expect(finalizeTimeCorrectionTerminal).toHaveBeenCalledWith(
+			expect.objectContaining({
+				correction: activeCorrection,
+				expectedSource: expect.objectContaining({
+					canonicalRecordId: null,
+					canonicalRecord: null,
+					canonicalWork: null,
+				}),
+				transition: { kind: "approve", reason: "verified" },
+			}),
+		);
+	});
+
 	it("requires an exact approved organization membership independently of the employee", async () => {
 		const { fixture, source } = await loadSource();
 

--- a/apps/webapp/src/lib/approvals/domain-adapters/time-correction.adapter.ts
+++ b/apps/webapp/src/lib/approvals/domain-adapters/time-correction.adapter.ts
@@ -57,13 +57,13 @@ const TIMEZONE_SOURCES = new Set([
 
 type OvertimeRisk = "none" | "warning" | "violation";
 
-export interface TimeCorrectionApprovalSource {
+interface TimeCorrectionApprovalSourceShape {
 	id: string;
 	organizationId: string;
 	employeeId: string;
 	requesterUserId: string;
 	approvalWorkflowId: string;
-	canonicalRecordId: string;
+	canonicalRecordId: string | null;
 	correction: TimeCorrectionWorkflowPayload["timeCorrection"];
 	originalWorkMetadata?: TimeCorrectionOriginalWorkMetadata;
 	clockIn: TimeCorrectionEndpointEvidence | null;
@@ -95,11 +95,32 @@ export interface TimeCorrectionApprovalSource {
 		endAt: Instant | null;
 		durationMinutes: number | null;
 		approvalState: "approved";
-	};
-	canonicalWork: CancelledTimeCorrectionSourceEvidence["canonicalWork"];
+	} | null;
+	canonicalWork: CancelledTimeCorrectionSourceEvidence["canonicalWork"] | null;
 	currentEndpoints: CancelledTimeCorrectionSourceEvidence["currentEndpoints"];
 	pendingCorrections: CancelledTimeCorrectionSourceEvidence["pendingCorrections"];
 }
+
+export type TimeCorrectionApprovalSource = Omit<
+	TimeCorrectionApprovalSourceShape,
+	"canonicalRecordId" | "canonicalRecord" | "canonicalWork"
+> &
+	(
+		| {
+				canonicalRecordId: string;
+				canonicalRecord: NonNullable<
+					TimeCorrectionApprovalSourceShape["canonicalRecord"]
+				>;
+				canonicalWork: NonNullable<
+					TimeCorrectionApprovalSourceShape["canonicalWork"]
+				>;
+		  }
+		| {
+				canonicalRecordId: null;
+				canonicalRecord: null;
+				canonicalWork: null;
+		  }
+	);
 
 export interface DeleteCancelledTimeCorrectionInput {
 	dbService: ApprovalDbService;
@@ -558,6 +579,12 @@ export function createTimeCorrectionApprovalAdapter(
 				)
 				.for("update");
 			const period = periodRows[0];
+			const isUnmaterializedActivePeriod =
+				period?.isActive === true &&
+				period.clockOutId === null &&
+				period.endTime === null &&
+				period.durationMinutes === null &&
+				period.canonicalRecordId === null;
 			if (
 				periodRows.length !== 1 ||
 				!period ||
@@ -565,7 +592,7 @@ export function createTimeCorrectionApprovalAdapter(
 				period.organizationId !== input.organizationId ||
 				period.employeeId !== requesterEmployeeId ||
 				period.approvalWorkflowId !== input.workflow.id ||
-				!period.canonicalRecordId ||
+				(!period.canonicalRecordId && !isUnmaterializedActivePeriod) ||
 				period.approvalStatus !== "approved" ||
 				period.pendingChanges !== null ||
 				period.deletedAt !== null ||
@@ -639,38 +666,42 @@ export function createTimeCorrectionApprovalAdapter(
 				predecessorRows.map((entry) => [entry.id, entry]),
 			);
 			if (predecessorsById.size !== predecessorIds.length) return fail();
-			const canonicalRows = await db
-				.select()
-				.from(timeRecord)
-				.where(
-					and(
-						eq(timeRecord.id, period.canonicalRecordId),
-						eq(timeRecord.organizationId, input.organizationId),
-						eq(timeRecord.employeeId, requesterEmployeeId),
-						eq(timeRecord.recordKind, "work"),
-					),
-				)
-				.orderBy(asc(timeRecord.id))
-				.for("update");
+			const canonicalRows = period.canonicalRecordId
+				? await db
+						.select()
+						.from(timeRecord)
+						.where(
+							and(
+								eq(timeRecord.id, period.canonicalRecordId),
+								eq(timeRecord.organizationId, input.organizationId),
+								eq(timeRecord.employeeId, requesterEmployeeId),
+								eq(timeRecord.recordKind, "work"),
+							),
+						)
+						.orderBy(asc(timeRecord.id))
+						.for("update")
+				: [];
 			const canonical = canonicalRows[0];
-			const canonicalWorkRows = await db
-				.select({
-					recordId: timeRecordWork.recordId,
-					organizationId: timeRecordWork.organizationId,
-					recordKind: timeRecordWork.recordKind,
-					workLocationType: timeRecordWork.workLocationType,
-					workCategoryId: timeRecordWork.workCategoryId,
-				})
-				.from(timeRecordWork)
-				.where(
-					and(
-						eq(timeRecordWork.recordId, period.canonicalRecordId),
-						eq(timeRecordWork.organizationId, input.organizationId),
-						eq(timeRecordWork.recordKind, "work"),
-					),
-				)
-				.orderBy(asc(timeRecordWork.recordId))
-				.for("update");
+			const canonicalWorkRows = period.canonicalRecordId
+				? await db
+						.select({
+							recordId: timeRecordWork.recordId,
+							organizationId: timeRecordWork.organizationId,
+							recordKind: timeRecordWork.recordKind,
+							workLocationType: timeRecordWork.workLocationType,
+							workCategoryId: timeRecordWork.workCategoryId,
+						})
+						.from(timeRecordWork)
+						.where(
+							and(
+								eq(timeRecordWork.recordId, period.canonicalRecordId),
+								eq(timeRecordWork.organizationId, input.organizationId),
+								eq(timeRecordWork.recordKind, "work"),
+							),
+						)
+						.orderBy(asc(timeRecordWork.recordId))
+						.for("update")
+				: [];
 			const canonicalWork = canonicalWorkRows[0];
 			const requester = await db.query.employee.findFirst({
 				where: and(
@@ -719,31 +750,35 @@ export function createTimeCorrectionApprovalAdapter(
 				membership.organizationId !== input.organizationId ||
 				membership.userId !== requester.userId ||
 				membership.status !== "approved" ||
-				canonicalRows.length !== 1 ||
-				!canonical ||
-				canonical.id !== period.canonicalRecordId ||
-				canonical.organizationId !== input.organizationId ||
-				canonical.employeeId !== requesterEmployeeId ||
-				canonical.recordKind !== "work" ||
-				canonical.approvalState !== period.approvalStatus ||
-				!sameInstant(canonical.startAt, period.startTime) ||
-				!sameInstant(canonical.endAt, period.endTime) ||
-				canonical.durationMinutes !== period.durationMinutes ||
-				canonicalWorkRows.length !== 1 ||
-				!canonicalWork ||
-				canonicalWork.recordId !== period.canonicalRecordId ||
-				canonicalWork.organizationId !== input.organizationId ||
-				canonicalWork.recordKind !== "work" ||
-				canonicalWork.workLocationType !== (period.workLocationType ?? null) ||
-				canonicalWork.workCategoryId !== (period.workCategoryId ?? null) ||
+				(period.canonicalRecordId !== null &&
+					(canonicalRows.length !== 1 ||
+						!canonical ||
+						canonical.id !== period.canonicalRecordId ||
+						canonical.organizationId !== input.organizationId ||
+						canonical.employeeId !== requesterEmployeeId ||
+						canonical.recordKind !== "work" ||
+						canonical.approvalState !== period.approvalStatus ||
+						!sameInstant(canonical.startAt, period.startTime) ||
+						!sameInstant(canonical.endAt, period.endTime) ||
+						canonical.durationMinutes !== period.durationMinutes ||
+						canonicalWorkRows.length !== 1 ||
+						!canonicalWork ||
+						canonicalWork.recordId !== period.canonicalRecordId ||
+						canonicalWork.organizationId !== input.organizationId ||
+						canonicalWork.recordKind !== "work" ||
+						canonicalWork.workLocationType !==
+							(period.workLocationType ?? null) ||
+						canonicalWork.workCategoryId !==
+							(period.workCategoryId ?? null))) ||
 				(originalWorkMetadata !== undefined &&
 					(normalizeWorkLocationType(period.workLocationType) !==
 						originalWorkMetadata.workLocationType ||
 						period.workCategoryId !== originalWorkMetadata.workCategoryId ||
-						normalizeWorkLocationType(canonicalWork.workLocationType) !==
-							originalWorkMetadata.workLocationType ||
-						canonicalWork.workCategoryId !==
-							originalWorkMetadata.workCategoryId)) ||
+						(canonicalWork !== undefined &&
+							(normalizeWorkLocationType(canonicalWork.workLocationType) !==
+								originalWorkMetadata.workLocationType ||
+								canonicalWork.workCategoryId !==
+									originalWorkMetadata.workCategoryId)))) ||
 				entries.length !== entryIds.length
 			) {
 				return fail();
@@ -859,24 +894,28 @@ export function createTimeCorrectionApprovalAdapter(
 					workLocationType: period.workLocationType ?? null,
 					workCategoryId: period.workCategoryId ?? null,
 				},
-				canonicalRecord: {
-					id: canonical.id,
-					employeeId: canonical.employeeId,
-					recordKind: "work",
-					startAt: instantFromTimeCorrectionBoundary(canonical.startAt),
-					endAt: canonical.endAt
-						? instantFromTimeCorrectionBoundary(canonical.endAt)
-						: null,
-					durationMinutes: canonical.durationMinutes,
-					approvalState: "approved",
-				},
-				canonicalWork: {
-					recordId: canonicalWork.recordId,
-					organizationId: canonicalWork.organizationId,
-					recordKind: "work",
-					workLocationType: canonicalWork.workLocationType,
-					workCategoryId: canonicalWork.workCategoryId,
-				},
+				canonicalRecord: canonical
+					? {
+							id: canonical.id,
+							employeeId: canonical.employeeId,
+							recordKind: "work",
+							startAt: instantFromTimeCorrectionBoundary(canonical.startAt),
+							endAt: canonical.endAt
+								? instantFromTimeCorrectionBoundary(canonical.endAt)
+								: null,
+							durationMinutes: canonical.durationMinutes,
+							approvalState: "approved",
+						}
+					: null,
+				canonicalWork: canonicalWork
+					? {
+							recordId: canonicalWork.recordId,
+							organizationId: canonicalWork.organizationId,
+							recordKind: "work",
+							workLocationType: canonicalWork.workLocationType,
+							workCategoryId: canonicalWork.workCategoryId,
+						}
+					: null,
 				currentEndpoints: {
 					clockIn: cancellationEntryEvidence(originalIn, "clock_in"),
 					clockOut: originalOut
@@ -969,6 +1008,13 @@ export function createTimeCorrectionApprovalAdapter(
 		async finalizeTerminal(input) {
 			await this.preflightTerminal(input);
 			if (input.transition.kind === "cancel_pending") {
+				if (
+					!input.source.canonicalRecordId ||
+					!input.source.canonicalRecord ||
+					!input.source.canonicalWork
+				) {
+					return fail("Time correction cancellation source is invalid");
+				}
 				await dependencies.deleteCancelledCorrections({
 					dbService: input.dbService,
 					organizationId: input.organizationId,
@@ -994,6 +1040,26 @@ export function createTimeCorrectionApprovalAdapter(
 					: input.transition.kind === "reject"
 						? { kind: "reject" as const, reason: input.transition.reason }
 						: fail("Unsupported time correction terminal transition");
+			const expectedSource = {
+				employeeId: input.source.employeeId,
+				approvalWorkflowId: input.source.approvalWorkflowId,
+				...input.source.workPeriod,
+				currentEndpoints: input.source.currentEndpoints,
+				pendingCorrections: input.source.pendingCorrections,
+				...(input.source.canonicalRecordId === null
+					? {
+							canonicalRecordId: null,
+							canonicalRecord: null,
+							canonicalWork: null,
+						}
+					: {
+							canonicalRecordId: input.source.canonicalRecordId,
+							canonicalRecord: input.source.canonicalRecord,
+							canonicalWork: input.source.canonicalWork,
+						}),
+			} satisfies NonNullable<
+				FinalizeTimeCorrectionTerminalInput["expectedSource"]
+			>;
 			await dependencies.finalizeTimeCorrectionTerminal({
 				dbService: input.dbService as unknown as ServerApprovalDbService,
 				organizationId: input.organizationId,
@@ -1001,16 +1067,7 @@ export function createTimeCorrectionApprovalAdapter(
 				expectedApprovalWorkflowId: input.workflow.id,
 				expectedApprovalWorkflowVersion: input.workflow.version,
 				expectedRequesterEmployeeId: input.source.employeeId,
-				expectedSource: {
-					employeeId: input.source.employeeId,
-					approvalWorkflowId: input.source.approvalWorkflowId,
-					canonicalRecordId: input.source.canonicalRecordId,
-					...input.source.workPeriod,
-					canonicalRecord: input.source.canonicalRecord,
-					canonicalWork: input.source.canonicalWork,
-					currentEndpoints: input.source.currentEndpoints,
-					pendingCorrections: input.source.pendingCorrections,
-				},
+				expectedSource,
 				...actor,
 				correction: input.source.correction,
 				expectedOriginalWorkMetadata: input.source.originalWorkMetadata,

--- a/apps/webapp/src/lib/approvals/server/time-correction-approvals.test.ts
+++ b/apps/webapp/src/lib/approvals/server/time-correction-approvals.test.ts
@@ -8150,6 +8150,151 @@ describe("finalizeTimeCorrectionTerminalInTransaction", () => {
 		);
 	});
 
+	it("applies a clock-in correction before an active period has a canonical record", async () => {
+		const correction = {
+			action: "edit" as const,
+			clockInCorrectionId: ids.correctionIn,
+			workLocationType: "office" as const,
+			workCategoryId: terminalPeriod.workCategoryId,
+		};
+		const { dbService, mutations } = createFinalizerDb({
+			period: {
+				...terminalPeriod,
+				clockOutId: null,
+				canonicalRecordId: null,
+				endTime: null,
+				durationMinutes: null,
+				isActive: true,
+			},
+			entries: [originalIn, correctionIn],
+			canonical: null,
+			canonicalWork: null,
+			legacyRequest: null,
+			workflow: {
+				...canonicalWorkflow,
+				contextSnapshot: {
+					timeCorrection: correction,
+					timeCorrectionOriginalWorkMetadata: {
+						workLocationType: "office",
+						workCategoryId: terminalPeriod.workCategoryId,
+					},
+				},
+			},
+			mutationRows: [
+				[{ id: ids.correctionIn }],
+				[{ id: ids.originalIn }],
+				[{ id: ids.period }],
+			],
+		});
+
+		const result = await finalizeTimeCorrectionTerminalInTransaction(
+			approveInput(dbService, {
+				legacyApprovalRequestId: null,
+				correction,
+			}),
+		);
+
+		expect(result.transition).toBe("approved");
+		expect(mutations.map(({ table }) => table)).toEqual([
+			timeEntry,
+			timeEntry,
+			workPeriod,
+		]);
+		expect(mutations.at(-1)?.values).toMatchObject({
+			clockInId: ids.correctionIn,
+			clockOutId: null,
+			endTime: null,
+			durationMinutes: null,
+		});
+	});
+
+	it("does not extend the missing-canonical exception to rejection", async () => {
+		const correction = {
+			action: "edit" as const,
+			clockInCorrectionId: ids.correctionIn,
+			workLocationType: "office" as const,
+			workCategoryId: terminalPeriod.workCategoryId,
+		};
+		const { dbService, mutations } = createFinalizerDb({
+			period: {
+				...terminalPeriod,
+				clockOutId: null,
+				canonicalRecordId: null,
+				endTime: null,
+				durationMinutes: null,
+				isActive: true,
+			},
+			entries: [originalIn, correctionIn],
+			canonical: null,
+			canonicalWork: null,
+			legacyRequest: null,
+			workflow: {
+				...canonicalWorkflow,
+				status: "rejected",
+				contextSnapshot: {
+					timeCorrection: correction,
+					timeCorrectionOriginalWorkMetadata: {
+						workLocationType: "office",
+						workCategoryId: terminalPeriod.workCategoryId,
+					},
+				},
+			},
+		});
+
+		await expect(
+			finalizeTimeCorrectionTerminalInTransaction(
+				approveInput(dbService, {
+					legacyApprovalRequestId: null,
+					correction,
+					transition: { kind: "reject", reason: "invalid" },
+				}),
+			),
+		).rejects.toMatchObject({
+			message: "Time correction source changed during finalization",
+			details: { reason: "missing_canonical_record" },
+		});
+		expect(mutations).toEqual([]);
+	});
+
+	it("rejects a completed period whose canonical record is missing", async () => {
+		const correction = {
+			action: "edit" as const,
+			clockInCorrectionId: ids.correctionIn,
+			workLocationType: "office" as const,
+			workCategoryId: terminalPeriod.workCategoryId,
+		};
+		const { dbService, mutations } = createFinalizerDb({
+			period: { ...terminalPeriod, canonicalRecordId: null },
+			entries: [originalIn, originalOut, correctionIn],
+			canonical: null,
+			canonicalWork: null,
+			legacyRequest: null,
+			workflow: {
+				...canonicalWorkflow,
+				contextSnapshot: {
+					timeCorrection: correction,
+					timeCorrectionOriginalWorkMetadata: {
+						workLocationType: "office",
+						workCategoryId: terminalPeriod.workCategoryId,
+					},
+				},
+			},
+		});
+
+		await expect(
+			finalizeTimeCorrectionTerminalInTransaction(
+				approveInput(dbService, {
+					legacyApprovalRequestId: null,
+					correction,
+				}),
+			),
+		).rejects.toMatchObject({
+			message: "Time correction source changed during finalization",
+			details: { reason: "missing_canonical_record" },
+		});
+		expect(mutations).toEqual([]);
+	});
+
 	it.each([
 		["category disabled", { categoryActive: false }],
 		["category moved to another organization", { categoryOrganizationId: "org-2" }],

--- a/apps/webapp/src/lib/approvals/server/time-correction-approvals.ts
+++ b/apps/webapp/src/lib/approvals/server/time-correction-approvals.ts
@@ -478,7 +478,7 @@ export interface FinalizeTimeCorrectionTerminalInput {
 	expectedApprovalWorkflowId: string | null;
 	expectedApprovalWorkflowVersion: number | null;
 	expectedRequesterEmployeeId: string;
-	expectedSource?: CancelledTimeCorrectionSourceEvidence;
+	expectedSource?: TimeCorrectionTerminalSourceEvidence;
 	expectedOriginalWorkMetadata?: TimeCorrectionOriginalWorkMetadata;
 	actorEmployeeId: string;
 	actorUserId: string;
@@ -832,6 +832,22 @@ export interface CancelledTimeCorrectionSourceEvidence {
 		clockOut: CancelledTimeCorrectionEntryEvidence | null;
 	};
 }
+
+export type TimeCorrectionTerminalSourceEvidence = Omit<
+	CancelledTimeCorrectionSourceEvidence,
+	"canonicalRecordId" | "canonicalRecord" | "canonicalWork"
+> &
+	(
+		| Pick<
+				CancelledTimeCorrectionSourceEvidence,
+				"canonicalRecordId" | "canonicalRecord" | "canonicalWork"
+		  >
+		| {
+				canonicalRecordId: null;
+				canonicalRecord: null;
+				canonicalWork: null;
+		  }
+	);
 
 function sameExpectedInstant(
 	actual: Date | null,
@@ -1965,8 +1981,7 @@ async function finalizeTimeCorrectionTerminalDetailedInTransaction(
 		expectedOriginalWorkMetadata &&
 		(normalizeWorkLocationType(period.workLocationType) !==
 			expectedOriginalWorkMetadata.workLocationType ||
-			period.workCategoryId !== expectedOriginalWorkMetadata.workCategoryId ||
-			!period.canonicalRecordId)
+			period.workCategoryId !== expectedOriginalWorkMetadata.workCategoryId)
 	) {
 		throw timeCorrectionFinalizationConflict("original_work_metadata_mismatch");
 	}
@@ -2010,6 +2025,12 @@ async function finalizeTimeCorrectionTerminalDetailedInTransaction(
 	if (period.approvalWorkflowId !== expectedApprovalWorkflowId) {
 		throw timeCorrectionFinalizationConflict("workflow_binding_mismatch");
 	}
+	const isUnmaterializedActivePeriod =
+		period.isActive &&
+		period.clockOutId === null &&
+		period.endTime === null &&
+		period.durationMinutes === null &&
+		period.canonicalRecordId === null;
 	await validatePersistedTimeCorrectionEvidence({
 		dbService: input.dbService,
 		organizationId: input.organizationId,
@@ -2300,7 +2321,9 @@ async function finalizeTimeCorrectionTerminalDetailedInTransaction(
 						canonicalWork.workCategoryId !==
 							expectedOriginalWorkMetadata.workCategoryId)) ||
 				(expectedSource !== undefined &&
-					(expectedSource.canonicalRecord.id !== canonical.id ||
+					(!expectedSource.canonicalRecord ||
+						!expectedSource.canonicalWork ||
+						expectedSource.canonicalRecord.id !== canonical.id ||
 						expectedSource.canonicalRecord.employeeId !==
 							canonical.employeeId ||
 						expectedSource.canonicalRecord.recordKind !==
@@ -2332,8 +2355,22 @@ async function finalizeTimeCorrectionTerminalDetailedInTransaction(
 				);
 			}
 		}
-	} else if (expectedApprovalWorkflowId !== null) {
-		throw timeCorrectionFinalizationConflict("missing_canonical_record");
+	} else {
+		if (
+			expectedSource &&
+			(expectedSource.canonicalRecord !== null ||
+				expectedSource.canonicalWork !== null)
+		) {
+			throw timeCorrectionFinalizationConflict(
+				"canonical_record_source_mismatch",
+			);
+		}
+		if (
+			(currentCorrection || expectedApprovalWorkflowId !== null) &&
+			(input.transition.kind !== "approve" || !isUnmaterializedActivePeriod)
+		) {
+			throw timeCorrectionFinalizationConflict("missing_canonical_record");
+		}
 	}
 	if (
 		input.transition.kind === "approve" &&


### PR DESCRIPTION
## Summary
- allow canonical approval adapters to load structurally active work periods before canonical record materialization
- permit approval finalization for that strict active shape while preserving completed-period, rejection, metadata, and source-evidence guards
- model canonical evidence as all-present or all-null and retain legacy v1 compatibility

## Verification
- pnpm test (10,323 passed, 261 skipped)
- pnpm typecheck in apps/webapp
- focused Biome checks for changed production files
- focused adapter/finalizer suites (553 passed)