### PR TITLE
refactor: migrate Telegram to shared bot approval attempts (#243)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ Employee time tracking and workforce management SaaS.
 
 - Treat concurrent work as normal. Never revert, overwrite, discard, or clean up changes you did not make unless explicitly asked.
 - Use **pnpm** only.
+- Before starting work on a ticket, claim it in GitHub by assigning it to the current user (`gh issue edit <number> --add-assignee @me`) and commenting that work has started. Verify the assignment so active work and ownership are visible; coordinate with any existing assignee before taking over.
+- `dev` is a staging branch. Before implementing a ticket, create and switch to a dedicated feature branch (for example, `feature/241-bot-approval-attempts`) and commit the ticket's work there.
+- After confirming the ticket's PR is merged into `dev`, switch back to `dev` locally and delete the completed feature branch from both `origin` and the local repository.
 - Keep all tenant data organization-scoped. Always filter by `organizationId` and enforce org-level permissions.
 - Use Temporal for new or migrated date/time business logic with explicit zones. Native `Date` is only for external and database boundaries; Luxon (`DateTime`) is legacy/unmigrated code only.
 - Use `@tanstack/react-form` for forms. Migrate legacy `react-hook-form` when modifying existing forms.
@@ -42,3 +45,20 @@ These references keep this file concise; open them when deeper implementation de
 - [i18n](docs/refs/i18n.md) - Tolgee namespaces and translation workflow.
 - [Date/Time](docs/refs/dates.md) - Temporal, timezone, and date-boundary rules.
 - [Billing & Stripe](docs/refs/billing-stripe.md) - Stripe setup, webhooks, per-seat billing.
+
+## Agent skills
+
+### Issue tracker
+
+Track issues and specs in GitHub Issues for `Umami-Creative-GmbH/z8`.
+Before tracker operations, read `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the five default triage labels.
+Before triaging, read `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Use a multi-context layout rooted at `CONTEXT-MAP.md`.
+Before domain exploration, read `docs/agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ These references keep this file concise; open them when deeper implementation de
 
 ## Agent skills
 
+### Workflow selection
+
+- Default to the Matt Pocock skill flow for ticket work; use `ask-matt` when unsure which Pocock skill applies.
+- If the user explicitly requests Obra Superpowers or one of its skills (for example, `brainstorming`), follow the Superpowers flow for that task, including ticket work. Explicit user workflow selection overrides the ticket-work default.
+- Keep the two flows separate: use only the selected flow's process skills unless the user explicitly switches workflows. In the Pocock flow, do not invoke any Obra Superpowers skills, including `using-superpowers`, `brainstorming`, `writing-plans`, `test-driven-development`, or `subagent-driven-development`. In the Superpowers flow, do not automatically invoke Pocock process skills.
+- This workflow selection takes precedence over skill-level instructions to automatically load or combine the two flows.
+
 ### Issue tracker
 
 Track issues and specs in GitHub Issues for `Umami-Creative-GmbH/z8`.

--- a/apps/webapp/src/lib/telegram/approval-handler.test.ts
+++ b/apps/webapp/src/lib/telegram/approval-handler.test.ts
@@ -1,227 +1,926 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConflictError } from "@/lib/effect/errors";
+import type { ResolvedTelegramBot, TelegramCallbackQuery } from "./types";
 
-const {
-	approvalFindFirstMock,
-	employeeFindFirstMock,
-	getChatIdForUserMock,
-	sendMessageMock,
-	decideBotApprovalMock,
-	loadBotApprovalDecisionTargetMock,
-	resolveTelegramUserMock,
-	getBotTranslateMock,
-	getUserLocaleMock,
-} = vi.hoisted(() => ({
-	approvalFindFirstMock: vi.fn(),
-	employeeFindFirstMock: vi.fn(),
-	getChatIdForUserMock: vi.fn(),
-	sendMessageMock: vi.fn(),
-	decideBotApprovalMock: vi.fn(),
-	loadBotApprovalDecisionTargetMock: vi.fn(),
-	resolveTelegramUserMock: vi.fn(),
-	getBotTranslateMock: vi.fn(),
-	getUserLocaleMock: vi.fn(),
+const effects = vi.hoisted(() => ({
+	approvalFindFirst: vi.fn(),
+	periodFindFirst: vi.fn(),
+	assignmentFindFirst: vi.fn(),
+	execute: vi.fn(),
+	employeeFindFirst: vi.fn(),
+	absenceFindFirst: vi.fn(),
+	messageFindFirst: vi.fn(),
+	trackResponse: vi.fn(),
+	persistDecision: vi.fn(),
+	resolveUser: vi.fn(),
+	resolveDisplay: vi.fn(),
+	getLocale: vi.fn(),
+	getTranslate: vi.fn(),
+	editMessage: vi.fn(),
+	sendMessage: vi.fn(),
+	getChat: vi.fn(),
+	acknowledge: vi.fn(),
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock("@/db", () => ({
 	db: {
 		query: {
-			approvalRequest: { findFirst: approvalFindFirstMock },
-			employee: { findFirst: employeeFindFirstMock },
+			approvalRequest: { findFirst: effects.approvalFindFirst },
+			workPeriod: { findFirst: effects.periodFindFirst },
+			timeEntry: { findMany: vi.fn(async () => []) },
+			approvalStageAssignment: { findFirst: effects.assignmentFindFirst },
+			employee: { findFirst: effects.employeeFindFirst },
+			absenceEntry: { findFirst: effects.absenceFindFirst },
+			telegramApprovalMessage: { findFirst: effects.messageFindFirst },
 		},
-		insert: vi.fn(),
+		execute: effects.execute,
+		update: () => ({
+			set: (values: unknown) => ({
+				where: (where: SQL) => effects.trackResponse(values, where),
+			}),
+		}),
 	},
 }));
 
-vi.mock("@/db/schema", () => ({
-	approvalRequest: {
-		id: "approvalRequest.id",
-		organizationId: "approvalRequest.organizationId",
-	},
-	employee: {
-		id: "employee.id",
-		organizationId: "employee.organizationId",
-		userId: "employee.userId",
-	},
-	telegramApprovalMessage: {},
-}));
-
-vi.mock("@/lib/logger", () => ({
-	createLogger: () => ({
-		debug: vi.fn(),
-		error: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-	}),
-}));
+// Same seam as Slack: real bot attempt, inbox discovery/eligibility/authorization,
+// registry lookup and Effect dispatch. Only the registered domain effect is
+// controlled; the ordinary owner tests verify exact replay/conflict persistence.
+vi.mock("@/lib/approvals/init", async () => {
+	const { registerApprovalHandler } = await import(
+		"@/lib/approvals/domain/registry"
+	);
+	const { TimeCorrectionHandler } = await import(
+		"@/lib/approvals/handlers/time-correction.handler"
+	);
+	const { Effect } = await import("effect");
+	registerApprovalHandler({
+		...TimeCorrectionHandler,
+		approve: (entityId, actorEmployeeId, options) =>
+			Effect.promise(() =>
+				effects.persistDecision({
+					entityId,
+					actorEmployeeId,
+					action: "approve",
+					options,
+				}),
+			),
+		reject: (entityId, actorEmployeeId, reason, options) =>
+			Effect.promise(() =>
+				effects.persistDecision({
+					entityId,
+					actorEmployeeId,
+					action: "reject",
+					reason,
+					options,
+				}),
+			),
+	});
+	return {};
+});
+vi.mock("@/lib/effect/runtime", async () => {
+	const { Effect } = await import("effect");
+	return { runtime: { runPromiseExit: Effect.runPromiseExit } };
+});
+vi.mock("@/lib/logger", () => ({ createLogger: () => effects.logger }));
 vi.mock("@/lib/bot-platform/i18n", () => ({
-	getBotTranslate: getBotTranslateMock,
-	getUserLocale: getUserLocaleMock,
-}));
-vi.mock("@/lib/bot-platform/approval-decision", () => ({
-	decideBotApproval: decideBotApprovalMock,
-	canAttemptBotApprovalDecision: ({
-		status,
-		workflowKind,
-	}: {
-		status: string;
-		workflowKind: string;
-	}) =>
-		status === "pending" ||
-		workflowKind === "manual_time_submission" ||
-		workflowKind === "policy_clock_out",
-	loadBotApprovalDecisionTarget: loadBotApprovalDecisionTargetMock,
+	getBotTranslate: effects.getTranslate,
+	getUserLocale: effects.getLocale,
+	setUserLocale: vi.fn(),
 }));
 vi.mock("@/lib/notifications/recipient-display-context", () => ({
-	resolveRecipientDisplayContext: vi.fn(),
-}));
-vi.mock("./api", () => ({
-	editMessageText: vi.fn(),
-	sendMessage: sendMessageMock,
-}));
-vi.mock("./conversation-manager", () => ({
-	getChatIdForUser: getChatIdForUserMock,
-}));
-vi.mock("./formatters", () => ({
-	buildApprovalMessage: vi.fn(),
-	buildResolvedApprovalMessage: vi.fn(),
-	escapeMarkdownV2: vi.fn(),
+	resolveRecipientDisplayContext: effects.resolveDisplay,
 }));
 vi.mock("./user-resolver", () => ({
-	resolveTelegramUser: resolveTelegramUserMock,
+	resolveTelegramUser: effects.resolveUser,
+	claimLinkCode: vi.fn(),
+}));
+vi.mock("./api", () => ({
+	editMessageText: effects.editMessage,
+	sendMessage: effects.sendMessage,
+	answerCallbackQuery: effects.acknowledge,
+}));
+vi.mock("./conversation-manager", () => ({
+	getChatIdForUser: effects.getChat,
+	saveConversation: vi.fn(),
+}));
+vi.mock("@/lib/bot-platform/command-registry", () => ({
+	executeCommand: vi.fn(),
+	getAllCommands: vi.fn(),
+	parseCommand: vi.fn(),
+}));
+vi.mock("@/lib/bot-platform/temporal-context", () => ({
+	resolveBotTemporalContext: vi.fn(),
 }));
 
-describe("sendApprovalMessageToManager", () => {
-	beforeEach(() => vi.clearAllMocks());
+import {
+	handleApprovalCallback,
+	sendApprovalMessageToManager,
+} from "./approval-handler";
+import { handleTelegramUpdate } from "./bot-handler";
 
-	it("does not send when the approver is outside the approval organization", async () => {
-		employeeFindFirstMock.mockResolvedValue(undefined);
-		const { sendApprovalMessageToManager } = await import("./approval-handler");
+const bot: ResolvedTelegramBot = {
+	organizationId: "org-1",
+	botToken: "token",
+	botUsername: "z8bot",
+	webhookSecret: "webhook-secret",
+	setupStatus: "completed",
+	enableApprovals: true,
+	enableCommands: true,
+	enableDailyDigest: false,
+	enableEscalations: false,
+	digestTime: "09:00",
+	digestTimezone: "UTC",
+	escalationTimeoutHours: 24,
+};
+const query: TelegramCallbackQuery = {
+	id: "query-1",
+	from: { id: 1, is_bot: false, first_name: "Morgan" },
+	message: {
+		chat: { id: 10, type: "private" },
+		message_id: 20,
+		date: 1784541600,
+	},
+	data: JSON.stringify({ a: "ap", id: "approval-1" }),
+};
 
-		await sendApprovalMessageToManager(
-			"approval-in-org-b",
-			"approver-in-org-b",
-			"org-a",
-			"token",
-		);
+function request(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "approval-1",
+		organizationId: "org-1",
+		entityType: "time_entry",
+		entityId: "period-1",
+		requestedBy: "employee-1",
+		approverId: "manager-1",
+		status: "pending",
+		metadata: { timeRequest: { kind: "manual_time_submission" } },
+		createdAt: new Date("2026-07-20T10:00:00Z"),
+		...overrides,
+	};
+}
 
-		expect(approvalFindFirstMock).not.toHaveBeenCalled();
-		expect(getChatIdForUserMock).not.toHaveBeenCalled();
-		expect(sendMessageMock).not.toHaveBeenCalled();
+function act(action: "approve" | "reject" = "approve", callback = query) {
+	return handleApprovalCallback(
+		callback,
+		{ a: action === "approve" ? "ap" : "rj", id: "approval-1" },
+		"1",
+		bot,
+	);
+}
+
+// Interpret equality predicates so omitting organization or id exposes foreign
+// rows, causing observable decision/presentation assertions to fail.
+function storedRow<T extends { id: string; organizationId: string }>(
+	table: string,
+	row: T,
+) {
+	return async ({ where }: { where: SQL }) => {
+		const query = new PgDialect().sqlToQuery(where);
+		for (const [column, value] of [
+			["id", row.id],
+			["organization_id", row.organizationId],
+		]) {
+			const parameter = query.sql.match(
+				new RegExp(`"${table}"\\."${column}" = \\$(\\d+)`),
+			);
+			if (parameter && query.params[Number(parameter[1]) - 1] !== value)
+				return undefined;
+		}
+		return row;
+	};
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	effects.resolveUser.mockResolvedValue({
+		status: "found",
+		user: {
+			employeeId: "manager-1",
+			userId: "user-1",
+			organizationId: "org-1",
+		},
 	});
+	effects.approvalFindFirst.mockImplementation(
+		storedRow("approval_request", request()),
+	);
+	effects.periodFindFirst.mockResolvedValue({
+		pendingChanges: null,
+		clockInId: null,
+		clockOutId: null,
+	});
+	effects.execute.mockResolvedValue({ rows: [] });
+	effects.employeeFindFirst.mockResolvedValue({
+		userId: "user-1",
+		user: { name: "Morgan Manager", email: "morgan@example.com" },
+	});
+	effects.messageFindFirst.mockResolvedValue({ id: "message-record-1" });
+	effects.persistDecision.mockResolvedValue(undefined);
+	effects.resolveDisplay.mockResolvedValue({
+		locale: "en",
+		timezone: "Europe/Berlin",
+		timeFormat: "24h",
+	});
+	effects.getLocale.mockResolvedValue("en");
+	effects.getTranslate.mockResolvedValue(
+		(_key: string, fallback: string) => fallback,
+	);
+});
 
-	it("does not send an approval from another organization", async () => {
-		employeeFindFirstMock.mockResolvedValue({ userId: "manager-in-org-a" });
-		approvalFindFirstMock.mockResolvedValue(undefined);
-		const { sendApprovalMessageToManager } = await import("./approval-handler");
+afterEach(() => vi.useRealTimers());
 
-		await sendApprovalMessageToManager(
-			"approval-in-org-b",
-			"approver-in-org-a",
-			"org-a",
-			"token",
+describe("Telegram approval attempts through the inbox", () => {
+	it("approves a pending request and presents and tracks the committed decision", async () => {
+		await act();
+		expect(effects.persistDecision).toHaveBeenCalledWith({
+			entityId: "period-1",
+			actorEmployeeId: "manager-1",
+			action: "approve",
+			options: { approvalRequestId: "approval-1" },
+		});
+		expect(effects.editMessage).toHaveBeenCalledWith("token", {
+			chat_id: 10,
+			message_id: 20,
+			text: expect.stringContaining("*Approved* by Morgan Manager"),
+			parse_mode: "MarkdownV2",
+		});
+		expect(effects.trackResponse).toHaveBeenCalledWith(
+			{ status: "approved", respondedAt: expect.any(Date) },
+			expect.anything(),
 		);
-
-		expect(approvalFindFirstMock).toHaveBeenCalledOnce();
-		expect(getChatIdForUserMock).not.toHaveBeenCalled();
-		expect(sendMessageMock).not.toHaveBeenCalled();
+		expect(effects.acknowledge).not.toHaveBeenCalled();
+		expect(effects.logger.error).not.toHaveBeenCalled();
 	});
 });
 
-describe("handleApprovalCallback", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		getUserLocaleMock.mockResolvedValue("en");
-		getBotTranslateMock.mockResolvedValue(
-			(_key: string, fallback: string) => fallback,
-		);
-		loadBotApprovalDecisionTargetMock.mockResolvedValue({
-			id: "approval-1",
-			organizationId: "org-1",
-			entityType: "time_entry",
+describe("Telegram approval eligibility and authority", () => {
+	it("rejects a pending request with exact Telegram attribution", async () => {
+		await act("reject");
+		expect(effects.persistDecision).toHaveBeenCalledWith({
 			entityId: "period-1",
-			approverId: "manager-1",
-			requesterEmployeeId: "employee-1",
-			status: "approved",
-			workflowKind: "manual_time_submission",
-		});
-	});
-
-	it("delegates an exact terminal time-entry target so the owner can replay", async () => {
-		resolveTelegramUserMock.mockResolvedValue({
-			status: "found",
-			user: { employeeId: "manager-1", userId: "user-1" },
-		});
-		approvalFindFirstMock.mockResolvedValue({
-			id: "approval-1",
-			organizationId: "org-1",
-			entityType: "time_entry",
-			entityId: "period-1",
-			requestedBy: "employee-1",
-			approverId: "manager-1",
-			status: "approved",
-			createdAt: new Date("2026-07-20T10:00:00Z"),
-		});
-		decideBotApprovalMock.mockResolvedValue({
-			id: "approval-1",
-			type: "time_entry",
-			status: "approved",
-		});
-		employeeFindFirstMock
-			.mockResolvedValueOnce({ user: { name: "Manager" } })
-			.mockResolvedValueOnce({
-				user: { name: "Employee", email: "employee@example.com" },
-			});
-
-		const { handleApprovalCallback } = await import("./approval-handler");
-		await handleApprovalCallback(
-			{ id: "query-1", from: { id: 1 }, message: undefined },
-			{ a: "ap", id: "approval-1" },
-			"telegram-1",
-			{ organizationId: "org-1", botToken: "token" } as never,
-		);
-
-		expect(decideBotApprovalMock).toHaveBeenCalledWith({
-			approvalId: "approval-1",
 			actorEmployeeId: "manager-1",
-			organizationId: "org-1",
-			action: "approve",
-			platform: "telegram",
+			action: "reject",
+			reason: "Rejected via Telegram",
+			options: { approvalRequestId: "approval-1" },
 		});
+		expect(effects.editMessage).toHaveBeenCalledWith(
+			"token",
+			expect.objectContaining({
+				text: expect.stringContaining("*Rejected* by Morgan Manager"),
+			}),
+		);
+		expect(effects.trackResponse).toHaveBeenCalledWith(
+			{ status: "rejected", respondedAt: expect.any(Date) },
+			expect.anything(),
+		);
 	});
 
-	it("keeps terminal time corrections already processed", async () => {
-		resolveTelegramUserMock.mockResolvedValue({
-			status: "found",
-			user: { employeeId: "manager-1", userId: "user-1" },
+	it("resolves identity before approval reads and silently exits for an unlinked actor", async () => {
+		effects.resolveUser.mockImplementation(async () => {
+			expect(effects.approvalFindFirst).not.toHaveBeenCalled();
+			return { status: "not_found" };
 		});
-		approvalFindFirstMock.mockResolvedValue({
+		await act();
+		expect(effects.resolveUser).toHaveBeenCalledWith("1", "org-1");
+		expect(effects.approvalFindFirst).not.toHaveBeenCalled();
+		expect(effects.persistDecision).not.toHaveBeenCalled();
+		expect(effects.editMessage).not.toHaveBeenCalled();
+		expect(effects.logger.warn).toHaveBeenCalledWith(
+			{ telegramUserId: "1" },
+			"Unlinked user tried to act on approval",
+		);
+	});
+
+	it("leaves identity resolution exceptions outside the attempt catch", async () => {
+		const error = new Error("Identity unavailable");
+		effects.resolveUser.mockRejectedValue(error);
+		await expect(act()).rejects.toBe(error);
+		expect(effects.approvalFindFirst).not.toHaveBeenCalled();
+		expect(effects.logger.error).not.toHaveBeenCalled();
+	});
+
+	it.each(["missing", "foreign organization", "foreign id"])(
+		"silently exits for a %s compatibility request",
+		async (scenario) => {
+			if (scenario === "missing")
+				effects.approvalFindFirst.mockResolvedValue(undefined);
+			else
+				effects.approvalFindFirst.mockImplementation(
+					storedRow(
+						"approval_request",
+						request(
+							scenario === "foreign organization"
+								? { organizationId: "org-2" }
+								: { id: "approval-2" },
+						),
+					),
+				);
+			await act();
+			expect(effects.persistDecision).not.toHaveBeenCalled();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.periodFindFirst).not.toHaveBeenCalled();
+			expect(effects.logger.warn).toHaveBeenCalledWith(
+				{ approvalId: "approval-1" },
+				"Approval not found",
+			);
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it("requires a compatibility request even when a canonical assignment exists", async () => {
+		effects.approvalFindFirst.mockResolvedValue(undefined);
+		effects.assignmentFindFirst.mockResolvedValue({
 			id: "approval-1",
 			organizationId: "org-1",
-			entityType: "time_entry",
-			entityId: "period-1",
-			requestedBy: "employee-1",
-			approverId: "manager-1",
+			workflowId: "workflow-1",
+			stageId: "stage-1",
+			approverEmployeeId: "manager-1",
 			status: "approved",
-		});
-		loadBotApprovalDecisionTargetMock.mockResolvedValue({
-			status: "approved",
-			workflowKind: "time_correction",
-		});
-		const editMessageText = vi.mocked((await import("./api")).editMessageText);
-
-		const { handleApprovalCallback } = await import("./approval-handler");
-		await handleApprovalCallback(
-			{
-				id: "query-1",
-				from: { id: 1 },
-				message: { chat: { id: 1 }, message_id: 2 },
+			workflow: {
+				id: "workflow-1",
+				organizationId: "org-1",
+				workflowType: "manual_time_submission",
+				sourceType: "time_entry",
+				sourceId: "period-1",
+				requesterEmployeeId: "employee-1",
+				status: "approved",
+				currentStageOrder: null,
 			},
-			{ a: "ap", id: "approval-1" },
-			"telegram-1",
-			{ organizationId: "org-1", botToken: "token" } as never,
+			stage: {
+				id: "stage-1",
+				organizationId: "org-1",
+				workflowId: "workflow-1",
+				sequence: 1,
+				status: "approved",
+			},
+		});
+		await act();
+		expect(effects.assignmentFindFirst).not.toHaveBeenCalled();
+		expect(effects.persistDecision).not.toHaveBeenCalled();
+		expect(effects.editMessage).not.toHaveBeenCalled();
+		expect(effects.logger.warn).toHaveBeenCalledWith(
+			{ approvalId: "approval-1" },
+			"Approval not found",
 		);
+	});
 
-		expect(editMessageText).toHaveBeenCalled();
-		expect(decideBotApprovalMock).not.toHaveBeenCalled();
+	it("silently rejects a linked employee who is not the assigned approver", async () => {
+		effects.approvalFindFirst.mockResolvedValue(
+			request({ approverId: "other-manager" }),
+		);
+		await act();
+		expect(effects.persistDecision).not.toHaveBeenCalled();
+		expect(effects.editMessage).not.toHaveBeenCalled();
+		expect(effects.logger.warn).toHaveBeenCalledWith(
+			{ approvalId: "approval-1", employeeId: "manager-1" },
+			"Unauthorized approval attempt",
+		);
+	});
+
+	it.each([
+		["approved", "manual_time_submission", "approve", "Approved"],
+		["rejected", "manual_time_submission", "reject", "Rejected"],
+		["approved", "policy_clock_out", "approve", "Approved"],
+		["rejected", "policy_clock_out", "reject", "Rejected"],
+	] as const)(
+		"presents successful %s %s replay as success",
+		async (status, kind, action, label) => {
+			effects.approvalFindFirst.mockResolvedValue(
+				request({ status, metadata: { timeRequest: { kind } } }),
+			);
+			await act(action);
+			expect(effects.persistDecision).toHaveBeenCalledOnce();
+			expect(effects.persistDecision).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action,
+					...(action === "reject" ? { reason: "Rejected via Telegram" } : {}),
+				}),
+			);
+			expect(effects.editMessage).toHaveBeenCalledWith(
+				"token",
+				expect.objectContaining({
+					text: expect.stringContaining(`*${label}* by Morgan Manager`),
+				}),
+			);
+			expect(effects.trackResponse).toHaveBeenCalledWith(
+				{ status, respondedAt: expect.any(Date) },
+				expect.anything(),
+			);
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		[
+			"approved",
+			{
+				timeCorrection: {
+					action: "edit",
+					workLocationType: "office",
+					workCategoryId: null,
+				},
+			},
+		],
+		[
+			"rejected",
+			{
+				timeCorrection: {
+					action: "edit",
+					workLocationType: "office",
+					workCategoryId: null,
+				},
+			},
+		],
+		["cancelled", { timeRequest: { kind: "manual_time_submission" } }],
+		["unknown", { timeRequest: { kind: "policy_clock_out" } }],
+		["approved", null],
+	])(
+		"keeps %s ineligible targets already processed before comparing approvers",
+		async (status, metadata) => {
+			effects.approvalFindFirst.mockResolvedValue(
+				request({ status, metadata, approverId: "other-manager" }),
+			);
+			effects.getLocale.mockResolvedValue("de");
+			effects.getTranslate.mockResolvedValue(() => "Bereits [bearbeitet]!");
+			await act();
+			expect(effects.getLocale).toHaveBeenCalledWith("user-1");
+			expect(effects.getTranslate).toHaveBeenCalledWith("de");
+			expect(effects.editMessage).toHaveBeenCalledWith("token", {
+				chat_id: 10,
+				message_id: 20,
+				text: "Bereits \\[bearbeitet\\]\\!",
+				parse_mode: "MarkdownV2",
+			});
+			expect(effects.persistDecision).not.toHaveBeenCalled();
+			expect(effects.trackResponse).not.toHaveBeenCalled();
+			expect(effects.logger.warn).not.toHaveBeenCalled();
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it("fails closed for terminal ordinary metadata when its scoped period is missing", async () => {
+		effects.approvalFindFirst.mockResolvedValue(
+			request({ status: "approved" }),
+		);
+		effects.periodFindFirst.mockResolvedValue(undefined);
+		await act();
+		expect(effects.persistDecision).not.toHaveBeenCalled();
+		expect(effects.editMessage).toHaveBeenCalledWith(
+			"token",
+			expect.objectContaining({
+				text: "This approval has already been processed\\.",
+			}),
+		);
+	});
+
+	it("silently exits an already processed request without a message", async () => {
+		effects.approvalFindFirst.mockResolvedValue(
+			request({ status: "cancelled" }),
+		);
+		await act("approve", { ...query, message: undefined });
+		expect(effects.editMessage).not.toHaveBeenCalled();
+		expect(effects.getLocale).not.toHaveBeenCalled();
+		expect(effects.persistDecision).not.toHaveBeenCalled();
+		expect(effects.logger.error).not.toHaveBeenCalled();
+	});
+
+	it.each(["target load", "authoritative reload"])(
+		"logs later %s absence as an error rather than initial not-found",
+		async (stage) => {
+			effects.approvalFindFirst
+				.mockResolvedValue(undefined)
+				.mockResolvedValueOnce(request());
+			if (stage === "authoritative reload")
+				effects.approvalFindFirst.mockResolvedValueOnce(request());
+			await act();
+			expect(effects.persistDecision).not.toHaveBeenCalled();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.logger.warn).not.toHaveBeenCalled();
+			expect(effects.logger.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					error: expect.objectContaining({ _tag: "NotFoundError" }),
+					approvalId: "approval-1",
+					action: "approve",
+				}),
+				"Failed to process approval action",
+			);
+		},
+	);
+
+	it.each(["target load", "authoritative reload"])(
+		"preserves organization scope during %s",
+		async (stage) => {
+			effects.approvalFindFirst
+				.mockImplementation(
+					storedRow("approval_request", request({ organizationId: "org-2" })),
+				)
+				.mockResolvedValueOnce(request());
+			if (stage === "authoritative reload")
+				effects.approvalFindFirst.mockResolvedValueOnce(request());
+			await act();
+			expect(effects.persistDecision).not.toHaveBeenCalled();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.logger.error).toHaveBeenCalledWith(
+				expect.objectContaining({
+					error: expect.objectContaining({ _tag: "NotFoundError" }),
+				}),
+				"Failed to process approval action",
+			);
+		},
+	);
+
+	it.each([{ approverId: "new-manager" }, { status: "cancelled" }])(
+		"uses authoritative reload to prevent a stale decision after %j",
+		async (change) => {
+			effects.approvalFindFirst
+				.mockResolvedValue(request(change))
+				.mockResolvedValueOnce(request())
+				.mockResolvedValueOnce(request());
+			await act();
+			expect(effects.persistDecision).not.toHaveBeenCalled();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.logger.error).toHaveBeenCalledWith(
+				expect.objectContaining({ approvalId: "approval-1" }),
+				"Failed to process approval action",
+			);
+		},
+	);
+
+	it.each([
+		new Error("Decision persistence failed"),
+		new ConflictError({
+			message: "Conflicting ordinary replay",
+			conflictType: "approval_transition",
+		}),
+	])(
+		"logs and swallows domain decision failure without success presentation: %s",
+		async (error) => {
+			effects.approvalFindFirst.mockResolvedValue(
+				request({ status: "approved" }),
+			);
+			effects.persistDecision.mockRejectedValue(error);
+			await expect(act()).resolves.toBeUndefined();
+			expect(effects.persistDecision).toHaveBeenCalledOnce();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.trackResponse).not.toHaveBeenCalled();
+			expect(effects.logger.error).toHaveBeenCalledWith(
+				{ error, approvalId: "approval-1", action: "approve" },
+				"Failed to process approval action",
+			);
+		},
+	);
+});
+
+describe("Telegram post-decision presentation", () => {
+	it("uses the original request for presentation and the authoritative target for dispatch", async () => {
+		effects.approvalFindFirst
+			.mockResolvedValue(
+				request({ requestedBy: "employee-2", entityId: "period-2" }),
+			)
+			.mockResolvedValueOnce(
+				request({ entityType: "absence_entry", entityId: "absence-1" }),
+			);
+		let committed = false;
+		effects.persistDecision.mockImplementation(async () => {
+			committed = true;
+		});
+		effects.employeeFindFirst.mockImplementation(
+			async ({ where }: { where: SQL }) => {
+				expect(committed).toBe(true);
+				const { params } = new PgDialect().sqlToQuery(where);
+				return {
+					user: {
+						name: params.includes("employee-1")
+							? "Original Requester"
+							: "Refreshed Person",
+					},
+				};
+			},
+		);
+		effects.absenceFindFirst.mockImplementation(
+			storedRow("absence_entry", {
+				id: "absence-1",
+				organizationId: "org-1",
+				category: { name: "Original Leave" },
+				startDate: "2026-07-20",
+				endDate: "2026-07-21",
+			}),
+		);
+		await act();
+		expect(effects.persistDecision).toHaveBeenCalledWith(
+			expect.objectContaining({ entityId: "period-2" }),
+		);
+		expect(effects.editMessage).toHaveBeenCalledWith(
+			"token",
+			expect.objectContaining({
+				text: expect.stringContaining(
+					"From: *Original Requester*\nType: Original Leave\nPeriod: Jul 20, 2026 \\- Jul 21, 2026",
+				),
+			}),
+		);
+		expect(effects.logger.error).not.toHaveBeenCalled();
+	});
+
+	it("formats success with the recipient locale, timezone, and time preference", async () => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(new Date("2026-07-20T10:00:00Z"));
+		effects.resolveDisplay.mockResolvedValue({
+			locale: "de",
+			timezone: "Europe/Berlin",
+			timeFormat: "24h",
+		});
+		effects.getTranslate.mockResolvedValue((key: string, fallback: string) =>
+			key === "bot.approval.approved" ? "Genehmigt" : fallback,
+		);
+		await act();
+		expect(effects.resolveDisplay).toHaveBeenCalledWith({
+			userId: "user-1",
+			organizationId: "org-1",
+		});
+		expect(effects.getTranslate).toHaveBeenCalledWith("de");
+		expect(effects.editMessage).toHaveBeenCalledWith(
+			"token",
+			expect.objectContaining({
+				text: expect.stringContaining(
+					"*Genehmigt* by Morgan Manager\nat 20\\. Juli 2026, 12:00",
+				),
+			}),
+		);
+	});
+
+	it.each(["missing", "foreign"])(
+		"skips presentation and tracking for a %s approver employee",
+		async (scenario) => {
+			if (scenario === "missing")
+				effects.employeeFindFirst.mockResolvedValue(undefined);
+			else
+				effects.employeeFindFirst.mockImplementation(
+					storedRow("employee", {
+						id: "manager-1",
+						organizationId: "org-2",
+						user: { name: "Foreign Manager" },
+					}),
+				);
+			await act();
+			expect(effects.persistDecision).toHaveBeenCalledOnce();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.resolveDisplay).not.toHaveBeenCalled();
+			expect(effects.messageFindFirst).not.toHaveBeenCalled();
+			expect(effects.trackResponse).not.toHaveBeenCalled();
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["message", "requester", "display context", "foreign requester"])(
+		"still tracks success when presentation has no %s",
+		async (missing) => {
+			if (missing === "requester")
+				effects.employeeFindFirst
+					.mockResolvedValue(undefined)
+					.mockResolvedValueOnce({ user: { name: "Manager" } });
+			if (missing === "foreign requester")
+				effects.employeeFindFirst
+					.mockImplementation(
+						storedRow("employee", {
+							id: "employee-1",
+							organizationId: "org-2",
+							user: { name: "Foreign" },
+						}),
+					)
+					.mockResolvedValueOnce({ user: { name: "Manager" } });
+			if (missing === "display context")
+				effects.resolveDisplay.mockResolvedValue(null);
+			await act(
+				"approve",
+				missing === "message" ? { ...query, message: undefined } : query,
+			);
+			expect(effects.persistDecision).toHaveBeenCalledOnce();
+			expect(effects.editMessage).not.toHaveBeenCalled();
+			expect(effects.trackResponse).toHaveBeenCalledWith(
+				{ status: "approved", respondedAt: expect.any(Date) },
+				expect.anything(),
+			);
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it("omits foreign absence details from original-request presentation", async () => {
+		effects.approvalFindFirst
+			.mockResolvedValue(request())
+			.mockResolvedValueOnce(
+				request({ entityType: "absence_entry", entityId: "absence-1" }),
+			);
+		effects.absenceFindFirst.mockImplementation(
+			storedRow("absence_entry", {
+				id: "absence-1",
+				organizationId: "org-2",
+				category: { name: "Foreign Leave" },
+				startDate: "2026-07-20",
+				endDate: "2026-07-21",
+			}),
+		);
+		await act();
+		expect(effects.editMessage).toHaveBeenCalledWith(
+			"token",
+			expect.objectContaining({
+				text: expect.stringContaining("Type: Leave"),
+			}),
+		);
+		expect(effects.editMessage.mock.calls[0][1].text).not.toContain(
+			"Foreign Leave",
+		);
+		expect(effects.trackResponse).toHaveBeenCalledOnce();
+	});
+
+	it.each(["missing", "foreign"])(
+		"still presents success with a %s tracking record",
+		async (scenario) => {
+			if (scenario === "missing")
+				effects.messageFindFirst.mockResolvedValue(undefined);
+			else
+				effects.messageFindFirst.mockImplementation(
+					storedRow("telegram_approval_message", {
+						id: "message-record-1",
+						organizationId: "org-2",
+					}),
+				);
+			effects.employeeFindFirst.mockResolvedValueOnce({ user: null });
+			await act();
+			expect(effects.editMessage).toHaveBeenCalledWith(
+				"token",
+				expect.objectContaining({
+					text: expect.stringContaining("*Approved* by Unknown"),
+				}),
+			);
+			expect(effects.trackResponse).not.toHaveBeenCalled();
+			expect(effects.logger.error).not.toHaveBeenCalled();
+		},
+	);
+
+	it("scopes the response tracking write to the message and organization", async () => {
+		await act();
+		const { sql, params } = new PgDialect().sqlToQuery(
+			effects.trackResponse.mock.calls[0][1],
+		);
+		expect(sql).toContain('"telegram_approval_message"."id" = $1');
+		expect(sql).toContain('"telegram_approval_message"."organization_id" = $2');
+		expect(params).toEqual(["message-record-1", "org-1"]);
+	});
+
+	it("keeps a committed decision when delivery throws and skips tracking", async () => {
+		const committed: string[] = [];
+		effects.persistDecision.mockImplementation(
+			async ({ action }: { action: string }) => {
+				committed.push(action);
+			},
+		);
+		const error = new Error("Telegram unavailable");
+		effects.editMessage.mockImplementation(async () => {
+			expect(committed).toEqual(["approve"]);
+			throw error;
+		});
+		await expect(act()).resolves.toBeUndefined();
+		expect(committed).toEqual(["approve"]);
+		expect(effects.logger.error).toHaveBeenCalledWith(
+			{ error, approvalId: "approval-1", action: "approve" },
+			"Failed to process approval action",
+		);
+		expect(effects.messageFindFirst).not.toHaveBeenCalled();
+		expect(effects.trackResponse).not.toHaveBeenCalled();
+	});
+
+	it("still tracks the committed decision when Telegram returns an unsuccessful edit", async () => {
+		effects.editMessage.mockResolvedValue(false);
+		await act();
+		expect(effects.persistDecision).toHaveBeenCalledOnce();
+		expect(effects.trackResponse).toHaveBeenCalledOnce();
+		expect(effects.logger.error).not.toHaveBeenCalled();
+	});
+});
+
+describe("Telegram dispatcher acknowledgement", () => {
+	it("acknowledges only after the real approval handler finishes presentation and tracking", async () => {
+		let release: () => void = () => {};
+		const delivery = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		effects.editMessage.mockReturnValue(delivery);
+		const update = handleTelegramUpdate(
+			{ update_id: 1, callback_query: query },
+			bot,
+		);
+		await vi.waitFor(() => expect(effects.editMessage).toHaveBeenCalledOnce());
+		expect(effects.persistDecision).toHaveBeenCalledOnce();
+		expect(effects.acknowledge).not.toHaveBeenCalled();
+		effects.acknowledge.mockImplementation(async () => {
+			expect(effects.trackResponse).toHaveBeenCalledOnce();
+		});
+		release();
+		await update;
+		expect(effects.acknowledge).toHaveBeenCalledExactlyOnceWith(
+			"token",
+			"query-1",
+		);
+	});
+
+	it.each([
+		"unlinked",
+		"missing request",
+		"wrong approver",
+		"already processed",
+		"decision failure",
+		"delivery failure",
+		"resolver failure",
+		"malformed callback",
+	])(
+		"acknowledges after the existing success/catch flow for %s",
+		async (scenario) => {
+			const error = new Error(scenario);
+			if (scenario === "unlinked")
+				effects.resolveUser.mockResolvedValue({ status: "not_found" });
+			if (scenario === "missing request")
+				effects.approvalFindFirst.mockResolvedValue(undefined);
+			if (scenario === "wrong approver")
+				effects.approvalFindFirst.mockResolvedValue(
+					request({ approverId: "other-manager" }),
+				);
+			if (scenario === "already processed")
+				effects.approvalFindFirst.mockResolvedValue(
+					request({ status: "cancelled" }),
+				);
+			if (scenario === "decision failure")
+				effects.persistDecision.mockRejectedValue(error);
+			if (scenario === "delivery failure")
+				effects.editMessage.mockRejectedValue(error);
+			if (scenario === "resolver failure")
+				effects.resolveUser.mockRejectedValue(error);
+			await handleTelegramUpdate(
+				{
+					update_id: 1,
+					callback_query:
+						scenario === "malformed callback" ? { ...query, data: "{" } : query,
+				},
+				bot,
+			);
+			expect(effects.acknowledge).toHaveBeenCalledExactlyOnceWith(
+				"token",
+				"query-1",
+			);
+			if (scenario === "resolver failure")
+				expect(effects.logger.error).toHaveBeenCalledWith(
+					{ error, data: query.data },
+					"Failed to parse callback data",
+				);
+		},
+	);
+
+	it("leaves acknowledgement failures with the outer dispatcher catch", async () => {
+		const error = new Error("Acknowledgement unavailable");
+		effects.acknowledge.mockRejectedValue(error);
+		await expect(
+			handleTelegramUpdate({ update_id: 1, callback_query: query }, bot),
+		).resolves.toBeUndefined();
+		expect(effects.trackResponse).toHaveBeenCalledOnce();
+		expect(effects.logger.error).toHaveBeenCalledWith(
+			{ error, updateId: 1, organizationId: "org-1" },
+			"Error handling Telegram update",
+		);
+	});
+});
+
+describe("sendApprovalMessageToManager", () => {
+	it("does not send when the approver is outside the approval organization", async () => {
+		effects.employeeFindFirst.mockImplementation(
+			storedRow("employee", {
+				id: "manager-1",
+				organizationId: "org-2",
+				userId: "user-2",
+			}),
+		);
+		await sendApprovalMessageToManager(
+			"approval-1",
+			"manager-1",
+			"org-1",
+			"token",
+		);
+		expect(effects.approvalFindFirst).not.toHaveBeenCalled();
+		expect(effects.getChat).not.toHaveBeenCalled();
+		expect(effects.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not send an approval from another organization", async () => {
+		effects.approvalFindFirst.mockImplementation(
+			storedRow("approval_request", request({ organizationId: "org-2" })),
+		);
+		await sendApprovalMessageToManager(
+			"approval-1",
+			"manager-1",
+			"org-1",
+			"token",
+		);
+		expect(effects.approvalFindFirst).toHaveBeenCalledOnce();
+		expect(effects.getChat).not.toHaveBeenCalled();
+		expect(effects.sendMessage).not.toHaveBeenCalled();
 	});
 });

--- a/apps/webapp/src/lib/telegram/approval-handler.ts
+++ b/apps/webapp/src/lib/telegram/approval-handler.ts
@@ -55,30 +55,24 @@ export async function handleApprovalCallback(
 	}
 
 	try {
-		// Get approval request
-		const approval = await db.query.approvalRequest.findFirst({
-			where: and(
-				eq(approvalRequest.id, approvalId),
-				eq(approvalRequest.organizationId, bot.organizationId),
-			),
+		// Keep Next.js-only decision dependencies out of escalation worker imports.
+		const { attemptBotApproval } = await import(
+			"@/lib/bot-platform/approval-decision"
+		);
+		const result = await attemptBotApproval({
+			approvalId,
+			actorEmployeeId: userResult.user.employeeId,
+			organizationId: bot.organizationId,
+			action,
+			platform: "telegram",
 		});
 
-		if (!approval) {
+		if (result.status === "not_found") {
 			logger.warn({ approvalId }, "Approval not found");
 			return;
 		}
-		// Keep Next.js-only decision dependencies out of escalation worker imports.
-		const {
-			canAttemptBotApprovalDecision,
-			decideBotApproval,
-			loadBotApprovalDecisionTarget,
-		} = await import("@/lib/bot-platform/approval-decision");
-		const decisionTarget = await loadBotApprovalDecisionTarget({
-			approvalId,
-			organizationId: bot.organizationId,
-		});
 
-		if (!canAttemptBotApprovalDecision(decisionTarget)) {
+		if (result.status === "already_processed") {
 			// Update the message to show it's already resolved
 			if (query.message) {
 				const locale = await getUserLocale(userResult.user.userId);
@@ -98,8 +92,7 @@ export async function handleApprovalCallback(
 			return;
 		}
 
-		// Verify user is the approver
-		if (decisionTarget.approverId !== userResult.user.employeeId) {
+		if (result.status === "unauthorized") {
 			logger.warn(
 				{ approvalId, employeeId: userResult.user.employeeId },
 				"Unauthorized approval attempt",
@@ -107,15 +100,8 @@ export async function handleApprovalCallback(
 			return;
 		}
 
+		const { approval } = result;
 		const newStatus = action === "approve" ? "approved" : "rejected";
-
-		await decideBotApproval({
-			approvalId,
-			actorEmployeeId: userResult.user.employeeId,
-			organizationId: bot.organizationId,
-			action,
-			platform: "telegram",
-		});
 
 		logger.info(
 			{

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain docs
+
+## Before exploring
+
+1. Read root `CONTEXT-MAP.md` and follow its pointers to every
+   `CONTEXT.md` relevant to the task.
+2. Read relevant system-wide decisions in root `docs/adr/`.
+3. Read relevant context-scoped ADRs alongside each selected
+   context's `CONTEXT.md`, under its `docs/adr/` directory.
+
+If these files are absent, proceed silently. `/domain-modeling`,
+also used by `/grill-with-docs` and `/improve-codebase-architecture`,
+creates them lazily as terminology and decisions are resolved.
+
+## Multi-context layout
+
+- `CONTEXT-MAP.md`: root index of contexts and their document paths.
+- `docs/adr/`: system-wide decisions.
+- `<context-root>/CONTEXT.md`: a context's domain model and glossary.
+- `<context-root>/docs/adr/`: decisions scoped to that context.
+
+Context roots may be apps, packages, or domain subdirectories within
+them. The map defines the boundaries; an app or package does not
+automatically constitute a separate domain context.
+
+## Vocabulary
+
+Use the relevant glossary's terms in issue titles, proposals,
+hypotheses, and test names. If a needed concept is missing, reconsider
+the terminology or note the gap for `/domain-modeling`.
+
+## ADR conflicts
+
+Explicitly surface proposals that contradict an existing ADR,
+identifying the decision and why it may be worth reopening.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,92 @@
+# Issue tracker: GitHub
+
+Issues and specs live in GitHub Issues for `Umami-Creative-GmbH/z8`.
+Use the `gh` CLI for all tracker operations.
+
+## Conventions
+
+Run commands inside this clone so `gh` resolves the repository from
+the Git remote. Outside the clone, pass `--repo Umami-Creative-GmbH/z8`.
+
+- Create: `gh issue create --title "..." --body "..."`
+- Read: `gh issue view <number> --comments`
+- Read structured data:
+  `gh issue view <number> --json number,title,body,labels,comments`
+- List:
+  `gh issue list --state open --json number,title,body,labels,comments`
+  with appropriate label and state filters.
+- Comment: `gh issue comment <number> --body "..."`
+- Apply/remove labels:
+  `gh issue edit <number> --add-label "..." --remove-label "..."`
+- Close: `gh issue close <number> --comment "..."`
+
+For multiline bodies, use `--body-file <path>`.
+
+“Publish to the issue tracker” means create a GitHub issue.
+“Fetch the relevant ticket” means read the issue and its comments.
+
+## Tickets derived from a spec
+
+Every ticket created from a spec, including through `/to-tickets`, must
+be linked as a native GitHub sub-issue of the originating spec issue.
+The spec issue is the parent; each derived ticket is a child.
+
+If the spec has not been published as an issue, publish it first.
+After creating each ticket, get its numeric database ID with
+`gh api repos/Umami-Creative-GmbH/z8/issues/<ticket-number> --jq .id`,
+then attach it to the spec:
+
+```bash
+gh api --method POST \
+  repos/Umami-Creative-GmbH/z8/issues/<spec-number>/sub_issues \
+  -F sub_issue_id=<ticket-db-id>
+```
+
+Use the spec's repository for the parent endpoint and the ticket's
+repository when looking up its database ID for cross-repository tickets.
+Verify the relationship by listing the spec's sub-issues with
+`gh api --paginate repos/Umami-Creative-GmbH/z8/issues/<spec-number>/sub_issues`.
+Ticket creation is complete only after this relationship is verified.
+A body reference or task-list entry alone does not satisfy this rule.
+If linking fails, report the blocker and keep the setup incomplete.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+If enabled later, use `gh pr` equivalents for reading, commenting,
+labelling, and closing. Read proposed changes with `gh pr diff`.
+External PRs are those whose author association is CONTRIBUTOR,
+FIRST_TIME_CONTRIBUTOR, or NONE.
+
+GitHub shares issue and PR numbers. For an ambiguous reference,
+try `gh pr view <number>`, then fall back to `gh issue view <number>`.
+
+## Wayfinding operations
+
+- Map: one issue labelled `wayfinder:map`, containing Notes,
+  Decisions-so-far, and Fog.
+- Children: link tickets as native GitHub sub-issues. If unavailable,
+  use a task list in the map and `Part of #<map>` in each child.
+  Label children `wayfinder:<type>` where type is research,
+  prototype, grilling, or task.
+- Blocking: use native issue dependencies. Get the blocker's database
+  ID with `gh api repos/Umami-Creative-GmbH/z8/issues/<n> --jq .id`,
+  then add the edge:
+
+  ```bash
+  gh api --method POST \
+    repos/Umami-Creative-GmbH/z8/issues/<child>/dependencies/blocked_by \
+    -F issue_id=<blocker-db-id>
+  ```
+
+  If dependencies are unavailable, put `Blocked by: #<n>, #<n>` at
+  the top of the child body. A ticket is unblocked when every blocker
+  is closed.
+- Frontier: select the first open child in map order with no assignee
+  and no open blockers. For native dependencies, inspect
+  `issue_dependencies_summary.blocked_by`.
+- Claim: `gh issue edit <n> --add-assignee @me` as the session's first
+  tracker write.
+- Resolve: comment with the answer, close the ticket, and append a
+  summary plus link to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,14 @@
+# Triage labels
+
+Map canonical triage roles to these GitHub label strings:
+
+| Role | Label | Meaning |
+| --- | --- | --- |
+| needs-triage | needs-triage | Maintainer needs to evaluate |
+| needs-info | needs-info | Waiting on reporter information |
+| ready-for-agent | ready-for-agent | Fully specified for autonomous implementation |
+| ready-for-human | ready-for-human | Requires human implementation |
+| wontfix | wontfix | Will not be actioned |
+
+When a skill names a role, use its corresponding label.
+Edit the Label column to change the tracker vocabulary.

--- a/docs/refs/agent-workflow.md
+++ b/docs/refs/agent-workflow.md
@@ -19,6 +19,13 @@ pnpm test             # Run tests (vitest)
 pnpm drizzle-kit push # Push schema to database
 ```
 
+## Opening Files and URLs in WSL
+
+In WSL sessions, use `wslview "<path-or-url>"` first to open reports, files, and URLs in Windows.
+For local files, fall back to `explorer.exe "$(wslpath -w /absolute/path/to/file)"` if needed.
+
+`wslview` has successfully opened a report here despite a missing WindowsApps path warning. That warning alone does not establish failure; confirm before launching a second copy.
+
 ## Environment Variables
 
 This is a multi-tenant SaaS application. Configuration follows these rules:


### PR DESCRIPTION
## Summary

- Migrate Telegram's approval callback handler to the shared `attemptBotApproval` module introduced by #241, preserving identity resolution ordering, scoped request loading, eligibility/authorization, replay handling, and exact rejection attribution.
- Preserve Telegram-owned localized presentation, original-request snapshot, post-decision tracking boundaries, delivery-error behavior, and dispatcher callback acknowledgement.
- Replace forwarding-only tests with 54 composed Telegram handler/dispatcher and sending checks using real shared attempt and inbox logic.
- Include the branch's agent-workflow documentation updates: ticket ownership and branch lifecycle, workflow selection, issue-tracker/domain conventions, triage labels, and WSL opening guidance.

Closes #243

## Verification

- 54 Telegram tests passed before and after migration.
- Combined focused checks: **8 files / 272 tests passed**, including all four plain-Node worker-import guards and existing inbox/domain decision suites.
- Application typecheck passed before and after migration; separate test-inclusive TypeScript check passed.
- Biome check of both changed TypeScript files and `git diff --check` passed.
- Independent standards and spec code reviews: **0 findings on each axis** for the Telegram implementation.

### Full suite and environment blockers

- `pnpm test`: **29 Docker/runtime tests passed**; Turbo then could not launch webapp tests (`Exec format error (os error 8)`).
- Direct `pnpm --filter webapp test --maxWorkers=4`: **998 files passed, 2 failed, 5 skipped; 10,983 tests passed, 66 failed, 283 skipped**.
- Failures match the baseline issues already reproduced and documented in #241: 65 organization-settings action tests and 1 environment-usage test. PostgreSQL integration tests remain skipped because dedicated test database/sentinel configuration is unavailable.

Detailed results: https://github.com/Umami-Creative-GmbH/z8/issues/243#issuecomment-5652450590
