### PR TITLE
fix: illuminate missing canonical conflicts

### DIFF
--- a/apps/webapp/src/lib/approvals/server/time-correction-approvals.test.ts
+++ b/apps/webapp/src/lib/approvals/server/time-correction-approvals.test.ts
@@ -29,14 +29,14 @@ const {
 	markEmployeeWorkBalanceDirty,
 	onTimeCorrectionApproved,
 	onTimeCorrectionRejected,
+	loggerWarn,
+	testEnv,
 } = vi.hoisted(() => ({
 	markEmployeeWorkBalanceDirty: vi.fn().mockResolvedValue(undefined),
 	onTimeCorrectionApproved: vi.fn(),
 	onTimeCorrectionRejected: vi.fn(),
-}));
-
-vi.mock("@/env", () => ({
-	env: {
+	loggerWarn: vi.fn(),
+	testEnv: {
 		BETTER_AUTH_SECRET: "test-secret",
 		S3_PUBLIC_BUCKET: "test-bucket",
 		S3_PUBLIC_ACCESS_KEY_ID: "test-access-key",
@@ -45,8 +45,21 @@ vi.mock("@/env", () => ({
 		S3_PUBLIC_URL: "https://example.com",
 		S3_PUBLIC_REGION: "us-east-1",
 		S3_PUBLIC_FORCE_PATH_STYLE: "true",
-		NODE_ENV: "test",
+		NODE_ENV: "test" as string,
 	},
+}));
+
+vi.mock("@/env", () => ({
+	env: testEnv,
+}));
+
+vi.mock("@/lib/logger", () => ({
+	createLogger: vi.fn(() => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: loggerWarn,
+		error: vi.fn(),
+	})),
 }));
 
 vi.mock("@/lib/notifications/triggers", () => ({
@@ -123,6 +136,8 @@ beforeEach(() => {
 	markEmployeeWorkBalanceDirty.mockClear();
 	onTimeCorrectionApproved.mockClear();
 	onTimeCorrectionRejected.mockClear();
+	loggerWarn.mockClear();
+	testEnv.NODE_ENV = "test";
 });
 
 function requiredValue<T>(value: T | undefined): T {
@@ -8257,6 +8272,7 @@ describe("finalizeTimeCorrectionTerminalInTransaction", () => {
 	});
 
 	it("rejects a completed period whose canonical record is missing", async () => {
+		testEnv.NODE_ENV = "production";
 		const correction = {
 			action: "edit" as const,
 			clockInCorrectionId: ids.correctionIn,
@@ -8292,6 +8308,26 @@ describe("finalizeTimeCorrectionTerminalInTransaction", () => {
 			message: "Time correction source changed during finalization",
 			details: { reason: "missing_canonical_record" },
 		});
+		expect(loggerWarn).toHaveBeenCalledExactlyOnceWith(
+			{
+				reason: "missing_canonical_record",
+				transitionKind: "approve",
+				workflowMode: "canonical",
+				correctionContract: "current",
+				periodShape: {
+					isActive: false,
+					hasClockOut: true,
+					hasEndTime: true,
+					hasDuration: true,
+					hasCanonicalRecord: false,
+				},
+				correctionEndpoints: {
+					hasClockIn: true,
+					hasClockOut: false,
+				},
+			},
+			"Time correction finalization conflict",
+		);
 		expect(mutations).toEqual([]);
 	});
 

--- a/apps/webapp/src/lib/approvals/server/time-correction-approvals.ts
+++ b/apps/webapp/src/lib/approvals/server/time-correction-approvals.ts
@@ -1369,9 +1369,13 @@ const TIME_CORRECTION_TIMEZONE_SOURCES = new Set([
 
 function timeCorrectionFinalizationConflict(
 	reason = "unclassified_finalization_conflict",
+	diagnostics: Record<string, unknown> = {},
 ): ConflictError {
 	if (env.NODE_ENV === "production") {
-		logger.warn({ reason }, "Time correction finalization conflict");
+		logger.warn(
+			{ reason, ...diagnostics },
+			"Time correction finalization conflict",
+		);
 	}
 	return new ConflictError({
 		message: "Time correction source changed during finalization",
@@ -2369,7 +2373,23 @@ async function finalizeTimeCorrectionTerminalDetailedInTransaction(
 			(currentCorrection || expectedApprovalWorkflowId !== null) &&
 			(input.transition.kind !== "approve" || !isUnmaterializedActivePeriod)
 		) {
-			throw timeCorrectionFinalizationConflict("missing_canonical_record");
+			throw timeCorrectionFinalizationConflict("missing_canonical_record", {
+				transitionKind: input.transition.kind,
+				workflowMode:
+					expectedApprovalWorkflowId === null ? "legacy" : "canonical",
+				correctionContract: currentCorrection ? "current" : "legacy",
+				periodShape: {
+					isActive: period.isActive,
+					hasClockOut: period.clockOutId !== null,
+					hasEndTime: period.endTime !== null,
+					hasDuration: period.durationMinutes !== null,
+					hasCanonicalRecord: period.canonicalRecordId !== null,
+				},
+				correctionEndpoints: {
+					hasClockIn: correction.clockInCorrectionId !== undefined,
+					hasClockOut: correction.clockOutCorrectionId !== undefined,
+				},
+			});
 		}
 	}
 	if (


### PR DESCRIPTION
## Changelog

- Add redacted production diagnostics for `missing_canonical_record` finalization conflicts.
- Report transition, workflow binding, correction contract, period shape, and correction endpoint presence without tenant or employee data.
- Add regression coverage for the exact structured log payload.

## Validation

- `pnpm --filter webapp exec vitest run src/lib/approvals/server/time-correction-approvals.test.ts`
- `pnpm --filter webapp typecheck`
- `pnpm --filter webapp exec biome check src/lib/approvals/server/time-correction-approvals.ts`
- `pnpm --filter webapp exec biome lint src/lib/approvals/server/time-correction-approvals.test.ts`