### PR TITLE
feat: bring audited approval cleanup to platform settings

### DIFF
--- a/apps/webapp/messages/admin/de.json
+++ b/apps/webapp/messages/admin/de.json
@@ -318,6 +318,29 @@
       "title": "Übersicht"
     },
     "settings": {
+      "approvalMaintenance": {
+        "title": "Genehmigung zwangsweise löschen",
+        "description": "Eine Genehmigung und ihre verknüpften Genehmigungsdatensätze dauerhaft entfernen. Die zugrunde liegenden Datensätze und deren Status bleiben erhalten.",
+        "organizationId": "Organisations-ID",
+        "organizationHint": "Die Organisation, zu der die Genehmigung gehört.",
+        "approvalId": "Genehmigungs-ID",
+        "approvalHint": "Die UUID eines bisherigen Genehmigungsantrags oder eines kanonischen Workflows.",
+        "delete": "Löschen erzwingen",
+        "deleting": "Wird gelöscht…",
+        "success": "Genehmigung gelöscht. Entfernte Datensätze:",
+        "legacy": "Bisheriger Antrag",
+        "workflow": "Workflow",
+        "chain": "Genehmigungskette",
+        "errors": {
+          "organizationRequired": "Gib eine Organisations-ID ein.",
+          "approvalInvalid": "Gib eine gültige Genehmigungs-UUID ein.",
+          "invalidInput": "Gib eine Organisations-ID und eine gültige Genehmigungs-UUID ein.",
+          "unauthorized": "Zugriff als Plattformadministrator erforderlich.",
+          "notFound": "In dieser Organisation wurde keine Genehmigung mit dieser ID gefunden.",
+          "ambiguous": "Diese ID existiert in beiden Genehmigungstabellen. Es wurde keine Genehmigung gelöscht.",
+          "failed": "Das Löschen konnte nicht abgeschlossen werden. Prüfe die Genehmigungs-ID, bevor du es erneut versuchst."
+        }
+      },
       "actions": {
         "saveChanges": "Änderungen speichern"
       },

--- a/apps/webapp/messages/admin/en.json
+++ b/apps/webapp/messages/admin/en.json
@@ -318,6 +318,29 @@
       "title": "Overview"
     },
     "settings": {
+      "approvalMaintenance": {
+        "title": "Force delete approval",
+        "description": "Permanently remove an approval and its linked approval records. Source records and their statuses are preserved.",
+        "organizationId": "Organization ID",
+        "organizationHint": "The organization that owns the approval.",
+        "approvalId": "Approval ID",
+        "approvalHint": "A legacy approval request or canonical workflow UUID.",
+        "delete": "Force delete",
+        "deleting": "Deleting…",
+        "success": "Approval deleted. Removed records:",
+        "legacy": "Legacy request",
+        "workflow": "Workflow",
+        "chain": "Approval chain",
+        "errors": {
+          "organizationRequired": "Enter an organization ID.",
+          "approvalInvalid": "Enter a valid approval UUID.",
+          "invalidInput": "Enter an organization ID and a valid approval UUID.",
+          "unauthorized": "Platform admin access required.",
+          "notFound": "Approval not found in this organization.",
+          "ambiguous": "This ID exists in both approval stores. No approval was deleted.",
+          "failed": "Could not complete deletion. Check the approval ID before trying again."
+        }
+      },
       "actions": {
         "saveChanges": "Save Changes"
       },

--- a/apps/webapp/scripts/approvals.ts
+++ b/apps/webapp/scripts/approvals.ts
@@ -5,7 +5,7 @@ import {
 	type ApprovalMaintenanceDatabase,
 	deleteApproval,
 	listApprovals,
-} from "./approval-maintenance";
+} from "@/lib/approvals/maintenance";
 
 const HELP = `Approval maintenance (server operator access and database credentials required)
 

--- a/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/approval-maintenance-actions.ts
+++ b/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/approval-maintenance-actions.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { z } from "zod";
+import { db } from "@/db";
+import { platformAdminAuditLog } from "@/db/schema/platform-admin";
+import {
+	ApprovalMaintenanceError,
+	type DeletedApprovalRecords,
+	deleteApprovalInTransaction,
+} from "@/lib/approvals/maintenance";
+import type { ServerActionResult } from "@/lib/effect/result";
+import { requirePlatformAdmin } from "@/lib/effect/services/platform-admin.service";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("PlatformAdminApprovalMaintenance");
+const inputSchema = z.object({
+	organizationId: z.string().trim().min(1).max(255),
+	approvalId: z.string().trim().regex(
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+	),
+});
+
+export async function forceDeleteApprovalAction(
+	input: unknown,
+): Promise<ServerActionResult<DeletedApprovalRecords>> {
+	let admin: Awaited<ReturnType<typeof requirePlatformAdmin>>;
+	try {
+		admin = await requirePlatformAdmin();
+	} catch {
+		return {
+			success: false,
+			code: "UNAUTHORIZED",
+			error: "Platform admin access required",
+		};
+	}
+
+	const parsed = inputSchema.safeParse(input);
+	if (!parsed.success) {
+		return {
+			success: false,
+			code: "INVALID_INPUT",
+			error: "Enter an organization ID and a valid approval UUID",
+		};
+	}
+	const { organizationId, approvalId } = parsed.data;
+
+	try {
+		const deleted = await db.transaction(async (transaction) => {
+			const result = await deleteApprovalInTransaction(transaction, organizationId, approvalId);
+			await transaction.insert(platformAdminAuditLog).values({
+				adminUserId: admin.userId,
+				action: "force_delete_approval",
+				targetType: "approval",
+				targetId: approvalId,
+				metadata: JSON.stringify({ organizationId, ...result }),
+			});
+			return result;
+		});
+		return { success: true, data: deleted };
+	} catch (error) {
+		if (error instanceof ApprovalMaintenanceError) {
+			return { success: false, code: error.code, error: error.message };
+		}
+		logger.error({ error, organizationId, approvalId }, "Failed to force delete approval");
+		return {
+			success: false,
+			code: "DELETE_FAILED",
+			error: "Could not complete deletion. Check the approval ID before trying again.",
+		};
+	}
+}

--- a/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/approval-maintenance-card.tsx
+++ b/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/approval-maintenance-card.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { IconLoader2, IconTrash } from "@tabler/icons-react";
+import { useForm } from "@tanstack/react-form";
+import { useTranslate } from "@tolgee/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	TFormControl,
+	TFormDescription,
+	TFormItem,
+	TFormLabel,
+	TFormMessage,
+} from "@/components/ui/tanstack-form";
+import { fieldHasError } from "@/components/ui/tanstack-form-utils";
+import type { DeletedApprovalRecords } from "@/lib/approvals/maintenance";
+import type { ServerActionResult } from "@/lib/effect/result";
+import { forceDeleteApprovalAction } from "./approval-maintenance-actions";
+
+const APPROVAL_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function deletionError(t: ReturnType<typeof useTranslate>["t"], code?: string) {
+	switch (code) {
+		case "UNAUTHORIZED":
+			return t("admin:admin.settings.approvalMaintenance.errors.unauthorized", "Platform admin access required.");
+		case "APPROVAL_NOT_FOUND":
+			return t("admin:admin.settings.approvalMaintenance.errors.notFound", "Approval not found in this organization.");
+		case "APPROVAL_AMBIGUOUS":
+			return t("admin:admin.settings.approvalMaintenance.errors.ambiguous", "This ID exists in both approval stores. No approval was deleted.");
+		case "INVALID_INPUT":
+			return t("admin:admin.settings.approvalMaintenance.errors.invalidInput", "Enter an organization ID and a valid approval UUID.");
+		default:
+			return t("admin:admin.settings.approvalMaintenance.errors.failed", "Could not complete deletion. Check the approval ID before trying again.");
+	}
+}
+
+export function ApprovalMaintenanceCard() {
+	const { t } = useTranslate();
+	const [result, setResult] = useState<ServerActionResult<DeletedApprovalRecords> | null>(null);
+	const form = useForm({
+		defaultValues: { organizationId: "", approvalId: "" },
+		onSubmit: async ({ value, formApi }) => {
+			setResult(null);
+			try {
+				const response = await forceDeleteApprovalAction(value);
+				setResult(response);
+				if (response.success) formApi.reset();
+			} catch {
+				setResult({ success: false, code: "DELETE_FAILED", error: "Deletion failed" });
+			}
+		},
+	});
+	const deletedRecords = result?.success
+		? [
+				...result.data.legacyRequests.map((id) => ({
+					id,
+					kind: "legacy",
+					label: t("admin:admin.settings.approvalMaintenance.legacy", "Legacy request"),
+				})),
+				...result.data.workflows.map((id) => ({
+					id,
+					kind: "workflow",
+					label: t("admin:admin.settings.approvalMaintenance.workflow", "Workflow"),
+				})),
+				...result.data.chains.map((id) => ({
+					id,
+					kind: "chain",
+					label: t("admin:admin.settings.approvalMaintenance.chain", "Approval chain"),
+				})),
+			]
+		: [];
+
+	return (
+		<Card className="lg:col-span-2">
+			<CardHeader>
+				<div className="flex items-start gap-3">
+					<div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+						<IconTrash className="size-5 text-muted-foreground" aria-hidden="true" />
+					</div>
+					<div className="space-y-1">
+						<CardTitle>
+							{t("admin:admin.settings.approvalMaintenance.title", "Force delete approval")}
+						</CardTitle>
+						<CardDescription>
+							{t("admin:admin.settings.approvalMaintenance.description", "Permanently remove an approval and its linked approval records. Source records and their statuses are preserved.")}
+						</CardDescription>
+					</div>
+				</div>
+			</CardHeader>
+			<form
+				noValidate
+				aria-label={t("admin:admin.settings.approvalMaintenance.title", "Force delete approval")}
+				onSubmit={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					void form.handleSubmit();
+				}}
+			>
+				<form.Subscribe selector={(state) => state.isSubmitting}>
+					{(isSubmitting) => (
+						<>
+							<CardContent className="space-y-4">
+								<fieldset disabled={isSubmitting} className="grid min-w-0 gap-4 sm:grid-cols-2">
+									<form.Field
+										name="organizationId"
+										validators={{
+											onChange: ({ value }) => value.trim()
+												? undefined
+												: t("admin:admin.settings.approvalMaintenance.errors.organizationRequired", "Enter an organization ID."),
+										}}
+									>
+										{(field) => (
+											<TFormItem>
+												<TFormLabel required hasError={fieldHasError(field)}>
+													{t("admin:admin.settings.approvalMaintenance.organizationId", "Organization ID")}
+												</TFormLabel>
+												<TFormControl hasError={fieldHasError(field)}>
+													<Input
+														name={field.name}
+														value={field.state.value}
+														onBlur={field.handleBlur}
+														onChange={(event) => {
+															setResult(null);
+															field.handleChange(event.target.value);
+														}}
+														autoComplete="off"
+														autoCapitalize="none"
+														spellCheck={false}
+														maxLength={255}
+														required
+													/>
+												</TFormControl>
+												<TFormDescription>
+													{t("admin:admin.settings.approvalMaintenance.organizationHint", "The organization that owns the approval.")}
+												</TFormDescription>
+												<TFormMessage field={field} />
+											</TFormItem>
+										)}
+									</form.Field>
+									<form.Field
+										name="approvalId"
+										validators={{
+											onChange: ({ value }) => APPROVAL_ID_PATTERN.test(value.trim())
+												? undefined
+												: t("admin:admin.settings.approvalMaintenance.errors.approvalInvalid", "Enter a valid approval UUID."),
+										}}
+									>
+										{(field) => (
+											<TFormItem>
+												<TFormLabel required hasError={fieldHasError(field)}>
+													{t("admin:admin.settings.approvalMaintenance.approvalId", "Approval ID")}
+												</TFormLabel>
+												<TFormControl hasError={fieldHasError(field)}>
+													<Input
+														name={field.name}
+														value={field.state.value}
+														onBlur={field.handleBlur}
+														onChange={(event) => {
+															setResult(null);
+															field.handleChange(event.target.value);
+														}}
+														autoComplete="off"
+														autoCapitalize="none"
+														spellCheck={false}
+														className="font-mono"
+														required
+													/>
+												</TFormControl>
+												<TFormDescription>
+													{t("admin:admin.settings.approvalMaintenance.approvalHint", "A legacy approval request or canonical workflow UUID.")}
+												</TFormDescription>
+												<TFormMessage field={field} />
+											</TFormItem>
+										)}
+									</form.Field>
+								</fieldset>
+								{result && !result.success && (
+									<p role="alert" className="text-sm text-destructive">
+										{deletionError(t, result.code)}
+									</p>
+								)}
+								{result?.success && (
+									<div role="status" className="space-y-3 rounded-lg border bg-muted/30 p-4">
+										<p className="text-sm font-medium">
+											{t("admin:admin.settings.approvalMaintenance.success", "Approval deleted. Removed records:")}
+										</p>
+										<ul className="max-h-64 space-y-2 overflow-auto text-sm">
+											{deletedRecords.map((record) => (
+												<li key={`${record.kind}:${record.id}`} className="flex flex-col gap-1 sm:flex-row sm:gap-3">
+													<span className="text-muted-foreground">{record.label}</span>
+													<code className="break-all text-xs" translate="no">{record.id}</code>
+												</li>
+											))}
+										</ul>
+									</div>
+								)}
+							</CardContent>
+							<CardFooter className="border-t bg-muted/30 px-6 py-4">
+								<Button type="submit" variant="destructive" disabled={isSubmitting}>
+									{isSubmitting && <IconLoader2 className="mr-2 size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />}
+									{isSubmitting
+										? t("admin:admin.settings.approvalMaintenance.deleting", "Deleting…")
+										: t("admin:admin.settings.approvalMaintenance.delete", "Force delete")}
+								</Button>
+							</CardFooter>
+						</>
+					)}
+				</form.Subscribe>
+			</form>
+		</Card>
+	);
+}

--- a/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/page.tsx
+++ b/apps/webapp/src/app/[locale]/(admin)/platform-admin/settings/page.tsx
@@ -17,6 +17,7 @@ import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { getCookieConsentScriptAction, setCookieConsentScriptAction } from "./actions";
+import { ApprovalMaintenanceCard } from "./approval-maintenance-card";
 
 export default function PlatformSettingsPage() {
 	const { t } = useTranslate();
@@ -74,6 +75,7 @@ export default function PlatformSettingsPage() {
 
 			{/* Settings Grid */}
 			<div className="grid gap-6 lg:grid-cols-2">
+				<ApprovalMaintenanceCard />
 				{/* Cookie Consent Script */}
 				<Card className="lg:col-span-2">
 					<CardHeader>

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.test.ts
@@ -4118,7 +4118,7 @@ db.delete(approvalOutbox);`,
 
 	it("exports the complete exact canonical owner map", () => {
 		expect(CANONICAL_WRITE_OWNERS).toEqual({
-			"scripts/approval-maintenance.ts": {
+			"src/lib/approvals/maintenance.ts": {
 				approval_chain_instance: ["delete"],
 				approval_request: ["delete"],
 				approval_workflow: ["delete"],
@@ -4197,7 +4197,7 @@ db.delete(approvalOutbox);`,
 			SOURCE_WRITE_EXCEPTIONS: unknown;
 		};
 		expect(boundary.CANONICAL_SOURCE_WRITE_OWNERS).toEqual({
-			"scripts/approval-maintenance.ts": [
+			"src/lib/approvals/maintenance.ts": [
 				{
 					columns: ["approval_workflow_id"],
 					functionName: "clearWorkflowSourceReferences",

--- a/apps/webapp/src/lib/approvals/approval-write-boundary.ts
+++ b/apps/webapp/src/lib/approvals/approval-write-boundary.ts
@@ -60,8 +60,8 @@ type CanonicalApprovalSourceWriteOwners = Readonly<
 >;
 
 export const CANONICAL_WRITE_OWNERS = {
-	// Server-operator CLI only: permanently remove an explicitly selected approval lifecycle.
-	"scripts/approval-maintenance.ts": {
+	// Shared by the operator CLI and authenticated platform-admin maintenance action.
+	"src/lib/approvals/maintenance.ts": {
 		approval_chain_instance: ["delete"],
 		approval_request: ["delete"],
 		approval_workflow: ["delete"],
@@ -136,7 +136,7 @@ export const TEMPORARY_LEGACY_WRITE_EXCEPTIONS = {
 } as const satisfies ApprovalWriteOwners;
 
 export const CANONICAL_SOURCE_WRITE_OWNERS = {
-	"scripts/approval-maintenance.ts": [
+	"src/lib/approvals/maintenance.ts": [
 		{
 			columns: ["approval_workflow_id"],
 			functionName: "clearWorkflowSourceReferences",

--- a/apps/webapp/src/lib/approvals/maintenance.ts
+++ b/apps/webapp/src/lib/approvals/maintenance.ts
@@ -7,6 +7,16 @@ export interface ApprovalMaintenanceDatabase extends ApprovalTransactionClient {
 	): Promise<T>;
 }
 
+export class ApprovalMaintenanceError extends Error {
+	constructor(
+		readonly code: "APPROVAL_NOT_FOUND" | "APPROVAL_AMBIGUOUS",
+		message: string,
+	) {
+		super(message);
+		this.name = "ApprovalMaintenanceError";
+	}
+}
+
 function rows(result: unknown): Record<string, unknown>[] {
 	if (
 		!result ||
@@ -132,75 +142,91 @@ export async function deleteApproval(
 	organizationId: string,
 	id: string,
 ): Promise<DeletedApprovalRecords> {
-	return database.transaction(async (transaction) => {
-		// Operator-only, short-lived topology lock: do not race submissions or stage linking.
-		// Keep FK checks enabled so an unexpected dependency rolls everything back.
-		await transaction.execute(sql`set local lock_timeout = '10s'`);
-		await transaction.execute(sql`set local statement_timeout = '30s'`);
-		await transaction.execute(sql`
-			lock table approval_request, approval_chain_instance, approval_chain_stage_instance,
-				approval_workflow, approval_workflow_stage in share row exclusive mode
-		`);
+	return database.transaction((transaction) =>
+		deleteApprovalInTransaction(transaction, organizationId, id),
+	);
+}
 
-		const matches = rows(
-			await transaction.execute(sql`
+// The caller owns the transaction so platform-admin audit logging can be atomic
+// with deletion. Authorization is enforced at the CLI/server-action boundary.
+export async function deleteApprovalInTransaction(
+	transaction: ApprovalTransactionClient,
+	organizationId: string,
+	id: string,
+): Promise<DeletedApprovalRecords> {
+	// Privileged maintenance only: do not race submissions or stage linking.
+	// Keep FK checks enabled so an unexpected dependency rolls everything back.
+	await transaction.execute(sql`set local lock_timeout = '10s'`);
+	await transaction.execute(sql`set local statement_timeout = '30s'`);
+	await transaction.execute(sql`
+		lock table approval_request, approval_chain_instance, approval_chain_stage_instance,
+			approval_workflow, approval_workflow_stage in share row exclusive mode
+	`);
+
+	const matches = rows(
+		await transaction.execute(sql`
 			select 'legacy' as storage_type, id from approval_request
 			where organization_id = ${organizationId} and id = ${id}::uuid
 			union all
 			select 'workflow' as storage_type, id from approval_workflow
 			where organization_id = ${organizationId} and id = ${id}::uuid
-			`),
+		`),
+	);
+	if (matches.length === 0) {
+		throw new ApprovalMaintenanceError(
+			"APPROVAL_NOT_FOUND",
+			`Approval ${id} not found in organization ${organizationId}`,
 		);
-		if (matches.length === 0) {
-			throw new Error(`Approval ${id} not found in organization ${organizationId}`);
-		}
-		if (matches.length !== 1) {
-			throw new Error(`Approval ${id} is ambiguous: it exists in both approval stores`);
-		}
-		const kind = matches[0].storage_type;
-		if (kind !== "legacy" && kind !== "workflow") {
-			throw new Error("Unexpected approval storage type");
-		}
+	}
+	if (matches.length !== 1) {
+		throw new ApprovalMaintenanceError(
+			"APPROVAL_AMBIGUOUS",
+			`Approval ${id} is ambiguous: it exists in both approval stores`,
+		);
+	}
+	const kind = matches[0].storage_type;
+	if (kind !== "legacy" && kind !== "workflow") {
+		throw new Error("Unexpected approval storage type");
+	}
 
-		const lifecycle = await resolveLifecycle(transaction, organizationId, kind, id);
-		const idsFor = (type: string) => lifecycle.filter((row) => row.kind === type).map(rowId);
-		const legacyIds = idsFor("legacy");
-		const workflowIds = idsFor("workflow");
-		const chainIds = idsFor("chain");
+	const lifecycle = await resolveLifecycle(transaction, organizationId, kind, id);
+	const idsFor = (type: string) => lifecycle.filter((row) => row.kind === type).map(rowId);
+	const legacyIds = idsFor("legacy");
+	const workflowIds = idsFor("workflow");
+	const chainIds = idsFor("chain");
 
-		await clearWorkflowSourceReferences(transaction, organizationId, workflowIds);
-		if (legacyIds.length > 0) {
-			await transaction.execute(sql`
-				update work_period set deletion_approval_request_id = null
-				where organization_id = ${organizationId}
-					and deletion_approval_request_id = any(${sql.param(legacyIds)}::uuid[])
-			`);
-		}
+	await clearWorkflowSourceReferences(transaction, organizationId, workflowIds);
+	if (legacyIds.length > 0) {
+		await transaction.execute(sql`
+			update work_period set deletion_approval_request_id = null
+			where organization_id = ${organizationId}
+				and deletion_approval_request_id = any(${sql.param(legacyIds)}::uuid[])
+		`);
+	}
 
-		const deletedIds = async (query: SQL) => rows(await transaction.execute(query)).map(rowId);
-		// Chains cascade to their stages, removing the non-cascading legacy request FK.
-		const chains = chainIds.length === 0 ? [] : await deletedIds(sql`
+	const deletedIds = async (query: SQL) => rows(await transaction.execute(query)).map(rowId);
+	// Chains cascade to their stages, removing the non-cascading legacy request FK.
+	const chains = chainIds.length === 0 ? [] : await deletedIds(sql`
 			delete from approval_chain_instance
 			where organization_id = ${organizationId} and id = any(${sql.param(chainIds)}::uuid[])
 			returning id
 		`);
-		const legacyRequests = legacyIds.length === 0 ? [] : await deletedIds(sql`
+	const legacyRequests = legacyIds.length === 0 ? [] : await deletedIds(sql`
 			delete from approval_request
 			where organization_id = ${organizationId} and id = any(${sql.param(legacyIds)}::uuid[])
 			returning id
 		`);
-		// Workflow FKs cascade through stages, assignments, events, commands, projections,
-		// outbox/deliveries and migration issues. No decision handlers are invoked.
-		const workflows = workflowIds.length === 0 ? [] : await deletedIds(sql`
+	// Workflow FKs cascade through stages, assignments, events, commands, projections,
+	// outbox/deliveries and migration issues. No decision handlers are invoked.
+	const workflows = workflowIds.length === 0 ? [] : await deletedIds(sql`
 			delete from approval_workflow
 			where organization_id = ${organizationId} and id = any(${sql.param(workflowIds)}::uuid[])
 			returning id
 		`);
 
-		return {
-			legacyRequests: legacyRequests.sort(),
-			workflows: workflows.sort(),
-			chains: chains.sort(),
-		};
-	});
+	return {
+		legacyRequests: legacyRequests.sort(),
+		workflows: workflows.sort(),
+		chains: chains.sort(),
+	};
 }

--- a/apps/webapp/src/lib/approvals/maintenance.ts
+++ b/apps/webapp/src/lib/approvals/maintenance.ts
@@ -190,10 +190,22 @@ export async function deleteApprovalInTransaction(
 	}
 
 	const lifecycle = await resolveLifecycle(transaction, organizationId, kind, id);
-	const idsFor = (type: string) => lifecycle.filter((row) => row.kind === type).map(rowId);
-	const legacyIds = idsFor("legacy");
-	const workflowIds = idsFor("workflow");
-	const chainIds = idsFor("chain");
+	const legacyIds: string[] = [];
+	const workflowIds: string[] = [];
+	const chainIds: string[] = [];
+	for (const row of lifecycle) {
+		switch (row.kind) {
+			case "legacy":
+				legacyIds.push(rowId(row));
+				break;
+			case "workflow":
+				workflowIds.push(rowId(row));
+				break;
+			case "chain":
+				chainIds.push(rowId(row));
+				break;
+		}
+	}
 
 	await clearWorkflowSourceReferences(transaction, organizationId, workflowIds);
 	if (legacyIds.length > 0) {

--- a/apps/webapp/src/lib/cron/escalation-worker-imports.test.ts
+++ b/apps/webapp/src/lib/cron/escalation-worker-imports.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Workers use plain Node, where server-only throws rather than using the
+// no-op alias configured for the webapp's other tests.
+vi.mock("server-only", () => {
+	throw new Error(
+		"This module cannot be imported from a Client Component module. It should only be used from a Server Component.",
+	);
+});
+
+// Importing a processor must not require a live database connection.
+vi.mock("@/db", () => ({ db: {} }));
+
+describe("escalation worker imports", () => {
+	it.each([
+		[
+			"Slack",
+			() => import("@/lib/slack/jobs/escalation-checker"),
+			"runSlackEscalationCheckerJob",
+		],
+		[
+			"Discord",
+			() => import("@/lib/discord/jobs/escalation-checker"),
+			"runDiscordEscalationCheckerJob",
+		],
+		[
+			"Telegram",
+			() => import("@/lib/telegram/jobs/escalation-checker"),
+			"runTelegramEscalationCheckerJob",
+		],
+		[
+			"Teams",
+			() => import("@/lib/teams/jobs/escalation-checker"),
+			"runEscalationCheckerJob",
+		],
+	] as const)(
+		"loads the %s processor in a plain Node worker",
+		async (_platform, load, exportName) => {
+			await expect(load()).resolves.toHaveProperty(
+				exportName,
+				expect.any(Function),
+			);
+		},
+	);
+});

--- a/apps/webapp/src/lib/discord/approval-handler.ts
+++ b/apps/webapp/src/lib/discord/approval-handler.ts
@@ -8,11 +8,6 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { approvalRequest, discordApprovalMessage, employee } from "@/db/schema";
-import {
-	canAttemptBotApprovalDecision,
-	decideBotApproval,
-	loadBotApprovalDecisionTarget,
-} from "@/lib/bot-platform/approval-decision";
 import { createLogger } from "@/lib/logger";
 import { createInteractionResponse, sendMessage } from "./api";
 import { getChannelIdForUser } from "./conversation-manager";
@@ -75,6 +70,12 @@ export async function handleApprovalButtonClick(
 			);
 			return;
 		}
+		// Keep Next.js-only decision dependencies out of escalation worker imports.
+		const {
+			canAttemptBotApprovalDecision,
+			decideBotApproval,
+			loadBotApprovalDecisionTarget,
+		} = await import("@/lib/bot-platform/approval-decision");
 		const decisionTarget = await loadBotApprovalDecisionTarget({
 			approvalId,
 			organizationId: bot.organizationId,

--- a/apps/webapp/src/lib/slack/approval-handler.ts
+++ b/apps/webapp/src/lib/slack/approval-handler.ts
@@ -8,11 +8,6 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { approvalRequest, employee, slackApprovalMessage } from "@/db/schema";
-import {
-	canAttemptBotApprovalDecision,
-	decideBotApproval,
-	loadBotApprovalDecisionTarget,
-} from "@/lib/bot-platform/approval-decision";
 import { createLogger } from "@/lib/logger";
 import { openConversation, postMessage, updateMessage } from "./api";
 import { getChannelIdForUser } from "./conversation-manager";
@@ -61,6 +56,12 @@ export async function handleApprovalAction(
 			logger.warn({ approvalId }, "Approval not found");
 			return;
 		}
+		// Keep Next.js-only decision dependencies out of escalation worker imports.
+		const {
+			canAttemptBotApprovalDecision,
+			decideBotApproval,
+			loadBotApprovalDecisionTarget,
+		} = await import("@/lib/bot-platform/approval-decision");
 		const decisionTarget = await loadBotApprovalDecisionTarget({
 			approvalId,
 			organizationId: bot.organizationId,

--- a/apps/webapp/src/lib/teams/approval-handler.ts
+++ b/apps/webapp/src/lib/teams/approval-handler.ts
@@ -14,11 +14,6 @@ import {
 	teamsApprovalCard,
 	timeEntry,
 } from "@/db/schema";
-import {
-	canAttemptBotApprovalDecision,
-	decideBotApproval,
-	loadBotApprovalDecisionTarget,
-} from "@/lib/bot-platform/approval-decision";
 import { getBotTranslate, getUserLocale } from "@/lib/bot-platform/i18n";
 import { createLogger } from "@/lib/logger";
 import { updateMessage } from "./bot-adapter";
@@ -61,6 +56,12 @@ export async function handleApprovalAction(
 		if (!approval) {
 			throw new TeamsError("Approval not found", "APPROVAL_NOT_FOUND");
 		}
+		// Keep Next.js-only decision dependencies out of escalation worker imports.
+		const {
+			canAttemptBotApprovalDecision,
+			decideBotApproval,
+			loadBotApprovalDecisionTarget,
+		} = await import("@/lib/bot-platform/approval-decision");
 		const decisionTarget = await loadBotApprovalDecisionTarget({
 			approvalId,
 			organizationId: tenant.organizationId,

--- a/apps/webapp/src/lib/telegram/approval-handler.ts
+++ b/apps/webapp/src/lib/telegram/approval-handler.ts
@@ -12,11 +12,6 @@ import {
 	employee,
 	telegramApprovalMessage,
 } from "@/db/schema";
-import {
-	canAttemptBotApprovalDecision,
-	decideBotApproval,
-	loadBotApprovalDecisionTarget,
-} from "@/lib/bot-platform/approval-decision";
 import { getBotTranslate, getUserLocale } from "@/lib/bot-platform/i18n";
 import { createLogger } from "@/lib/logger";
 import { resolveRecipientDisplayContext } from "@/lib/notifications/recipient-display-context";
@@ -72,6 +67,12 @@ export async function handleApprovalCallback(
 			logger.warn({ approvalId }, "Approval not found");
 			return;
 		}
+		// Keep Next.js-only decision dependencies out of escalation worker imports.
+		const {
+			canAttemptBotApprovalDecision,
+			decideBotApproval,
+			loadBotApprovalDecisionTarget,
+		} = await import("@/lib/bot-platform/approval-decision");
 		const decisionTarget = await loadBotApprovalDecisionTarget({
 			approvalId,
 			organizationId: bot.organizationId,

--- a/docs/refs/approval-maintenance.md
+++ b/docs/refs/approval-maintenance.md
@@ -1,6 +1,14 @@
-# Approval Maintenance CLI
+# Approval Maintenance
 
 Server operators can list approvals and permanently remove a broken approval lifecycle using package scripts. Run these from the repository root with the target environment's usual Phase-provided configuration.
+
+## Platform-admin settings
+
+Platform administrators can also use **Platform Admin → Settings → Force delete approval**. Enter the organization ID and approval ID, then select **Force delete**. The card displays the approval and chain IDs removed, or an error if deletion cannot be completed.
+
+The server action checks the authenticated user's platform-admin role and banned status on every request. Organization-admin access alone does not authorize this operation. Deletion and a `force_delete_approval` platform-admin audit entry are committed in the same transaction; an audit-write failure rolls back deletion. The audit entry records the acting admin, organization, requested approval ID, and removed request/workflow/chain IDs.
+
+The UI and CLI share the cleanup implementation in `apps/webapp/src/lib/approvals/maintenance.ts` and use the deletion scope below.
 
 ## Commands
 

--- a/docs/superpowers/plans/2026-09-10-platform-admin-approval-deletion.md
+++ b/docs/superpowers/plans/2026-09-10-platform-admin-approval-deletion.md
@@ -1,0 +1,15 @@
+# Platform-admin approval deletion implementation plan
+
+**Goal:** Expose approval force deletion by organization and approval ID to authenticated platform administrators.
+
+**Architecture:** Share maintenance SQL between the CLI and a guarded server action, with atomic admin auditing. Render a focused TanStack Form card on the existing settings page.
+
+## Tasks
+
+- [x] Move `scripts/approval-maintenance.ts` to `src/lib/approvals/maintenance.ts`; preserve the CLI transaction wrapper and expose `deleteApprovalInTransaction`.
+- [x] Update the CLI import, exact approval write-owner maps, and their existing expectations.
+- [x] Add `settings/approval-maintenance-actions.ts`, enforcing `requirePlatformAdmin`, validating organization/approval IDs, and recording deleted IDs in an audit entry within the cleanup transaction.
+- [x] Add `settings/approval-maintenance-card.tsx` using TanStack Form, shared accessibility primitives, pending-state controls, localized errors, and a removed-ID summary.
+- [x] Mount the card on the settings page and add English/German catalog entries.
+- [x] Update `docs/refs/approval-maintenance.md` with the platform-admin workflow and audit semantics.
+- [x] Review the diff and source changes without running tests or database operations, as requested.

--- a/docs/superpowers/specs/2026-09-10-platform-admin-approval-deletion-design.md
+++ b/docs/superpowers/specs/2026-09-10-platform-admin-approval-deletion-design.md
@@ -1,0 +1,19 @@
+# Platform-admin approval deletion
+
+## Approved design
+
+Add a Force delete approval card to Platform Admin → Settings. It accepts organization ID and approval ID and invokes the same transactional lifecycle cleanup as the maintenance CLI. Show a pending state, field validation, localized errors, and a durable success summary of removed request/workflow/chain IDs.
+
+Use TanStack Form and existing accessible form/card components. Follow the existing settings typography, spacing, and neutral surfaces, with a destructive submit button. Support English and German catalogs with statically extractable fallback text for other locales.
+
+## Server boundary
+
+The server action calls the existing `requirePlatformAdmin` before validating input or accessing tenant records. Revalidate both fields on the server. The cleanup continues to scope every query and mutation to the supplied organization, supports both approval stores, and preserves source records and statuses.
+
+Move the cleanup module from `scripts` into `src/lib/approvals/maintenance.ts`. Expose an in-transaction entry point and retain the transaction-owning wrapper for the CLI. The admin action owns a single transaction containing cleanup and insertion into `platform_admin_audit_log`, with authenticated actor ID, target approval ID, organization ID, and deleted IDs. Audit failure rolls back cleanup. Return safe error codes rather than raw database errors.
+
+Update the approval write-owner map and its existing expectations to the shared module path. Do not broaden the allowed operations.
+
+## Verification scope
+
+The user explicitly requested no tests or database operations. Review the implementation and diff only; do not run unit tests, browser checks, builds, or database-backed commands. Do not commit or push this extension without a new request.


### PR DESCRIPTION
## Changelog

### Added
- Platform-admin settings card to force-delete an approval by organization ID and approval UUID.
- Server-side platform-admin authorization, input validation, and atomic audit logging alongside deletion.
- English and German labels, localized errors, pending states, and a summary of deleted record IDs.

### Refactored
- Shared approval maintenance logic between the operator CLI and platform-admin server action.
- Updated approval write-boundary ownership and existing test expectations for the shared module.
- Preserved organization-scoped lifecycle cleanup and source records and statuses.

### Documentation
- Documented the platform-admin workflow, audit semantics, approved design, and implementation plan.

## Verification
- Reviewed all three commits and the complete diff against main.
- `git diff --check` passed; working tree clean after committing.
- Local tests, builds, browser checks, and database operations were not run, per the saved implementation verification scope.
- GitHub checks must succeed before merge.